### PR TITLE
Fix bug with optional callable typehint

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -241,7 +241,7 @@ BODY;
                 $paramDef .= 'array ';
             } elseif ($param->getClass()) {
                 $paramDef .= $param->getClass()->getName() . ' ';
-            }  elseif (preg_match('/^Parameter #[0-9]+ \[ \<(required|optional)\> (?<typehint>\S+ )?\$' . $param->getName() . ' \]$/', $param->__toString(), $typehintMatch)) {
+            }  elseif (preg_match('/^Parameter #[0-9]+ \[ \<(required|optional)\> (?<typehint>\S+ )?.*\$' . $param->getName() . ' .*\]$/', $param->__toString(), $typehintMatch)) {
                 if (!empty($typehintMatch['typehint'])) {
                     $paramDef .= $typehintMatch['typehint'] . ' ';
                 }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -850,6 +850,7 @@ class MockeryTest_TestInheritedType {}
 if(PHP_VERSION_ID >= 50400) {
     class MockeryTest_MockCallableTypeHint {
         public function foo(callable $baz) {$baz();}
+        public function bar(callable $callback = null) {$callback();}
     }
 }
 


### PR DESCRIPTION
Callable typehint parameter generation was failing with optional (nullable) parameters
