### PR TITLE
Create a failing test for mocking an exception

### DIFF
--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -135,6 +135,12 @@ class Mockery_MockTest extends MockeryTestCase
         assertThat($mock->bar(), equalTo('bar'));
         assertThat($mock->nonExistentMethod(), equalTo('result'));
     }
+
+    public function testCanMockException()
+    {
+        $exception = Mockery::mock('Exception');
+        $this->assertInstanceOf('Exception', $exception);
+    }
 }
 
 


### PR DESCRIPTION
This test demonstrates an issue on hhvm when mocking instances of the base `Exception` class. I've not been able to figure out why it fails though
```
BadMethodCallException: Call to a member function mockery_getName() on a non-object (NULL)

/home/craig/dev/duncan3dc/mockery/library/Mockery/Container.php:473
/home/craig/dev/duncan3dc/mockery/library/Mockery/Container.php:221
/home/craig/dev/duncan3dc/mockery/library/Mockery.php:74
/home/craig/dev/duncan3dc/mockery/tests/Mockery/MockTest.php:141
```