### PR TITLE
Allow HHVM Failures On Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
   - sh -c "if [ \"$TRAVIS_PHP_VERSION\" != \"hhvm\" ]; then echo \"extension = mongo.so\nextension = redis.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - phpenv rehash
 
@@ -26,3 +26,8 @@ notifications:
   email:
     - padraic.brady@gmail.com
     - dave@atstsolutions.co.uk
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
I've allowed hhvm to fail, and have removed the depricated `--dev` flag from the composer install.
