### PR TITLE
Fix distinguishing constructor params and expectation closures

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -95,8 +95,8 @@ class Container
         if (count($args) > 1) {
             $finalArg = end($args);
             reset($args);
-            if (is_callable($finalArg)) {
-                $expectationClosure = array_pop($args);
+            if (is_callable($finalArg) && is_object($finalArg)) {
+                 $expectationClosure = array_pop($args);
             }
         }
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -989,8 +989,9 @@ class ContainerTest extends PHPUnit_Framework_TestCase
 
     public function testMockeryShouldDistinguishBetweenConstructorParamsAndClosures()
     {
+        $obj = new MockeryTestFoo();
         $mock = $this->container->mock('MockeryTest_ClassMultipleConstructorParams[dave]',
-            array(new stdClass, 'bar'));
+            array( &$obj, 'foo' ));
     }
 
     /** @group nette */


### PR DESCRIPTION
Mockery was unable to tell the difference between expectation closures and partial mocks constructor params that happened to be callable (which can happen if the constructor params array contains an object and a string that happens to be a method of the object, for example). There was a test in place to test for this, but the array that was supposed to look callable was not actually callable.

This should fix this bug.

To anyone else who runs into this bug before this is merged (or if for some reason this patch can't be merged), I fixed this in my test by adding an extra 'foo' param to my constructor params, so the array was no longer callable. :)
