### PR TITLE
Issue 299 - Handle __toString more gracefully

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -339,6 +339,11 @@ class Mock implements MockInterface
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
         } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")) {
             return call_user_func_array("parent::$method", $args);
+        } elseif ($method == '__toString') {
+            // __toString is special because we force its addition to the class API regardless of the 
+            // original implementation.  Thus, we should always return a string rather than honor 
+            // _mockery_ignoreMissing and break the API with an error.
+            return sprintf("%s#%s", __CLASS__, spl_object_hash($this));
         } elseif ($this->_mockery_ignoreMissing) {
             if ($this->_mockery_ignoreMissingAsUndefined === true) {
                 $undef = new \Mockery\Undefined;

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -52,6 +52,27 @@ class Mockery_MockTest extends PHPUnit_Framework_TestCase
         assertThat($m->testSomeNonExistentMethod(), equalTo(true));
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
     }
+
+    public function testMockAddsToString() 
+    {
+        $mock = $this->container->mock('ClassWithNoToString');
+        assertThat(hasToString($mock));
+    }
+
+    public function testMockToStringMayBeDeferred() 
+    {
+        $mock = $this->container->mock('ClassWithToString')->shouldDeferMissing();
+        assertThat((string)$mock, equalTo("foo"));
+    }
+
+    public function testMockToStringShouldIgnoreMissingAlwaysReturnsString() 
+    {
+        $mock = $this->container->mock('ClassWithNoToString')->shouldIgnoreMissing();
+        assertThat(isNonEmptyString((string)$mock));
+
+        $mock->asUndefined();
+        assertThat(isNonEmptyString((string)$mock));
+    }
 }
 
 
@@ -59,3 +80,14 @@ class ExampleClassForTestingNonExistentMethod
 {
 }
 
+class ClassWithToString 
+{
+    public function __toString() 
+    {
+        return 'foo';
+    }
+}
+
+class ClassWithNoToString 
+{
+}


### PR DESCRIPTION
Mock will now ensure a string is returned for __toString() regardless of configuration or original implementation.  This prevents confusing PHP fatal errors from happening if the __toString() API is broken.
