### PR TITLE
Exclude static properties and methods differently when formatting objects.

### DIFF
--- a/tests/Mockery/WithFormatterExpectationTest.php
+++ b/tests/Mockery/WithFormatterExpectationTest.php
@@ -69,6 +69,21 @@ class WithFormatterExpectationTest extends PHPUnit_Framework_TestCase
         $this->assertNotContains('Missing argument 1 for', $string);
     }
 
+    public function testFormatObjectsExcludesStaticProperties()
+    {
+        $obj = new ClassWithPublicStaticProperty();
+        $string = Mockery::formatObjects(array($obj));
+
+        $this->assertNotContains('excludedProperty', $string);
+    }
+
+    public function testFormatObjectsExcludesStaticGetters()
+    {
+        $obj = new ClassWithPublicStaticGetter();
+        $string = Mockery::formatObjects(array($obj));
+
+        $this->assertNotContains('getExcluded', $string);
+    }
 }
 
 class ClassWithGetter
@@ -89,4 +104,14 @@ class ClassWithGetter
 class ClassWithGetterWithParam
 {
     public function getBar($bar) {}
+}
+
+class ClassWithPublicStaticProperty
+{
+    public static $excludedProperty;
+}
+
+class ClassWithPublicStaticGetter
+{
+    public static function getExcluded() { }
 }


### PR DESCRIPTION
Assuming the existing *intended* behaviour remains desired, then this resolves #416