### PR TITLE
Catch exceptions thrown by Mockery::close(); in the test listener and add to the test result object

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -32,7 +32,13 @@ class TestListener implements \PHPUnit_Framework_TestListener
      */
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
-        \Mockery::close();
+        try
+        {
+            \Mockery::close();
+        } catch (\Exception $e) {
+            $result = $test->getTestResultObject();
+            $result->addError($test, $e, $time);
+        }
     }
     
 	/**


### PR DESCRIPTION
Mockery close will throw an exception if for example, validation count fails in the test listener. This exception will not be caught and will halt test execution. Instead add the error to the test result object, thereby allowing further tests to run.
