### PR TITLE
Add options to make all methods as stubs, returning null by default

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -651,7 +651,7 @@ class Mockery
         $methodNames = explode('->', $arg);
         reset($methodNames);
 
-        if (!\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed()
+        if (!$mock->mockingNonExistentMethodsAllowed()
             && !$mock->mockery_isAnonymous()
             && !in_array(current($methodNames), $mock->mockery_getMockableMethods())
         ) {

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -86,6 +86,17 @@ class Mockery
     /**
      * @return \Mockery\MockInterface
      */
+    public static function stub()
+    {
+        $args = func_get_args();
+        return call_user_func_array(array(self::getContainer(), 'mock'), $args)->shouldIgnoreMissing()
+            ->disallowMockingNonExistentMethods()
+            ;
+    }
+
+    /**
+     * @return \Mockery\MockInterface
+     */
     public static function instanceMock()
     {
         $args = func_get_args();

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -163,7 +163,7 @@ class Mock implements MockInterface
             $this->_mockery_partial = $partialObject;
         }
 
-        if (!\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed()) {
+        if (!$this->mockingNonExistentMethodsAllowed()) {
             foreach ($this->mockery_getMethods() as $method) {
                 if ($method->isPublic() && !$method->isStatic()) {
                     $this->_mockery_mockableMethods[] = $method->getName();

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -49,6 +49,13 @@ class Mock implements MockInterface
     protected $_mockery_deferMissing = false;
 
     /**
+     * Flag to indicate whether existing method calls return null by default
+     *
+     * @var bool
+     */
+    protected $_mockery_allStubs = false;
+
+    /**
      * Flag to indicate whether this mock was verified
      *
      * @var bool
@@ -279,6 +286,17 @@ class Mock implements MockInterface
     public function makePartial()
     {
         return $this->shouldDeferMissing();
+    }
+
+    /**
+     * Set mock to return null by default for all existing methods
+     *
+     * @return Mock
+     */
+    public function makeStubs()
+    {
+        $this->_mockery_allStubs = true;
+        return $this;
     }
 
     /**
@@ -688,7 +706,9 @@ class Mock implements MockInterface
             }
         }
 
-        if (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) {
+        if ($this->_mockery_allStubs && (method_exists($this->_mockery_partial, $method) || is_callable("parent::$method"))) {
+            return null;
+        } elseif (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
         } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")) {
             return call_user_func_array("parent::$method", $args);

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -50,7 +50,7 @@ class Mock implements MockInterface
 
     /**
      * Local flag to indicate whether mocking non-existing methods allowed.
-     * 
+     *
      * @var bool
      */
     protected $_mockery_allowMockingNotExistentMethod = null;
@@ -163,6 +163,12 @@ class Mock implements MockInterface
             $this->_mockery_partial = $partialObject;
         }
 
+        $this->collectMockableMethods();
+    }
+
+    protected function collectMockableMethods()
+    {
+        $this->_mockery_mockableMethods = array();
         if (!$this->mockingNonExistentMethodsAllowed()) {
             foreach ($this->mockery_getMethods() as $method) {
                 if ($method->isPublic() && !$method->isStatic()) {
@@ -296,6 +302,7 @@ class Mock implements MockInterface
     public function disallowMockingNonExistentMethods()
     {
         $this->_mockery_allowMockingNotExistentMethod = false;
+        $this->collectMockableMethods();
         return $this;
     }
 

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -81,6 +81,13 @@ interface MockInterface
     public function makePartial();
 
     /**
+     * Set mock to return null by default for all existing methods
+     *
+     * @return Mock
+     */
+    public function makeStubs();
+
+    /**
      * @param $method
      * @param null $args
      * @return \Mockery\Expectation

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -88,6 +88,14 @@ interface MockInterface
     public function disallowMockingNonExistentMethods();
 
     /**
+     * Return flag indicating whether mocking non-existent methods allowed
+     * Fallback to global configuration
+     *
+     * @return bool
+     */
+    public function mockingNonExistentMethodsAllowed();
+
+    /**
      * @param $method
      * @param null $args
      * @return \Mockery\Expectation

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -81,11 +81,11 @@ interface MockInterface
     public function makePartial();
 
     /**
-     * Set mock to return null by default for all existing methods
+     * Disable mocking non-existent methods
      *
      * @return Mock
      */
-    public function makeStubs();
+    public function disallowMockingNonExistentMethods();
 
     /**
      * @param $method

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -136,6 +136,31 @@ class Mockery_MockTest extends MockeryTestCase
         assertThat($mock->nonExistentMethod(), equalTo('result'));
     }
 
+    /**
+     * @expectedException Mockery\Exception
+     */
+    public function testShouldIgnoreMissingDisallowMockingNonExistentMethods()
+    {
+        Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
+        $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing()->disallowMockingNonExistentMethods();
+        assertThat(nullValue($mock->foo()));
+        $mock->shouldReceive('foo')->andReturn('new_foo');
+        assertThat($mock->foo(), equalTo('new_foo'));
+        $mock->shouldReceive('bar')->passthru();
+        assertThat($mock->bar(), equalTo('bar'));
+        $mock->shouldReceive('nonExistentMethod');
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testShouldIgnoreMissingDisallowCallingNonExistentMethods()
+    {
+        Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
+        $mock = $this->container->mock('ClassWithNoToString')->shouldIgnoreMissing()->disallowMockingNonExistentMethods();
+        $mock->nonExistentMethod();
+    }
+
     public function testCanMockException()
     {
         $exception = Mockery::mock('Exception');

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -136,10 +136,7 @@ class Mockery_MockTest extends MockeryTestCase
         assertThat($mock->nonExistentMethod(), equalTo('result'));
     }
 
-    /**
-     * @expectedException Mockery\Exception
-     */
-    public function testShouldIgnoreMissingDisallowMockingNonExistentMethods()
+    public function testShouldIgnoreMissingAllowMockingExistentMethods()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
         $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing()->disallowMockingNonExistentMethods();
@@ -148,6 +145,14 @@ class Mockery_MockTest extends MockeryTestCase
         assertThat($mock->foo(), equalTo('new_foo'));
         $mock->shouldReceive('bar')->passthru();
         assertThat($mock->bar(), equalTo('bar'));
+    }
+
+    /**
+     * @expectedException Mockery\Exception
+     */
+    public function testShouldIgnoreMissingDisallowMockingNonExistentMethods()
+    {
+        $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing()->disallowMockingNonExistentMethods();
         $mock->shouldReceive('nonExistentMethod');
     }
 

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -138,7 +138,6 @@ class Mockery_MockTest extends MockeryTestCase
 
     public function testShouldIgnoreMissingAllowMockingExistentMethods()
     {
-        Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
         $mock = $this->container->mock('ClassWithMethods')->shouldIgnoreMissing()->disallowMockingNonExistentMethods();
         assertThat(nullValue($mock->foo()));
         $mock->shouldReceive('foo')->andReturn('new_foo');


### PR DESCRIPTION
I'm referring to this documentation of PHPUnit for creating mocked object that all methods are stubs, which return null by default: [Unit Testing Tutorial](https://jtreminio.com/2013/03/unit-testing-tutorial-part-5-mock-methods-and-overriding-constructors/) (Do not call setMethods() & Passing an empty array)

This kind of feature doesn't seems currently available on Mockery.

One option that close to that is `shouldIgnoreMissing()`, but this option will always return null even when the method being called is not exists. This is not good when there's a typo in either unit test's class or actual class.

The additional option of `makeStubs()` works alike, but will still throw error when a nonexistent method is called.
