### PR TITLE
Fix infinite loop when a getter passes $this into a mock.

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -395,6 +395,10 @@ class Mockery
      */
     public static function formatObjects(array $args = null)
     {
+        static $formatting;
+        if($formatting)
+            return '[Recursion]';
+        $formatting = true;
         $hasObjects = false;
         $parts = array();
         $return = 'Objects: (';
@@ -409,6 +413,7 @@ class Mockery
         $return .= var_export($parts, true);
         $return .= ')';
         $return = $hasObjects ? $return : '';
+        $formatting = false;
         return $return;
     }
 

--- a/tests/Mockery/WithFormatterExpectationTest.php
+++ b/tests/Mockery/WithFormatterExpectationTest.php
@@ -32,6 +32,20 @@ class WithFormatterExpectationTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException Mockery\Exception\NoMatchingExpectationException
+     *
+     * Note that without the patch checked in with this test, rather than throwing
+     * an exception, the program will go into an infinite recursive loop
+     */
+    public function testFormatObjectsWithMockCalledInGetterDoesNotLeadToRecursion()
+    {
+        $mock = Mockery::mock('stdClass');
+        $mock->shouldReceive('doBar')->with('foo');
+        $obj = new ClassWithGetter($mock);
+        $obj->getFoo();
+    }
+
     public function formatObjectsDataProvider()
     {
         return array(
@@ -46,4 +60,18 @@ class WithFormatterExpectationTest extends PHPUnit_Framework_TestCase
         );
     }
 
+}
+ 
+class ClassWithGetter
+{
+    private $dep;
+
+    function __construct($dep)
+    {
+        $this->dep = $dep;
+    }
+    public function getFoo()
+    {
+        return $this->dep->doBar('bar', $this);
+    }
 }


### PR DESCRIPTION
Fixed Issue #282
