### PR TITLE
Better random names on fast machines.

### DIFF
--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -53,7 +53,7 @@ class Generator
         $allowFinal = false, $block = array(), $makeInstanceMock = false,
         $partialMethods = array())
     {
-        if (is_null($mockName)) $mockName = str_replace('.','_',uniqid('Mockery_'));
+        if (is_null($mockName)) $mockName = 'Mockery_' . mt_rand();
         $definition = '';
         $inheritance = '';
         $interfaceInheritance = array();


### PR DESCRIPTION
Change uniqid to mt_rand to get better random numbers on fast machines. (Issue #183)
