### PR TITLE
Add Hamcrest assertThat() so assertions can be counted

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -301,7 +301,12 @@ class Expectation
             return $expected->match($actual);
         }
         if ($expected instanceof \Hamcrest_Matcher) {
-            return $expected->matches($actual);
+            try {
+                assertThat($actual, is($expected));
+            } catch (Exception $e) {
+                return false;
+            }
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
I've integrated Hamcrest with my PHPUnit in RunBare method https://gist.github.com/dharkness/3965902

And when i use Mockery with Hamcrest Matchers as arguments in method f.ex. with() than PHPUnit doesnt count assertion.

Example:
$adapter = Mockery::mock('Logger');
$adapter->shouldReceive('write')->once()->with(hasKey('message')->andReturnNull();

This update pass the matcher to the asserThat method of Hamcrest Framework so the assertions are counted.