### PR TITLE
Corrected documentation related to andReturnValues() method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -446,7 +446,7 @@ will always return the final value (or the only value) given to this declaration
 Both of the above options are primarily for communication to test readers. They mark the
 mock object method call as returning NULL or nothing.
 
-    andReturns(array)
+    andReturnValues(array)
 
 Alternative syntax for andReturn() that accepts a simple array instead of a list of parameters.
 The order of return is determined by the numerical index of the given array with the last array


### PR DESCRIPTION
I've been using mockery more and more over the last few months and the few times I decided I wanted to pass an array to andReturn() I kept getting fooled by the documentation, which currently states that one should use andReturns(), which doesn't actually exist.

So, I figured I'd use this as an opportunity to fork, clone, fix, add, commit, push, and fire off a pull request for the first time with a public repository.  Hope I don't screw things up...!  ;-)
