### PR TITLE
Ignore methods where expectation exists with wrong args

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -492,7 +492,24 @@ BODY;
         if (isset(\$this->_mockery_expectations[\$method])
         && !\$this->_mockery_disableExpectationMatching) {
             \$handler = \$this->_mockery_expectations[\$method];
-            return \$handler->call(\$args);
+
+            try {
+                \$return = \$handler->call(\$args);
+            } catch (\Mockery\Exception\NoMatchingExpectationException \$e) {
+                if (\$this->_mockery_ignoreMissing) {
+                    if (\$this->_mockery_ignoreMissingAsUndefined === true) {
+                        \$undef = new \Mockery\Undefined;
+                        return call_user_func_array(array(\$undef, \$method), \$args);
+                    } else {
+                        return null;
+                    }
+                }
+
+                throw \$e; 
+            }
+
+            return \$return;
+
         } elseif (!is_null(\$this->_mockery_partial) && method_exists(\$this->_mockery_partial, \$method)) {
             return call_user_func_array(array(\$this->_mockery_partial, \$method), \$args);
         } elseif (\$this->_mockery_deferMissing && is_callable("parent::\$method")) {

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -253,7 +253,24 @@ class Mock implements MockInterface
         if (isset($this->_mockery_expectations[$method])
         && !$this->_mockery_disableExpectationMatching) {
             $handler = $this->_mockery_expectations[$method];
-            return $handler->call($args);
+
+            try {
+                $return = $handler->call($args);
+            } catch (\Mockery\Exception\NoMatchingExpectationException $e) {
+                if ($this->_mockery_ignoreMissing) {
+                    if ($this->_mockery_ignoreMissingAsUndefined === true) {
+                        $undef = new \Mockery\Undefined;
+                        return call_user_func_array(array($undef, $method), $args);
+                    } else {
+                        return null;
+                    }
+                }
+
+                throw $e; 
+            }
+
+            return $return;
+
         } elseif (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
         } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")) {

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1703,6 +1703,16 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
         $this->container->mockery_verify();
     }
 
+
+    public function testShouldIgnoreMissingExpectationBasedOnArgs()
+    {
+        $mock = $this->container->mock("MyService2")->shouldIgnoreMissing();
+        $mock->shouldReceive("hasBookmarksTagged")->with("dave")->once();
+        $mock->hasBookmarksTagged("dave");
+        $mock->hasBookmarksTagged("padraic");
+        $this->container->mockery_verify();
+    }
+
 }
 
 class MockeryTest_SubjectCall1 {


### PR DESCRIPTION
I'm actually testing a horrible controller that assigns a million vars to a smarty template (I know, I know), this makes my tests a lot cleaner (shame about the production code).

We could make this part of the expectation director, but I'm not sure how far down a rabbit hole that would take us.
