### PR TITLE
Update README to warn about PHPUnit process isolation potential bug

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -238,6 +238,20 @@ If you are using PHPUnit's XML configuration approach, you can include the follo
 Make sure Composer's or Mockery's autoloader is present in the bootstrap file or you will need to also define a
 "file" attribute pointing to the file of the above TestListener class.
 
+### Warning: PHPUnit running tests in separate processes
+
+PHPUnit provides a functionnality that allows [tests to run in a separated process]
+(http://phpunit.de/manual/3.7/en/appendixes.annotations.html#appendixes.annotations.runTestsInSeparateProcesses), 
+to ensure better isolation. Mockery verifies the mocks expectations using the 
+`Mockery::close` method, and provides a PHPUnit listener, that automatically 
+calls this method for you after every test.
+
+However, this listener is not called in the right process when using PHPUnit's process 
+isolation, resulting in expectations that might not be respected, but without raising 
+any `Mockery\Exception`. To avoid this, you cannot rely on the supplied Mockery PHPUnit 
+`TestListener`, and you need to explicitely calls `Mockery::close`. The easiest solution
+to include this call in the `tearDown()` method, as explained previously.
+
 Quick Reference
 ---------------
 


### PR DESCRIPTION
Hello,

As explained in the edited README, I came across a vicous bug using PHPUnit process isolation. When tagging a test with the `@runTestsInSeparateProcesses` annotation, the test's mocks expectation aren't properly checked, resulting in green tests, where they should have been red.

Apparently the Mockyer test listener isn't called in the wrong time/process, and expectations verification doesn't work. You have to explicitely call `Mockery::close` in the test or in the testcase `tearDown`.

That's not really a bug, but this ought to be documented, so others won't spend hours figuring out why tests that shouldn't pass are passing. 

PS: if an english native might proofread my modifications to ensure there's no grammar problems in there, that would be great.
