### PR TITLE
Fixes Object of class SplFileInfo could not be converted to boolean

### DIFF
--- a/library/Mockery/Generator/MockConfiguration.php
+++ b/library/Mockery/Generator/MockConfiguration.php
@@ -268,7 +268,7 @@ class MockConfiguration
         if (class_exists($this->targetClassName)) {
             $dtc = DefinedTargetClass::factory($this->targetClassName);
 
-            if (!$this->getTargetObject() && $dtc->isFinal()) {
+            if ($this->getTargetObject() == false && $dtc->isFinal()) {
                 throw new \Mockery\Exception(
                     'The class ' . $this->targetClassName . ' is marked final and its methods'
                     . ' cannot be replaced. Classes marked final can be passed in'


### PR DESCRIPTION
When using mockery to mock a file like so:

``` PHP
    protected function setUp()
    {
        $fileMock = Mockery::mock((new Instantiator())->instantiate('Symfony\\Component\\Finder\\SplFileInfo'));
        $fileMock
            ->shouldReceive('getBasename')
            ->atLeast(1)
            ->andReturn('VirtualClass');

        $stream = new TokenStream();
        $stream->setCode(self::FILE_CONTENTS);

        /** @var Source $source */
        $source = (new Instantiator())->instantiate('TheDevNetwork\\CodeTools\\Model\\Source');
        $source->setStream($stream);
        $sourceMock = Mockery::mock($source);
        $sourceMock
            ->shouldReceive('getFile')
            ->atLeast(1)
            ->andReturn($fileMock);

        $this->objectHelper = new ObjectHelper($sourceMock);
    }

```

An exception is thrown: 
`Object of class Symfony\Component\Finder\SplFileInfo could not be converted to boolean`

This fixes it.
