### PR TITLE
Mockery::equalsStringIgnoringWhitespace() matcher

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -382,6 +382,18 @@ class Mockery
     }
 
     /**
+     * Returns an instance of the EQUALSTRINGIGNORINGWHITESPACE matcher.
+     *
+     * @param string $expected
+     *
+     * @return \Mockery\Matcher\EqualsStringIgnoringWhitespace
+     */
+    public static function equalsStringIgnoringWhitespace($expected)
+    {
+        return new \Mockery\Matcher\EqualsStringIgnoringWhitespace($expected);
+    }
+
+    /**
      * Get the global configuration container.
      */
     public static function getConfiguration()

--- a/library/Mockery/Matcher/EqualsStringIgnoringWhitespace.php
+++ b/library/Mockery/Matcher/EqualsStringIgnoringWhitespace.php
@@ -1,0 +1,77 @@
+<?php
+namespace Mockery\Matcher;
+
+use InvalidArgumentException;
+
+/**
+ * This class provides a matcher that matches two strings while ignoring whitespace.
+ *
+ * @author Sebastian Knott <sebastian.knott@sparhandy.de>
+ */
+class EqualsStringIgnoringWhitespace extends MatcherAbstract
+{
+    /**
+     * Constructor.
+     *
+     * @param string $expected
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($expected)
+    {
+        if (!is_string($expected))
+        {
+            throw new InvalidArgumentException(
+                'EqualsStringIgnoringWhitespace works with strings only.',
+                1417530930
+            );
+        }
+
+        $this->_expected = $this->removeUnwantedWhitespace($expected);
+    }
+
+    /**
+     * Checks if the actual value matches the expected value.
+     * $actual is passed by reference to preserve reference trail (where applicable)
+     * back to the original method parameter.
+     *
+     * @param mixed $actual
+     *
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        if (!is_string($actual))
+        {
+            return false;
+        }
+
+        $actualWithoutUnwantedWhitespace = $this->removeUnwantedWhitespace($actual);
+
+        return $actualWithoutUnwantedWhitespace === $this->_expected;
+    }
+
+    /**
+     * Returns a string representation of this Matcher.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<EqualsStringIgnoringWhitespace>';
+    }
+
+    /**
+     * This function replaces all \s \n and \t with one single whitespace. It also
+     * trims any leading or trailing whitespace from the string.
+     *
+     * @param string $expected
+     *
+     * @return string
+     */
+    private function removeUnwantedWhitespace(&$expected)
+    {
+        return mb_ereg_replace('[\\s\\n\\t]+', ' ', trim($expected));
+    }
+}
+

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -123,7 +123,7 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo();
         $this->assertEquals('bazzz', $this->mock->bar);
     }
-    
+
     public function testSetsPublicPropertiesWhenRequestedMoreTimesThanSetValues()
     {
         $this->mock->bar = null;
@@ -1728,6 +1728,60 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->with(Mockery::notAnyOf(1, 2))->once();
         $this->mock->foo(2);
+        $this->container->mockery_verify();
+    }
+
+    public function testEqualsStringIgnoringWhitespaceMatchGivenParameters()
+    {
+        $this->mock->shouldReceive('foo')
+            ->with(Mockery::equalsStringIgnoringWhitespace("My \t  Expectation! \n Wub. .. "))
+            ->once();
+        $this->mock->foo(" My \n  Expectation!  \t  Wub. ..");
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testEqualsStringIgnoringWhitespaceThrowsExceptionOnNonMatchingStrings()
+    {
+        $this->mock->shouldReceive('foo')
+            ->with(Mockery::equalsStringIgnoringWhitespace("My \t  Expectation! \n Wub. .. "))
+            ->once();
+        $this->mock->foo('I\'m no match');
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testEqualsStringIgnoringWhitespaceThrowsExceptionOnWrongParameterType()
+    {
+        $this->mock->shouldReceive('foo')
+            ->with(Mockery::equalsStringIgnoringWhitespace("My \t  Expectation! \n Wub. .. "))
+            ->once();
+        $this->mock->foo(1234);
+        $this->container->mockery_verify();
+    }
+
+    public function testEqualsStringIgnoringWhitespaceWorksWithUtf8()
+    {
+        $this->mock->shouldReceive('foo')
+            ->with(Mockery::equalsStringIgnoringWhitespace(" あ \t  ä"))
+            ->once();
+        $this->mock->foo("あ \n  ä ");
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testEqualsStringIgnoringWhitespaceThrowsExceptionOnWrongConstructorParameterType()
+    {
+        $this->mock->shouldReceive('foo')
+            ->with(Mockery::equalsStringIgnoringWhitespace(1234))
+            ->once();
+        $this->mock->foo('1234');
         $this->container->mockery_verify();
     }
 


### PR DESCRIPTION
EqualsStringIgnoringWhitespace() matches two strings while ignoring whitespace. This is especially useful if you want to match multi line strings which are not indented in the same way.