### PR TITLE
Change dependency to correct Hamcrest GitHub repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,27 +16,9 @@
         "lib-pcre": ">=7.0"
     },
     "require-dev": {
-        "hamcrest/hamcrest": "1.1.0"
+        "hamcrest/hamcrest-php": "~1.1"
     },
     "autoload": {
         "psr-0": { "Mockery": "library/" }
-    },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "hamcrest/hamcrest",
-                "version": "1.1.0",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://hamcrest.googlecode.com/files/hamcrest-php-1.1.0.zip"
-                },
-                "include-path": ["Hamcrest-1.1.0/"],
-                "autoload": {
-                    "psr-0": { "Hamcrest_": "Hamcrest-1.1.0/" },
-                    "files": ["Hamcrest-1.1.0/Hamcrest/Hamcrest.php"]
-                }
-            }
-        }
-    ]
+    }
 }

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -300,7 +300,7 @@ class Expectation
         if ($expected instanceof \Mockery\Matcher\MatcherAbstract) {
             return $expected->match($actual);
         }
-        if ($expected instanceof \Hamcrest_Matcher) {
+        if (is_a($expected, '\Hamcrest\Matcher') || is_a($expected, '\Hamcrest_Matcher')) {
             return $expected->matches($actual);
         }
         return false;

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -49,11 +49,12 @@ if (!file_exists($root . '/vendor/autoload.php')) {
  * this copy.
  */
 $path = array(
-    $library,
-    $tests,
+    $library, // required for `testCallingRegisterRegistersSelfAsSplAutoloaderFunction`
     get_include_path(),
 );
 set_include_path(implode(PATH_SEPARATOR, $path));
+
+require_once "$root/vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php";
 
 if (defined('TESTS_GENERATE_REPORT') && TESTS_GENERATE_REPORT === true &&
     version_compare(PHPUnit_Runner_Version::id(), '3.1.6', '>=')) {

--- a/tests/Mockery/HamcrestExpectationTest.php
+++ b/tests/Mockery/HamcrestExpectationTest.php
@@ -22,13 +22,14 @@
 class HamcrestExpectationTest extends PHPUnit_Framework_TestCase
 {
 
-    public function setup ()
+    public function setUp()
     {
         $this->container = new \Mockery\Container;
         $this->mock = $this->container->mock('foo');
     }
     
-    public function teardown()
+
+    public function tearDown()
     {
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
         $this->container->mockery_close();


### PR DESCRIPTION
Together with @cordoval and @davedevelopment we've updated @cordoval version of Hamcrest-php library on GitHub (to 1.1.0) and published it on Composer as well.

Then fork of @davedevelopment (based on 1.0.0) would be deleted and your tests would break. To prevent that I've changed a dependency to correct Composer package.

I've also made tests use Hamcrest from Composer, rather one from PEAR. I've checked, that  all tests pass (some were skipped) after the changes.
