### PR TITLE
Not matcher now negate anything

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -281,11 +281,16 @@ class Expectation implements ExpectationInterface
      */
     protected function _matchArg($expected, &$actual)
     {
+        $negate = false;
+        while ($expected instanceof \Mockery\Matcher\Not) {
+            $expected = $expected->getNegatedExpectation();
+            $negate = !$negate;
+        }
         if ($expected === $actual) {
-            return true;
+            return !$negate;
         }
         if (!is_object($expected) && !is_object($actual) && $expected == $actual) {
-            return true;
+            return !$negate;
         }
         if (is_string($expected) && !is_array($actual) && !is_object($actual)) {
             # push/pop an error handler here to to make sure no error/exception thrown if $expected is not a regex
@@ -294,22 +299,24 @@ class Expectation implements ExpectationInterface
             restore_error_handler();
 
             if($result) {
-                return true;
+                return !$negate;
             }
         }
         if (is_string($expected) && is_object($actual)) {
             $result = $actual instanceof $expected;
             if($result) {
-                return true;
+                return !$negate;
             }
         }
         if ($expected instanceof \Mockery\Matcher\MatcherAbstract) {
-            return $expected->match($actual);
+            $result = $expected->match($actual);
+            return $negate ? !$result : $result;
         }
         if (is_a($expected, '\Hamcrest\Matcher') || is_a($expected, '\Hamcrest_Matcher')) {
-            return $expected->matches($actual);
+            $result = $expected->matches($actual);
+            return $negate ? !$result : $result;
         }
-        return false;
+        return $negate;
     }
 
     /**

--- a/library/Mockery/Matcher/Not.php
+++ b/library/Mockery/Matcher/Not.php
@@ -24,6 +24,16 @@ class Not extends MatcherAbstract
 {
 
     /**
+     * Return the expectation that is negated by this matcher.
+     * 
+     * @return mixed
+     */
+    public function getNegatedExpectation()
+    {
+        return $this->_expected;
+    }
+
+    /**
      * Check if the actual value does not match the expected (in this
      * case it's specifically NOT expected).
      *
@@ -32,7 +42,7 @@ class Not extends MatcherAbstract
      */
     public function match(&$actual)
     {
-        return $actual !== $this->_expected;
+        return false;
     }
 
     /**

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1569,6 +1569,13 @@ class ExpectationTest extends PHPUnit_Framework_TestCase
         $this->container->mockery_verify();
     }
 
+    public function testNotConstraintChainable()
+    {
+        $this->mock->shouldReceive('foo')->with(Mockery::not(Mockery::not(1)))->once();
+        $this->mock->foo(1);
+        $this->container->mockery_verify();
+    }
+
     public function testNotConstraintNonMatchingCase()
     {
         $this->mock->shouldReceive('foo')->times(3);


### PR DESCRIPTION
Now you can use
- ``->with(Mockery::not('/regexp/i))``
- ``->with(Mockery::not('stdClass'))``
- ``->with(Mockery::not(Mockery::type('resource')))``