### PR TITLE
by ref & should be before variadic ...

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -49,8 +49,8 @@ class MethodDefinitionPass implements Pass
         $params = $method->getParameters();
         foreach ($params as $param) {
             $paramDef = $param->getTypeHintAsString();
-            $paramDef .= $param->isVariadic() ? '...' : '';
             $paramDef .= $param->isPassedByReference() ? '&' : '';
+            $paramDef .= $param->isVariadic() ? '...' : '';
             $paramDef .= '$' . $param->getName();
 
             if (!$param->isVariadic()) {


### PR DESCRIPTION
As per https://wiki.php.net/rfc/variadics#by-reference_capture by-reference variadic should be in the form of `&...$params`