### PR TITLE
Add method_existe() to TestListener to avoid mask test errors

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -34,7 +34,8 @@ class TestListener implements \PHPUnit_Framework_TestListener
     {
         try {
             $container = \Mockery::getContainer();
-            if ($container != null) {
+            // check addToAssertionCount is important to avoid mask test errors
+            if ($container != null && method_exists($test, 'addToAssertionCount')) {
                 $expectation_count = $container->mockery_getExpectationCount();
                 $test->addToAssertionCount($expectation_count);
             }


### PR DESCRIPTION
I was getting this error:

```
Fatal error: Call to undefined method PHPUnit_Framework_TestSuite::addToAssertionCount() in /private/var/www/uniplaces/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php on line 39
```

When added a method_exists start getting the real error:

```
1) Uniplaces\AccommodationBundle\Tests\Functional\AccommodationOffer\AccommodationOfferCommandControllerTest
exception 'RuntimeException' with message 'OUTPUT: 
Catchable fatal error: Argument 2 passed to Uniplaces\Library\Controller\CommandController::__construct() must implement interface Symfony\Component\Security\Core\SecurityContextInterface, none given, called in /private/var/www/uniplaces/src/Uniplaces/UserBundle/Application/Session/Controller/SessionCommandController.php on line 33 and defined in /private/var/www/uniplaces/vendor/uniplaces/uniplaces-library/src/Unip
```

Adding this method_exists allow to see the real error.
