### PR TITLE
Auto-Blacklisting Mockery files in PHPUnit

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -142,6 +142,19 @@ the following to your test suite's Bootstrap or TestHelper file:
     $loader = new \Mockery\Loader;
     $loader->register();
     
+To integrate Mockery into PHPUnit and avoid having to call the close method and
+have Mockery remove itself from code coverage reports, use this in you suite:
+
+	//Create Suite
+	$suite = new PHPUnit_Framework_TestSuite();
+	
+	//Create a result listener or add it
+	$result = new PHPUnit_Framework_TestResult();
+    $result->addListener(new Mockery\Adapter\Phpunit\TestListener());
+	
+	// Run the tests.
+	$suite->run($result);
+	
 Quick Reference
 ---------------
 

--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -20,8 +20,6 @@
  
 namespace Mockery\Adapter\Phpunit;
 
-require_once 'PHPUnit/Framework.php';
-
 class TestListener implements \PHPUnit_Framework_TestListener
 {
     
@@ -37,6 +35,19 @@ class TestListener implements \PHPUnit_Framework_TestListener
         \Mockery::close();
     }
     
+	/**
+	 * Add Mockery files to PHPUnit's blacklist so they don't showup on coverage reports 
+	 */
+    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {
+		
+		if ( class_exists('\\PHP_CodeCoverage_Filter') ) {
+			\PHP_CodeCoverage_Filter::getInstance()->addDirectoryToBlacklist(
+			  __DIR__.'/../../../Mockery/', '.php', '', 'PHPUNIT'
+			);
+			
+			\PHP_CodeCoverage_Filter::getInstance()->addFileToBlacklist(__DIR__.'/../../../Mockery.php', 'PHPUNIT');
+		}
+	}
     /**
      *  The Listening methods below are not required for Mockery
      */
@@ -48,7 +59,6 @@ class TestListener implements \PHPUnit_Framework_TestListener
 
     public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
 
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {}
 
     public function endTestSuite(\PHPUnit_Framework_TestSuite $suite) {}
 


### PR DESCRIPTION
Currently if you run PHPUnit Code Coverage with Mockery being used, it ends up inside the coverage reports.

Since removing this is phpunit.xml is a hassle because everyone has mockery in a different place depending on PEAR, its best to let mockery itself remove its files from PHPUnit.

So i added this in the TestListener in the StartSuite function.

Also the documentation mentions PHPUnit integration but does not show how to tie this Listener to PHPUnit itself, so i added this in.

Let me know if this is cool or if you need me to make any changes!
