### PR TITLE
Alternative to #219 - Remove mockery_name and replace with reflection

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -151,21 +151,21 @@ class Container
             }
             $result = class_alias($mockName, $name);
             $mock = $this->_getInstance($name, $constructorArgs);
-            $mock->mockery_init($class, $this);
+            $mock->mockery_init($this);
         } elseif (!is_null($name)) {
             $mock = new \Mockery\Mock();
-            $mock->mockery_init($name, $this);
+            $mock->mockery_init($this);
         } elseif(!is_null($class)) {
             $mockName = \Mockery\Generator::createClassMock($class, null, null, $blocks, false, $partialMethods);
             $mock = $this->_getInstance($mockName, $constructorArgs);
-            $mock->mockery_init($class, $this);
+            $mock->mockery_init($this);
         } elseif(!is_null($partial)) {
             $mockName = \Mockery\Generator::createClassMock(get_class($partial), null, true, $blocks);
             $mock = $this->_getInstance($mockName, $constructorArgs);
-            $mock->mockery_init(get_class($partial), $this, $partial);
+            $mock->mockery_init($this, $partial);
         } else {
             $mock = new \Mockery\Mock();
-            $mock->mockery_init('unknown', $this);
+            $mock->mockery_init($this);
         }
         if (!empty($quickdefs)) {
             $mock->shouldReceive($quickdefs)->byDefault();

--- a/library/Mockery/Generator.php
+++ b/library/Mockery/Generator.php
@@ -53,7 +53,7 @@ class Generator
         $allowFinal = false, $block = array(), $makeInstanceMock = false,
         $partialMethods = array())
     {
-        if (is_null($mockName)) $mockName = 'Mockery_' . mt_rand();
+        if (is_null($mockName)) $mockName = static::generateMockName($className);
         $definition = '';
         $inheritance = '';
         $interfaceInheritance = array();
@@ -343,8 +343,6 @@ BODY;
 
     protected \$_mockery_verified = false;
 
-    protected \$_mockery_name = null;
-
     protected \$_mockery_allocatedOrder = 0;
 
     protected \$_mockery_currentOrder = 0;
@@ -365,9 +363,8 @@ BODY;
 
     protected \$_mockery_allowMockingProtectedMethods = false;
 
-    public function mockery_init(\$name, \Mockery\Container \$container = null, \$partialObject = null)
+    public function mockery_init(\Mockery\Container \$container = null, \$partialObject = null)
     {
-        \$this->_mockery_name = \$name;
         if(is_null(\$container)) {
             \$container = new \Mockery\Container;
         }
@@ -504,14 +501,8 @@ BODY;
             }
         }
 
-        if (is_array(\$this->_mockery_name)) {
-            \$mock_name = join(', ', \$this->_mockery_name);
-        } else {
-            \$mock_name = \$this->_mockery_name;
-        }
-
         throw new \BadMethodCallException(
-            'Method ' . \$mock_name . '::' . \$method . '() does not exist on this mock object'
+            'Method ' . __CLASS__ . '::' . \$method . '() does not exist on this mock object'
         );
     }
 
@@ -576,7 +567,7 @@ BODY;
         }
         if (\$order < \$this->_mockery_currentOrder) {
             \$exception = new \Mockery\Exception\InvalidOrderException(
-                'Method ' . \$this->_mockery_name . '::' . \$method . '()'
+                'Method ' . __CLASS__ . '::' . \$method . '()'
                 . ' called out of order: expected order '
                 . \$order . ', was ' . \$this->_mockery_currentOrder
             );
@@ -626,7 +617,7 @@ BODY;
 
     public function mockery_getName()
     {
-        return \$this->_mockery_name;
+        return __CLASS__;
     }
 
     public function mockery_getMockableMethods()
@@ -772,5 +763,19 @@ MOCK;
         return $std;
     }
 
+    protected static function generateMockName($targets)
+    {
+        $name = 'Mockery_' . mt_rand();
+
+        foreach ((array) $targets as $target) {
+            if (is_object($target)) {
+                $name .= "_" . str_replace("\\", "_", get_class($this->getTargetObject()));
+            } else {
+                $name .= "_" . str_replace("\\", "_", $target);
+            }
+        }
+
+        return $name;
+    }
 
 }

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -127,14 +127,12 @@ class Mock implements MockInterface
      * We want to avoid constructors since class is copied to Generator.php
      * for inclusion on extending class definitions.
      *
-     * @param string $name
      * @param \Mockery\Container $container
      * @param object $partialObject
      * @return void
      */
-    public function mockery_init($name, \Mockery\Container $container = null, $partialObject = null)
+    public function mockery_init(\Mockery\Container $container = null, $partialObject = null)
     {
-        $this->_mockery_name = $name;
         if(is_null($container)) {
             $container = new \Mockery\Container;
         }

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -26,12 +26,11 @@ interface MockInterface
     /**
      * Alternative setup method to constructor
      *
-     * @param string $name
      * @param \Mockery\Container $container
      * @param object $partialObject
      * @return void
      */
-    public function mockery_init($name, \Mockery\Container $container = null, $partialObject = null);
+    public function mockery_init(\Mockery\Container $container = null, $partialObject = null);
     
     /**
      * Set expected method calls

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -107,7 +107,9 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         try {
             $m->f();
         } catch (BadMethodCallException $e) {
-            $this->assertTrue((bool) preg_match("/stdClass, ArrayAccess, Countable/", $e->getMessage()));
+            $this->assertTrue((bool) preg_match("/stdClass/", $e->getMessage()));
+            $this->assertTrue((bool) preg_match("/ArrayAccess/", $e->getMessage()));
+            $this->assertTrue((bool) preg_match("/Countable/", $e->getMessage()));
         }
     }
 


### PR DESCRIPTION
I'm :+1: on removing the `_mockery_name`, it's serves very little purpose in the actual mock. The only thing I'm not keen on is the `isPrivate` when getting the API methods, I'm not sure why PHP doesn't return a prototype for private methods.
