### PR TITLE
Prepend namespace separator to type hinted class

### DIFF
--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -48,7 +48,13 @@ class Parameter
         if ((version_compare(PHP_VERSION, '5.4.1') >= 0)) {
             try {
                 if ($this->rfp->getClass()) {
-                    return $this->rfp->getClass()->getName();
+                    $typehintedClass = $this->rfp->getClass()->getName();
+
+                    if ($this->isNamespacedClass($typehintedClass)) {
+                        return '\\' . $typehintedClass;
+                    }
+
+                    return $typehintedClass;
                 }
             } catch (\ReflectionException $re) {
                 // noop
@@ -56,7 +62,13 @@ class Parameter
         }
 
         if (preg_match('/^Parameter #[0-9]+ \[ \<(required|optional)\> (?<typehint>\S+ )?.*\$' . $this->rfp->getName() . ' .*\]$/', $this->rfp->__toString(), $typehintMatch)) {
+
             if (!empty($typehintMatch['typehint'])) {
+
+                if ($this->isNamespacedClass($typehintMatch['typehint'])) {
+                    return '\\' . $typehintMatch['typehint'];
+                }
+
                 return $typehintMatch['typehint'];
             }
         }
@@ -87,5 +99,13 @@ class Parameter
             return false;
         }
         return $this->rfp->isVariadic();
+    }
+
+    private function isNamespacedClass($class)
+    {
+        if (strpos($class, '\\') > 0) {
+            return true;
+        }
+        return false;
     }
 }

--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -48,13 +48,7 @@ class Parameter
         if ((version_compare(PHP_VERSION, '5.4.1') >= 0)) {
             try {
                 if ($this->rfp->getClass()) {
-                    $typehintedClass = $this->rfp->getClass()->getName();
-
-                    if ($this->isNamespacedClass($typehintedClass)) {
-                        return '\\' . $typehintedClass;
-                    }
-
-                    return $typehintedClass;
+                    return '\\' . $this->rfp->getClass()->getName();
                 }
             } catch (\ReflectionException $re) {
                 // noop

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -1,4 +1,25 @@
 <?php
+
+namespace Foo {
+    class Bar {
+        public function baz() { return 0; }
+    }
+}
+
+namespace Acme {
+    class Acme {
+        public function hammer(\Foo\Bar $bar) {
+            return $bar->baz();
+        }
+
+        public function workshop(Anvil $anvil) {}
+    }
+
+    class Anvil {}
+}
+
+namespace {
+
 /**
  * Mockery
  *
@@ -51,4 +72,22 @@ class NamedMockTest extends MockeryTestCase
         $mock = Mockery::namedMock("Mockery\Dave7");
         $mock = Mockery::namedMock("Mockery\Dave7", "DateTime");
     }
+
+    /**
+     * @test
+     */
+    public function itUsesCorrectNamespaceInFunctionParameterTypeHints()
+    {
+        $mock = Mockery::namedMock("MyNamespace\Acme", "\Acme\Acme");
+        $mock->shouldReceive('hammer')->once()->andReturn(1);
+        $mock->shouldReceive('workshop')->once();
+
+        $bar = new \Foo\Bar();
+        $mock->hammer($bar);
+
+        $anvil = new \Acme\Anvil();
+        $mock->workshop($anvil);
+    }
+}
+
 }


### PR DESCRIPTION
ReflectionParameter gets typehinted classes with
fully resolved names, but does not prepend the
namespace separator to it.

See issue #396 