### PR TITLE
Mockery::hasSubstrings() matcher

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -289,6 +289,17 @@ class Mockery
     }
 
     /**
+     * Return instance of HASSUBSTRINGS matcher
+     *
+     * @return
+     */
+    public static function hasSubstrings()
+    {
+        $return = new \Mockery\Matcher\HasSubstrings(func_get_args());
+        return $return;
+    }
+
+    /**
      * Return instance of CLOSURE matcher
      *
      * @return

--- a/library/Mockery/Matcher/HasSubstrings.php
+++ b/library/Mockery/Matcher/HasSubstrings.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mockery\Matcher;
+
+class HasSubstrings extends MatcherAbstract
+{
+
+    /**
+     * Check if the actual value matches the expected.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        foreach ($this->_expected as $needle) {
+            if (strpos($actual, $needle) === false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $return = '<HasSubstrings[';
+        $return .= implode(', ', $this->_expected) . ']>';
+        return $return;
+    }
+
+}

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1312,6 +1312,49 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
         $this->container->mockery_verify();
     }
 
+    public function hasSubstringsMatches()
+    {
+        return array(
+            array(),
+            array('The'),
+            array('The', 'quick')
+        );
+    }
+
+    /** @dataProvider hasSubstringsMatches */
+    public function testHasSubstringsConstraintMatchesArgument()
+    {
+        $substrings = func_get_args();
+        $matcher = call_user_func_array(array('Mockery', 'hasSubstrings'), $substrings);
+        $this->mock->shouldReceive('foo')->with($matcher)->once();
+        $this->mock->foo('The quick brown fox');
+        $this->container->mockery_verify();
+    }
+
+    public function hasSubstringsNonMatchingCases()
+    {
+        return array(
+            array('The', 'quick', 'brown', 'monkey'),
+            array('monkey')
+        );
+    }
+
+    /** @dataProvider hasSubstringsNonMatchingCases */
+    public function testHasSubstringsConstraintNonMatchingCase()
+    {
+        $substrings = func_get_args();
+        $matcher = call_user_func_array(array('Mockery', 'hasSubstrings'), $substrings);
+        $this->mock->shouldReceive('foo')->once()->with($matcher);
+        $thrown = false;
+        try {
+            $this->mock->foo('The quick brown fox');
+            $this->container->mockery_verify();
+        } catch (\Mockery\Exception\NoMatchingExpectationException $ex) {
+            $thrown = true;
+        }
+        $this->assertTrue($thrown, 'Unexpected match');
+    }
+
     /**
      * @expectedException \Mockery\Exception
      */


### PR DESCRIPTION
Use as Mockery::hasSubstrings('needed substring', 'another needed substring')

I wrote the NonMatchingCase test in a different way than the other tests, because it seems to me that there's something wrong.  If you change, for instance, the third call to `foo()` in `testHasKeyConstraintNonMatchingCase()`, to `$this->mock->foo(1, array('a'=>1))`, the test still passes; I think it should fail?
