### PR TITLE
only add redis extension to travis build if pecl available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ php:
   - hhvm
 before_script:
   - composer install --dev
-  - pecl install redis
-  - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - sh -c "if [[ \"$TRAVIS_PHP_VERSION\" != \"hhvm\" ]]; then pecl install redis; echo \"extension = mongo.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - phpenv rehash
-script: phpunit -v --colors --coverage-text 
+script: phpunit -v --colors --coverage-text
 notifications:
     email:
         - padraic.brady@gmail.com


### PR DESCRIPTION
HHVM doesn't have PECL available and can't build the Redis extension, although it should have a PHPRedis implementation inbuilt.  So making the build of the Redis extension for Travis dependent on PECL being available, mainly to stop HHVM builds failing unnecessarily on that hurdle.
