### PR TITLE
Fix regression from #81, __toString added twice

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -155,6 +155,7 @@ class Generator
             && $method->getName() !== '__wakeup'
             && $method->getName() !== '__set'
             && $method->getName() !== '__get'
+            && $method->getName() !== '__toString'
             && $method->getName() !== '__isset') {
                 $definition .= self::_replacePublicMethod($method);
             }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -662,6 +662,17 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         //$this->assertTrue(\Mockery::self() instanceof MockeryTestFoo);
         \Mockery::resetContainer();
     }
+
+    /**
+     * @issue issue/89
+     */
+    public function testCreatingMockOfClassWithExistingToStringMethodDoesntCreateClassWithTwoToStringMethods()
+    {
+        \Mockery::setContainer($this->container);
+        $m = $this->container->mock('MockeryTest_WithToString'); // this would fatal
+        $m->shouldReceive("__toString")->andReturn('dave');
+        $this->assertEquals("dave", "$m");
+    }
     
     public function testGetExpectationCount_freshContainer()
     {
@@ -841,3 +852,8 @@ if(PHP_VERSION_ID >= 50400) {
         public function foo(callable $baz) {$baz();}
     }
 }
+
+class MockeryTest_WithToString {
+    public function __toString() {}
+}
+


### PR DESCRIPTION
If __toString already exists on a class, we don't need to include it in the
class definition twice, so skip it during the public method replacement phase.
