### PR TITLE
replace dots with underscore in unique names for cygwin

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -53,7 +53,7 @@ class Generator
         $allowFinal = false, $block = array(), $makeInstanceMock = false,
         $partialMethods = array())
     {
-        if (is_null($mockName)) $mockName = uniqid('Mockery_');
+        if (is_null($mockName)) $mockName = str_replace('.','_',uniqid('Mockery_'));
         $definition = '';
         $inheritance = '';
         $interfaceInheritance = array();


### PR DESCRIPTION
Cygwin requires extra entropy on uniqid(), so creates mockNames with a '.' in them, which PHP can't grok.  Replace it with '_'. On other systems, this is a no-op.
