### PR TITLE
Fixes to Mockery::_objectToArray

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -345,7 +345,11 @@ class Mockery
             $name = $publicMethod->getName();
             $numberOfParameters = $publicMethod->getNumberOfParameters();
             if ((substr($name, 0, 3) === 'get' || substr($name, 0, 2) === 'is') && $numberOfParameters == 0) {
-                $getters[$name] = self::_cleanupNesting($object->$name(), $nesting);
+                try {
+                    $getters[$name] = self::_cleanupNesting($object->$name(), $nesting);
+                } catch(\Exception $e) {
+                    $getters[$name] = '!! ' . get_class($e) . ': ' . $e->getMessage() . ' !!';
+                }
             }
         }
         return array('class' => get_class($object), 'properties' => $properties, 'getters' => $getters);


### PR DESCRIPTION
1. Variable `$name` was not defined in the `->getProperties(...)` loop
2. `Mockery::_objectToArray` could not handle a getter throwing an exception.

For above 2, `Mockery::_objectToArray`, if it receives an exception when converting an object to an array, will return a string surrounded by `!!` that contains the exception class and exception method.

I personally encountered this problem when Mockery, in an attempt to display a `Mockery\Exception\NoMatchingExpectationException` was choking on a `\ReflectionMethod::getPrototype` which was throwing an exception.
