### PR TITLE
Demeter chain methods with arguments

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -338,7 +338,7 @@ class Mockery
             if (empty($names)) break;
             if ($needNew) {
                 $mock = $container->mock('demeter_' . $method);
-                $exp->withNoArgs()->andReturn($mock);
+                $exp->andReturn($mock);
             }
             $nextExp = function ($n) use ($mock) {return $mock->shouldReceive($n);};
         }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1590,6 +1590,17 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group issue #20 - with args in demeter chain
+     */
+    public function testMockingDemeterChainsPassesMockeryExpectationToCompositeExpectationWithArgs()
+    {
+        $mock = $this->container->mock('Mockery_Demeterowski');
+        $mock->shouldReceive('foo->bar->baz')->andReturn('Spam!');
+        $demeter = new Mockery_UseDemeter($mock);
+        $this->assertSame('Spam!', $demeter->doitWithArgs());
+    }
+
+    /**
     * @expectedException PHPUnit_Framework_Error_Warning
     */
     public function testPregMatchThrowsDelimiterWarningWithXdebugScreamTurnedOn()
@@ -1658,5 +1669,8 @@ class Mockery_UseDemeter {
     }
     public function doit() {
         return $this->demeter->foo()->bar()->baz();
+    }
+    public function doitWithArgs() {
+        return $this->demeter->foo("foo")->bar("bar")->baz("baz");
     }
 }


### PR DESCRIPTION
I found that adding demeter chain expectations where the methods in the chain were called with arguments e.g.,

```
$mock->shouldReceive('foo->bar->baz')->shouldReturn(10);
$object->foo("foo")->bar("bar")->baz();
```

throws a Mockery\Exception with message "No matching handler found for Mockery_Demeterowski::foo("foo"). Either the method was unexpected or its arguments matched no expected argument list for this method" 

To fix this I removed the `withNoArgs` expectation applied in `_buildDemeterChain`.
