### PR TITLE
Fix crash in php 5.3.6

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -356,7 +356,7 @@ BODY;
 
     public function shouldReceive()
     {
-        \$self =& \$this;
+        \$self = \$this;
         \$lastExpectation = \Mockery::parseShouldReturnArgs(
             \$this, func_get_args(), function(\$method) use (\$self) {
                 \$director = \$self->mockery_getExpectationsFor(\$method);

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -142,7 +142,7 @@ class Mock implements MockInterface
      */
     public function shouldReceive()
     {
-        $self =& $this;
+        $self = $this;
         $lastExpectation = \Mockery::parseShouldReturnArgs(
             $this, func_get_args(), function($method) use ($self) {
                 $director = $self->mockery_getExpectationsFor($method);


### PR DESCRIPTION
Why do you reference $this? Please pull it :)
