### PR TITLE
Add __toString method to mocks and undefined objs

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -407,12 +407,20 @@ BODY;
         } elseif (!is_null(\$this->_mockery_partial) && method_exists(\$this->_mockery_partial, \$method)) {
             return call_user_func_array(array(\$this->_mockery_partial, \$method), \$args);
         } elseif (\$this->_mockery_ignoreMissing) {
-            \$return = new \Mockery\Undefined;
-            return \$return;
+            \$undef = new \Mockery\Undefined;
+            return call_user_func_array(array(\$undef, \$method), \$args);
         }
         throw new \BadMethodCallException(
             'Method ' . \$this->_mockery_name . '::' . \$method . '() does not exist on this mock object'
         );
+    }
+
+    /**
+     * Forward calls to this magic method to the __call method
+     */
+    public function __toString()
+    {
+        return \$this->__call('__toString', array());
     }
 
     public function mockery_verify()

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -204,7 +204,7 @@ class Mock implements MockInterface
         }
         return $this;
     }
-    
+
     /**
      * Capture calls to this mock
      */
@@ -217,12 +217,20 @@ class Mock implements MockInterface
         } elseif (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
         } elseif ($this->_mockery_ignoreMissing) {
-            $return = new \Mockery\Undefined;
-            return $return;
+            $undef = new \Mockery\Undefined;
+            return call_user_func_array(array($undef, $method), $args);
         }
         throw new \BadMethodCallException(
             'Method ' . $this->_mockery_name . '::' . $method . '() does not exist on this mock object'
         );
+    }
+    
+    /**
+     * Forward calls to this magic method to the __call method
+     */
+    public function __toString()
+    {
+        return $this->__call('__toString', array());
     }
     
     /**public function __set($name, $value)

--- a/library/Mockery/Undefined.php
+++ b/library/Mockery/Undefined.php
@@ -35,4 +35,14 @@ class Undefined
         return $this;
     }  
 
+    /**
+     * Return a string, avoiding E_RECOVERABLE_ERROR 
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return __CLASS__ . ":" . spl_object_hash($this);
+    }
+
 }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1424,7 +1424,20 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->mock->shouldIgnoreMissing() instanceof \Mockery\MockInterface);
     }
-    
+
+    public function testShouldIgnoreMissingProxiesToUndefinedAllowingToString()
+    {
+        $this->mock->shouldIgnoreMissing();
+        $string = "Method call: {$this->mock->g()}";
+        $string = "Mock: {$this->mock}";
+    }
+
+    public function testToStringMagicMethodCanBeMocked()
+    {
+        $this->mock->shouldReceive("__toString")->andReturn('dave');
+        $this->assertEquals("{$this->mock}", "dave");
+    }
+
     public function testOptionalMockRetrieval()
     {
         $m = $this->container->mock('f')->shouldReceive('foo')->with(1)->andReturn(3)->mock();


### PR DESCRIPTION
- Avoids E_RECOVERABLE_ERROR
- Allows mocking of __toString

Not put a load of thought in to this, but needed this functionality to get some tests passing without polluting my tests too much.
