### PR TITLE
Added withArgs() expectation, to accept an array of arguments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -510,7 +510,7 @@ use case is automatically recording expectations based on an existing usage
 (e.g. during refactoring). See examples in a later section.
 
 ```PHP
-with(arg1, arg2, ...)
+with(arg1, arg2, ...) / withArgs(array(arg1, arg2, ...))
 ```
 
 Adds a constraint that this expectation only applies to method calls which

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -317,7 +317,19 @@ class Expectation
         $this->_expectedArgs = func_get_args();
         return $this;
     }
-    
+
+    /**
+     * Expected arguments for the expectation passed as an array
+     *
+     * @param array $args
+     * @return self
+     */
+    public function withArgs(array $args)
+    {
+        $this->_expectedArgs = $args;
+        return $this;
+    }
+
     /**
      * Set with() as no arguments expected
      *

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -205,7 +205,22 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
         $this->mock->shouldReceive('foo')->withNoArgs();
         $this->mock->foo(1);
     }
-    
+
+    public function testExpectsArgumentsArray()
+    {
+        $this->mock->shouldReceive('foo')->withArgs(array(1, 2));
+        $this->mock->foo(1, 2);
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArguments()
+    {
+        $this->mock->shouldReceive('foo')->withArgs(array(1, 2));
+        $this->mock->foo(3, 4);
+    }
+
     public function testExpectsAnyArguments()
     {
         $this->mock->shouldReceive('foo')->withAnyArgs();


### PR DESCRIPTION
I noticed that it doesn't seem possible to provide an array of arguments to the expectation, so created a quick pull request to add it in.
