### PR TITLE
TestCase should be abstract

### DIFF
--- a/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryTestCase.php
@@ -4,7 +4,7 @@ namespace Mockery\Adapter\Phpunit;
 
 use Mockery;
 
-class MockeryTestCase extends \PHPUnit_Framework_TestCase
+abstract class MockeryTestCase extends \PHPUnit_Framework_TestCase
 {
     protected function assertPostConditions()
     {


### PR DESCRIPTION
Otherwise, sometime phpunit will fail due to no tests being found in MockeryTestCase