### PR TITLE
Support PHP_CodeCoverage 1.1 by checking for getInstance method

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -40,15 +40,15 @@ class TestListener implements \PHPUnit_Framework_TestListener
 	 */
     public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {
 		
-		if (class_exists('\\PHP_CodeCoverage_Filter')
-		&& method_exists('\\PHP_CodeCoverage_Filter', 'getInstance')) {
-			\PHP_CodeCoverage_Filter::getInstance()->addDirectoryToBlacklist(
-			  __DIR__.'/../../../Mockery/', '.php', '', 'PHPUNIT'
-			);
-			
-			\PHP_CodeCoverage_Filter::getInstance()->addFileToBlacklist(__DIR__.'/../../../Mockery.php', 'PHPUNIT');
-		}
-	}
+        if (class_exists('\\PHP_CodeCoverage_Filter')
+        && method_exists('\\PHP_CodeCoverage_Filter', 'getInstance')) {
+            \PHP_CodeCoverage_Filter::getInstance()->addDirectoryToBlacklist(
+                 __DIR__.'/../../../Mockery/', '.php', '', 'PHPUNIT'
+            );
+
+            \PHP_CodeCoverage_Filter::getInstance()->addFileToBlacklist(__DIR__.'/../../../Mockery.php', 'PHPUNIT');
+        }
+    }
     /**
      *  The Listening methods below are not required for Mockery
      */


### PR DESCRIPTION
As of PHP_CodeCoverage 1.1 the filter class is no longer a singleton. This change enables use of Mockery with newer versions of PHP_CodeCoverage. Unfortunately this means that the test listener no longer adds Mockery to the blacklist. There appears to be no programmatic way to do this currently.

http://stackoverflow.com/questions/8085674/add-files-to-code-coverage-white-blacklists-in-bootstrap-php-for-phpunit/8119048#8119048
