### PR TITLE
Cleanup Travis builds and implement PHP7 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 5.3.3 #This will actually use PHP7
   - hhvm
   - hhvm-nightly
 
@@ -19,22 +20,20 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - ./travis/before_install.sh
+
 install:
-  - travis_retry composer install -n
+  - travis_retry ./travis/install.sh
 
 before_script:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then echo "extension = mongo.so\nextension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - phpenv rehash
+  - ./travis/before_script.sh
 
 script:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; fi
-  - if [[ "$TRAVIS_PHP_VERSION" == "hhvm" ]] || [[ "$TRAVIS_PHP_VERSION" == "hhvm-nightly" ]]; then vendor/bin/phpunit; fi
+  - ./travis/script.sh
 
 after_script:
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then vendor/bin/coveralls -v; fi
-  - if [[ "$TRAVIS_PHP_VERSION" == "5.5" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [[ "$TRAVIS_PHP_VERSION" == "5.5" ]]; then php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml; fi
-
+  - ./travis/after_script.sh
 notifications:
   email:
     - padraic.brady@gmail.com

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "hamcrest/hamcrest-php": "~1.1",
-        "satooshi/php-coveralls": "~0.7@dev"
+        "hamcrest/hamcrest-php": "~1.1"
     },
     "autoload": {
         "psr-0": { "Mockery": "library/" }

--- a/travis/after_script.sh
+++ b/travis/after_script.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
-if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then
+if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
   vendor/bin/coveralls -v
-fi
-
-if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
   wget https://scrutinizer-ci.com/ocular.phar
-fi
-
-if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
   php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml
 fi

--- a/travis/after_script.sh
+++ b/travis/after_script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then
+  vendor/bin/coveralls -v
+fi
+
+if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
+  wget https://scrutinizer-ci.com/ocular.phar
+fi
+
+if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
+  php ocular.phar code-coverage:upload --format=php-clover ./build/logs/clover.xml
+fi

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -10,7 +10,6 @@ if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
   phpenv global 7
   popd
   popd
-  php --version
   echo Travis PHP Version is $TRAVIS_PHP_VERSION
   wget http://getcomposer.org/composer.phar
   mkdir $PWD/phar

--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
+  pushd $HOME
+  git clone https://github.com/php/php-src.git
+  pushd php-src
+  ./buildconf -f
+  ./configure --with-curl --prefix=$HOME/.phpenv/versions/7 --quiet
+  make --quiet
+  make install
+  phpenv global 7
+  popd
+  popd
+  php --version
+  echo Travis PHP Version is $TRAVIS_PHP_VERSION
+  wget http://getcomposer.org/composer.phar
+  mkdir $PWD/phar
+  mv composer.phar $PWD/phar/composer
+  chmod +x $PWD/phar/composer
+else
+  composer self-update
+fi

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [[ "$TRAVIS_PHP_VERSION" != "hhvm" \
+  && "$TRAVIS_PHP_VERSION" != "hhvm-nightly" \
+  && "$TRAVIS_PHP_VERSION" != "5.3.3" ]]; then
+  phpenv config-add ./travis/extra.ini
+fi
+phpenv rehash

--- a/travis/before_script.sh
+++ b/travis/before_script.sh
@@ -3,5 +3,9 @@ if [[ "$TRAVIS_PHP_VERSION" != "hhvm" \
   && "$TRAVIS_PHP_VERSION" != "hhvm-nightly" \
   && "$TRAVIS_PHP_VERSION" != "5.3.3" ]]; then
   phpenv config-add ./travis/extra.ini
+  phpenv rehash
 fi
-phpenv rehash
+
+if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
+  php --version
+fi

--- a/travis/extra.ini
+++ b/travis/extra.ini
@@ -1,0 +1,2 @@
+extension = "mongo.so"
+extension = "redis.so"

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export PATH=$PWD/phar:$PATH
+if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
+    echo PATH is $PATH
+fi
+composer install -n

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -4,3 +4,4 @@ if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
     echo PATH is $PATH
 fi
 composer install -n
+composer require --dev satooshi/php-coveralls:~0.7@dev

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-export PATH=$PWD/phar:$PATH
 if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
+    export PATH=$PWD/phar:$PATH
     echo PATH is $PATH
 fi
 composer install -n

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
-    export PATH=$PWD/phar:$PATH
-    echo PATH is $PATH
+  export PATH=$PWD/phar:$PATH
+  echo PATH is $PATH
 fi
+
 composer install -n
-composer require --dev satooshi/php-coveralls:~0.7@dev
+
+if [[ "$TRAVIS_PHP_VERSION" == "5.6" ]]; then
+  composer require --dev satooshi/php-coveralls:~0.7@dev
+fi

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]]; then
+  vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
+fi
+
+if [[ "$TRAVIS_PHP_VERSION" == "hhvm" || "$TRAVIS_PHP_VERSION" == "hhvm-nightly" ]]; then
+  vendor/bin/phpunit
+fi


### PR DESCRIPTION
This does a few things:

* Extracts all the scripts out to separate bash scripts for easier editing.
* It uses the 5.3.3 build target to compile and use php-src master (i.e. PHP 7)
* Fixes the mongo and redis extension loading
* Adds a composer self-update where needed
* For the PHP 7 (aka 5.3.3) build, installs composer manually
* Code coverage and scrutinizer will now target PHP 5.6 (was 5.5)
* Move satooshi/php-coveralls from composer.json to travis composer require command

Note: A previous commit moved hhvm to allowed_failures so PRs can pass checks. The 5.3.3 (actually PHP 7) is currently not allowed to fail.