### PR TITLE
#350 public __sleep() results in BadMethodCallException

### DIFF
--- a/library/Mockery/Generator/MockConfigurationBuilder.php
+++ b/library/Mockery/Generator/MockConfigurationBuilder.php
@@ -9,6 +9,7 @@ class MockConfigurationBuilder
         '__call',
         '__callStatic',
         '__clone',
+        '__sleep',
         '__wakeup',
         '__set',
         '__get',


### PR DESCRIPTION
See issue #350
