### PR TITLE
Throw an exception when mockery_init is not found

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -206,6 +206,14 @@ class Container
         $this->getLoader()->load($def);
 
         $mock = $this->_getInstance($def->getClassName(), $constructorArgs);
+
+        if (! method_exists($mock, 'mockery_init')) {
+            throw new \Mockery\Exception(
+                'You cannot mock a class that has already been loaded: '
+                . $def->getClassName()
+            );
+        }
+
         $mock->mockery_init($this, $config->getTargetObject());
 
         if (!empty($quickdefs)) {


### PR DESCRIPTION
I seem to be coming across this error quite often, it happens when the class has already been loaded. There are a lot of discussion around this error online. The error i get is:

```
Call to undefined method RandomClass::mockery_init() in /vendor/composer/mockery/mockery/library/Mockery/Container.php on line 219
```

The reason for this PR is to try and cleanup the output (stack trace etc) when this error happens. The exception message may not be correct, so feel free to suggest another, but i feel that having an exception here instead of just the PHP error will clear things up. 

Thanks
Scott
