### PR TITLE
Added $prepend parameter to \Mockery_Loader::register() to be able to register the autoloader as first even after other autoloaders have been registered

### DIFF
--- a/library/Mockery/Loader.php
+++ b/library/Mockery/Loader.php
@@ -100,10 +100,12 @@ class Loader
 
     /**
      * Installs this class loader on the SPL autoload stack.
+	 *
+	 * @param bool $prepend If true, prepend autoloader on the autoload stack
      */
-    public function register()
+    public function register($prepend = false)
     {
-        spl_autoload_register(array($this, 'loadClass'));
+        spl_autoload_register(array($this, 'loadClass'), true, $prepend);
     }
 
     /**


### PR DESCRIPTION
We really need this because the default autoloader handles all files and the Mockery autoloader cannot be registered before it (in the code) in a clean way.

It's only a small addition with a default value to preserve the current behaviour so please add it.
