### PR TITLE
Suppress strict standards errors when mocking with E_ALL

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -87,7 +87,16 @@ class Generator
         }
         if ($useStandardMethods) $definition .= self::_getStandardMethods($callTypehinting, $makeInstanceMock);
         $definition .= PHP_EOL . '}';
+
+        //turn of strict
+        $errorReporting = error_reporting();
+        error_reporting($errorReporting ^ E_STRICT);
+
         eval($definition);
+
+        //turn back on
+        error_reporting($errorReporting);
+
         return $mockName;
     }
     


### PR DESCRIPTION
A hacky way to suppress E_STRICT for mock definition evaluation in generator. This is to prevent strict standard errors when mocking in E_ALL reporting mode.
