### PR TITLE
Fixed "Erroneous data format" error when mocking internal classes (eg. SplFileInfo) in PHP v5.5.14.

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -483,9 +483,11 @@ class Container
         } catch (\Exception $ex) {
             $internalMockName = $mockName . '_Internal';
 
-            eval("class $internalMockName extends $mockName {" .
-                    'public function __construct() {}' .
-                '}');
+            if (!class_exists($internalMockName)) {
+                eval("class $internalMockName extends $mockName {" .
+                        'public function __construct() {}' .
+                    '}');
+            }
 
             $return = new $internalMockName();
         }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -286,6 +286,15 @@ class ContainerTest extends PHPUnit_Framework_TestCase
 
     }
 
+    public function testSplClassWithFinalMethodsCanBeMockedMultipleTimes()
+    {
+        $this->container->mock('SplFileInfo');
+        $m = $this->container->mock('SplFileInfo');
+        $m->shouldReceive('foo')->andReturn('baz');
+        $this->assertEquals('baz', $m->foo());
+        $this->assertTrue($m instanceof SplFileInfo);
+    }
+
     public function testClassesWithFinalMethodsCanBeProxyPartialMocks()
     {
         $m = $this->container->mock(new MockeryFoo4);


### PR DESCRIPTION
```
~/ $ php -v
PHP 5.5.14 (cli) (built: Jun 30 2014 14:05:48) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
```

```
~/ [internal-php5.5.14] $ phpunit
PHPUnit 4.1.4 by Sebastian Bergmann.

Configuration read from /Library/WebServer/Documents/localhost/mockery/phpunit.xml.dist

.................................................S.............  63 / 382 ( 16%)
............................................................... 126 / 382 ( 32%)
............................................................... 189 / 382 ( 49%)
............................................................... 252 / 382 ( 65%)
............................................................... 315 / 382 ( 82%)
..............................................................S 378 / 382 ( 98%)
....

Time: 1.27 seconds, Memory: 58.75Mb

OK, but incomplete, skipped, or risky tests!
Tests: 382, Assertions: 411, Skipped: 2.
```

For reference, these were the errors output prior to the change:

```
~/ [master] $ phpunit
PHPUnit 4.1.4 by Sebastian Bergmann.

Configuration read from /Library/WebServer/Documents/localhost/mockery/phpunit.xml.dist

.E..............................E...............S..............  63 / 381 ( 16%)
............................................................... 126 / 381 ( 33%)
............................................................... 189 / 381 ( 49%)
............................................................... 252 / 381 ( 66%)
............................................................... 315 / 381 ( 82%)
.............................................................S. 378 / 381 ( 99%)
...

Time: 845 ms, Memory: 58.75Mb

There were 2 errors:

1) Mockery_AdhocTest::testMockeryInterfaceForClass
Erroneous data format for unserializing 'Mockery_1_SplFileInfo'

/Library/WebServer/Documents/localhost/mockery/library/Mockery/Container.php:478
/Library/WebServer/Documents/localhost/mockery/library/Mockery/Container.php:218
/Library/WebServer/Documents/localhost/mockery/tests/Mockery/AdhocTest.php:46
phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:176
phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:129

2) ContainerTest::testSplClassWithFinalMethodsCanBeMocked
Erroneous data format for unserializing 'Mockery_33_SplFileInfo'

/Library/WebServer/Documents/localhost/mockery/library/Mockery/Container.php:478
/Library/WebServer/Documents/localhost/mockery/library/Mockery/Container.php:218
/Library/WebServer/Documents/localhost/mockery/tests/Mockery/ContainerTest.php:282
phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:176
phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:129

FAILURES!
Tests: 381, Assertions: 406, Errors: 2, Skipped: 2.
```
