### PR TITLE
Handle reflected param names for variable length arguments

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -235,7 +235,7 @@ BODY;
         $methodParams = array();
         $params = $method->getParameters();
 		$typehintMatch = array();
-        foreach ($params as $param) {
+        foreach ($params as $i => $param) {
             $paramDef = '';
             if ($param->isArray()) {
                 $paramDef .= 'array ';
@@ -246,7 +246,11 @@ BODY;
                     $paramDef .= $typehintMatch['typehint'] . ' ';
                 }
             }
-            $paramDef .= ($param->isPassedByReference() ? '&' : '') . '$' . $param->getName();
+            $paramName = $param->getName();
+            if (empty($paramName) || $paramName === '...') {
+                $paramName = 'arg' . $i;
+            }
+            $paramDef .= ($param->isPassedByReference() ? '&' : '') . '$' . $paramName;
             if ($param->isOptional()) {
                 if ($param->isDefaultValueAvailable()) {
                     $default = var_export($param->getDefaultValue(), true);


### PR DESCRIPTION
Same reason as here: https://github.com/sebastianbergmann/phpunit/pull/642 some pecl package arguments have invalid names like [empty string] or ...
