### PR TITLE
Limit php-src clone to depth 1

### DIFF
--- a/travis/before_install.sh
+++ b/travis/before_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then
   pushd $HOME
-  git clone https://github.com/php/php-src.git
+  git clone --depth 1 https://github.com/php/php-src.git
   pushd php-src
   ./buildconf -f
   ./configure --with-curl --prefix=$HOME/.phpenv/versions/7 --quiet


### PR DESCRIPTION
Minor optimisation to speed up the php7 build by not cloning the entire history.