### PR TITLE
Adds fluent interface to the shouldIgnoreMissing method

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -375,6 +375,7 @@ BODY;
     public function shouldIgnoreMissing()
     {
         \$this->_mockery_ignoreMissing = true;
+        return \$this;
     }
 
     public function shouldExpect(Closure \$closure)

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -161,11 +161,12 @@ class Mock implements MockInterface
     /**
      * Set mock to ignore unexpected methods and return Undefined class
      *
-     * @return void
+     * @return Mock
      */
     public function shouldIgnoreMissing()
     {
         $this->_mockery_ignoreMissing = true;
+        return $this;
     }
     
     /**

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -44,7 +44,7 @@ interface MockInterface
     /**
      * Set mock to ignore unexpected methods and return Undefined class
      *
-     * @return void
+     * @return Mock
      */
     public function shouldIgnoreMissing();
     

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1406,6 +1406,11 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
         $this->mock->shouldIgnoreMissing();
         $this->assertTrue($this->mock->g(1,2)->a()->b()->c() instanceof \Mockery\Undefined);
     }
+
+    public function testShouldIgnoreMissingFluentInterface()
+    {
+        $this->assertTrue($this->mock->shouldIgnoreMissing() instanceof \Mockery\MockInterface);
+    }
     
     public function testOptionalMockRetrieval()
     {


### PR DESCRIPTION
I couldn't see a reason why this wasn't fluent
