### PR TITLE
Fix for issue #384

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -623,7 +623,7 @@ class Mock implements MockInterface
         $expectation->never();
         $director = new \Mockery\VerificationDirector($this->_mockery_getReceivedMethodCalls(), $expectation);
         $director->verify();
-        return $director;
+        return null;
     }
 
     protected static function _mockery_handleStaticMethodCall($method, array $args)

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -75,7 +75,7 @@ interface MockInterface
     /**
      * @param $method
      * @param null $args
-     * @return \Mockery\Expectation
+     * @return null
      */
     public function shouldNotHaveReceived($method, $args = null);
 


### PR DESCRIPTION
Calling shouldNotHaveReceived() returns null instead of Mockery/Expectation, so nobody will wrongly call with() or times(). 
