### PR TITLE
HHVM Fixes (Take 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,12 @@ before_script:
   - phpenv rehash
 
 script:
-  - phpunit -v --colors --coverage-text --coverage-clover ./build/logs/clover.xml
+  - vendor/bin/phpunit --verbose --colors --coverage-text --coverage-clover ./build/logs/clover.xml
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then vendor/bin/coveralls -v; fi
   - if [[ "$TRAVIS_PHP_VERSION" == "5.5" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
   - if [[ "$TRAVIS_PHP_VERSION" == "5.5" ]]; then php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml; fi
-
-matrix:
-  allow_failures:
-    - php: 5.6
-    - php: hhvm
-  fast_finish: true
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "lib-pcre": ">=7.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "4.0@dev",
         "hamcrest/hamcrest-php": "~1.1",
         "satooshi/php-coveralls": "dev-master"
     },


### PR DESCRIPTION
Let's load in phpunit 4.0. Let's make sure we only try to push to coveralls if we are not using hhvm.

_Note that I am not pulling in phpunit `~4.0@dev` because that would result in 4.1 being used, which is currently broken._
