### PR TITLE
Adapted adding of default expectation to LIFO

### DIFF
--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -146,7 +146,7 @@ class ExpectationDirector
         $last = end($this->_expectations);
         if ($last === $expectation) {
             array_pop($this->_expectations);
-            $this->_defaults[] = $expectation;
+            array_unshift($this->_defaults, $expectation);
         } else {
             throw new \Mockery\Exception(
                 'Cannot turn a previously defined expectation into a default'

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -740,6 +740,14 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
         $container = new \Mockery\Container;
         $mock = $container->mock('f')->byDefault();
     }
+
+    public function testDefaultExpectationsCanBeOverridden()
+    {
+        $this->mock->shouldReceive('foo')->with('test')->andReturn('bar')->byDefault();
+        $this->mock->shouldReceive('foo')->with('test')->andReturn('newbar')->byDefault();
+        $this->mock->foo('test');
+        $this->assertEquals('newbar', $this->mock->foo('test'));
+    }
     
     /**
      * @expectedException \Mockery\Exception


### PR DESCRIPTION
Hi Pádraic,

first of all, thank you for a great mock framework. I introduced it recently in our project, and we didn't regret that step - it's a pleasure to work with.

And Mockery gave us the ability to declare default expectations, which is a major improvement for us. Unfortunately it is not possible to override a default expectation, probably on purpose. ;) But in our case it would be great to do so.

My PR concerns the way an expectation is declared byDefault(). The current behaviour is that you write all default expectations to an array, and retrieve it by traversing the array and return the first match for certain expectation. I simply switched the way of adding expectation to that array, so that you actually will always retrieve the last expectation.

When this is not a drawback of some kind, and does not harm the whole framework, I would appreciate it much, when you consider to merge this PR.

Thank you, Jens.
