### PR TITLE
Add Expectation Count to PHPUnit TestCase Assertion Count

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -34,6 +34,11 @@ class TestListener implements \PHPUnit_Framework_TestListener
     {
         try
         {
+            $container = \Mockery::getContainer();
+            if ($container != null) {
+                $expectation_count = $container->mockery_getExpectationCount();
+                $test->addToAssertionCount($expectation_count);
+            }
             \Mockery::close();
         } catch (\Exception $e) {
             $result = $test->getTestResultObject();

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -285,6 +285,20 @@ class Container
     }
     
     /**
+     * Gets the count of expectations on the mocks
+     *
+     * @return int
+     */
+    public function mockery_getExpectationCount()
+    {
+        $count = 0;
+        foreach($this->_mocks as $mock) {
+            $count += $mock->mockery_getExpectationCount();
+        }
+        return $count;
+    }
+    
+    /**
      * Store a mock and set its container reference
      *
      * @param \Mockery\Mock

--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -184,5 +184,15 @@ class ExpectationDirector
     {
         return $this->_expectations;
     }
+    
+    /**
+     * Return the number of expectations assigned to this director.
+     *
+     * @return int
+     */
+    public function getExpectationCount()
+    {
+        return count($this->getExpectations());    
+    }
 
 }

--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -474,6 +474,15 @@ BODY;
         }
         \$this->mockery_setCurrentOrder(\$order);
     }
+    
+    public function mockery_getExpectationCount()
+    {
+        \$count = 0;
+        foreach(\$this->_mockery_expectations as \$director) {
+            \$count += \$director->getExpectationCount();
+        }
+        return \$count;
+    }
 
     public function mockery_setExpectationsFor(\$method, \Mockery\ExpectationDirector \$director)
     {

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -341,6 +341,20 @@ class Mock implements MockInterface
     }
     
     /**
+     * Gets the count of expectations for this mock
+     *
+     * @return int
+     */
+    public function mockery_getExpectationCount()
+    {
+        $count = 0;
+        foreach($this->_mockery_expectations as $director) {
+            $count += $director->getExpectationCount();
+        }
+        return $count;
+    }
+    
+    /**
      * Return the expectations director for the given method
      *
      * @var string $method

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -133,6 +133,13 @@ interface MockInterface
     public function mockery_validateOrder($method, $order);
     
     /**
+     * Gets the count of expectations for this mock
+     *
+     * @return int
+     */
+    public function mockery_getExpectationCount();
+    
+    /**
      * Return the expectations director for the given method
      *
      * @var string $method

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -618,6 +618,17 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         \Mockery::resetContainer();
     }
     
+    public function testGetExpectationCount_freshContainer()
+    {
+        $this->assertEquals(0, $this->container->mockery_getExpectationCount());
+    }
+    
+    public function testGetExpectationCount_simplestMock()
+    {
+        $m = $this->container->mock();
+        $m->shouldReceive('foo')->andReturn('bar');
+        $this->assertEquals(1, $this->container->mockery_getExpectationCount());
+    }
 }
 
 class MockeryTest_IssetMethod

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -14,5 +14,10 @@
             <directory suffix=".php">../library/</directory>
         </whitelist>
     </filter>
+    <listeners>
+        <listener
+            class='Mockery\Adapter\Phpunit\TestListener'
+            file='../library/Mockery/Adapter/Phpunit/TestListener.php'/>
+    </listeners>
 </phpunit>
 


### PR DESCRIPTION
This should make Mockery more compatible with the PHPUnit strict mode.
