### PR TITLE
add HHVM as an optional build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
 before_script:
   - composer install --dev
   - pecl install redis
@@ -13,3 +14,6 @@ notifications:
     email:
         - padraic.brady@gmail.com
         - dave@atstsolutions.co.uk
+matrix:
+    allow_failures:
+        - php: hhvm


### PR DESCRIPTION
I don't expect Mockery to pass tests in HHVM straight off, and I expect this will be down to an incomplete Reflection implementation in HHVM.  However, testing against HHVM will hopefully provide useful information that could help expedite bringing HHVM to parity so tests using Mockery can be used in that environment.
