### PR TITLE
Revert "unused namespace removed"

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -20,6 +20,8 @@
 
 namespace Mockery;
 
+use Mockery\MockInterface;
+
 class Mock implements MockInterface
 {
 


### PR DESCRIPTION
This isn't actually unused.

---
Reverts padraic/mockery#444