### PR TITLE
Display boolean arguments in exception messages as true/false instead of 1/empty string

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -72,7 +72,7 @@ class Mockery
 
         return self::$_container->self();
     }
-    
+
     /**
      * Static shortcut to closing up and verifying all mocks in the global
      * container, and resetting the container static variable to null
@@ -281,6 +281,8 @@ class Mockery
                     $parts[] = $arg;
                 } elseif (is_array($arg)) {
                     $parts[] = 'Array';
+                } elseif (is_bool($arg)) {
+                    $parts[] = $arg ? 'true' : 'false';
                 } else {
                     $parts[] = '"' . (string) $arg . '"';
                 }


### PR DESCRIPTION
Right now, when a method without an expectation is called like `$object->methodNameHere(false)`, then exception with following message will be thrown (see below). Notice `methodNameHere("")` part, which tells, that an empty string was given as input, however this was `false`.

`Mockery\Exception\NoMatchingExpectationException : No matching handler found for ClassNameHere::methodNameHere(""). Either the method was unexpected or its arguments matched no expected argument list for this method`

After fixing message would look like:
`Mockery\Exception\NoMatchingExpectationException : No matching handler found for ClassNameHere::methodNameHere(false). Either the method was unexpected or its arguments matched no expected argument list for this method`
