### PR TITLE
Corrected issue with calling an unexpected static method on a alias mock

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -535,7 +535,7 @@ BODY;
             return \$associatedRealObject->__call(\$method, \$args);
         } catch (\BadMethodCallException \$e) {
             throw new \BadMethodCallException(
-                'Static method ' . \$this->_mockery_name . '::' . \$method
+                'Static method ' . \$associatedRealObject->mockery_getName() . '::' . \$method
                 . '() does not exist on this mock object'
             );
         }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -405,6 +405,16 @@ class ContainerTest extends PHPUnit_Framework_TestCase
     }
     
     /**
+     * @expectedException BadMethodCallException
+     */
+    public function testMockedStaticThrowsExceptionWhenMethodDoesNotExist(){
+    	\Mockery::setContainer($this->container);
+        $m = $this->container->mock('alias:MyNamespace\StaticNoMethod');
+        $this->assertEquals('bar', \MyNameSpace\StaticNoMethod::staticFoo());
+        \Mockery::resetContainer();
+    }
+    
+    /**
      * @group issue/17
      */
     public function testMockingAllowsPublicPropertyStubbingOnRealClass()


### PR DESCRIPTION
When calling a unexpected static method on an alias mock would generate a fatel error for using $this while not in the context of an object. The root cause is in the generated mock where in the exception handling for __callStatic was trying to build a error message by referring to `$this->_mockery_name.`` Updated the exception handling to call use the real object and get the name from it. Also included unit test to prove that it now works as expected.
