### PR TITLE
Fix for Return by Reference Bug

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -244,7 +244,8 @@ if (isset(\$stack[0]['args'])) {
         \$args[\$i] =& \$stack[0]['args'][\$i];
     }
 }
-return \$this->__call('$name', \$args);
+\$ret = \$this->__call('$name', \$args);
+return \$ret;
 BODY;
         }
         $methodParams = self::_renderPublicMethodParameters($method);


### PR DESCRIPTION
When trying to mock a function that returns by reference, the internals
of the mocked class do not actually return by reference - because the
call to the __call function makes it return by value.  Assigning this to
a variable and then returning it allows it to not throw a "Only variable
references should be returned by reference" error.  This doesn't affect
functions that aren't return by reference - other than adding a new
variable to be Garbage Collected.
