### PR TITLE
Fixes #311 PHP fatal error

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -429,7 +429,7 @@ class Mockery
         if ($nesting == 0) {
             return array('...');
         }
-        $reflection = new \ReflectionClass($object);
+        $reflection = new \ReflectionClass(get_class($object));
         $properties = array();
         foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $publicProperty) {
             if ($publicProperty->isStatic()) continue;


### PR DESCRIPTION
Original Issue: #311 

Due to a memory handling issue in PHP core Mocks might cause PHP to error out when called in a destructor.

The workaround works because it causes ReflectionClass to create a new class entry and not reuse the one from the existing object. Alternatively `ReflectionClass` could be replaced with `ReflectionObject`.

Relevant part of the code: http://lxr.php.net/xref/PHP_5_5/ext/reflection/php_reflection.c#3313

Any chance to get this in a tagged release quickly? It kinda gets in the way of my SwiftMailer work ;)
