### PR TITLE
Format null argument correctly

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -447,6 +447,10 @@ class Mockery
             return 'resource(...)';
         }
 
+        if (is_null($argument)) {
+            return 'NULL';
+        }
+
         $argument = (string) $argument;
 
         return $depth === 0 ? '"' . $argument . '"' : $argument;

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -358,6 +358,16 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(3, 4);
     }
 
+    /**
+     * @expectedException \Mockery\Exception
+     * @expectedExceptionMessageRegExp /foo\(NULL\)/
+     */
+    public function testExpectsStringArgumentExceptionMessageDifferentiatesBetweenNullAndEmptyString()
+    {
+        $this->mock->shouldReceive('foo')->withArgs(array('a string'));
+        $this->mock->foo(null);
+    }
+
     public function testExpectsAnyArguments()
     {
         $this->mock->shouldReceive('foo')->withAnyArgs();


### PR DESCRIPTION
When an expectation is set for a string, but a null is passed instead,
make sure the argument is correctly formatted in the exception message
so we don't get an empty string printed where null should be.

Ended up chasing my tail a couple of times because of messages like `No matching handler found for Mockery_154_Foo::foo("")` :)