### PR TITLE
Add 'addRiskyTest' to maintain abstract class relationship in TestListener

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -78,4 +78,5 @@ class TestListener implements \PHPUnit_Framework_TestListener
 
     public function startTest(\PHPUnit_Framework_Test $test) {}
 
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {}
 }


### PR DESCRIPTION
Fixes PHPUnit 4.4 incompatibility.

Tested on PHPUnit 4.4.5 and PHPUnit 3.7.28.