### PR TITLE
Requiring libpcre >= 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "lib-pcre": ">=7.0"
     },
     "require-dev": {
         "hamcrest/hamcrest": "1.1.0"


### PR DESCRIPTION
There is a bug in libpcre < 7.0 that causes preg compilation errors that break
mockery. Libpcre >= 7.0 should fix this issue according to their changelog, but
the author has only tested on libpcre 8.31.
