### PR TITLE
Subset matcher does not match if an array value is NULL

### DIFF
--- a/library/Mockery/Matcher/Subset.php
+++ b/library/Mockery/Matcher/Subset.php
@@ -32,7 +32,7 @@ class Subset extends MatcherAbstract
     public function match(&$actual)
     {
         foreach ($this->_expected as $k=>$v) {
-            if (!isset($actual[$k])) {
+            if (!array_key_exists($k, $actual)) {
                 return false;
             }
             if ($actual[$k] !== $v) {


### PR DESCRIPTION
The subset matcher incorrectly fails matching an array which contains keys with NULL values as the isset() function returns false if a value is NULL. Replaced the isset() call with array_key_exists().

Example code:

``` php
$expectedData = array(
    'test1' => null,
);

$actualData = array(
    'test1'  => null,
    'test2' => 'value'
);

Mockery::mock('Test')
    ->shouldReceive('testMethod')
    ->with(Mockery::subset($expectedData))
    ->getMock()
    ->testMethod($actualData);
```

Expected result: the argument validation passes.

Actual result: a Mockery\Exception is thrown
