### PR TITLE
Add varargs to Mockinterface::shouldReceive and MockInterface::shouldNotReceive

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -168,10 +168,10 @@ class Mock implements MockInterface
     /**
      * Set expected method calls
      *
-     * @param mixed
+     * @param mixed ...
      * @return \Mockery\Expectation
      */
-    public function shouldReceive()
+    public function shouldReceive($args)
     {
         /** @var array $nonPublicMethods */
         $nonPublicMethods = $this->getNonPublicMethods();
@@ -207,10 +207,10 @@ class Mock implements MockInterface
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param mixed
+     * @param mixed ...
      * @return \Mockery\Expectation
      */
-    public function shouldNotReceive()
+    public function shouldNotReceive($args)
     {
         $expectation = call_user_func_array(array($this, 'shouldReceive'), func_get_args());
         $expectation->never();

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -168,10 +168,10 @@ class Mock implements MockInterface
     /**
      * Set expected method calls
      *
-     * @param mixed ...
+     * @param string $methodName,... one or many methods that are expected to be called in this mock
      * @return \Mockery\Expectation
      */
-    public function shouldReceive($args)
+    public function shouldReceive($methodName)
     {
         /** @var array $nonPublicMethods */
         $nonPublicMethods = $this->getNonPublicMethods();
@@ -207,10 +207,10 @@ class Mock implements MockInterface
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param mixed ...
+     * @param string $methodName,... one or many methods that are expected not to be called in this mock
      * @return \Mockery\Expectation
      */
-    public function shouldNotReceive($args)
+    public function shouldNotReceive($methodName)
     {
         $expectation = call_user_func_array(array($this, 'shouldReceive'), func_get_args());
         $expectation->never();

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -35,18 +35,18 @@ interface MockInterface
     /**
      * Set expected method calls
      *
-     * @param mixed ...
+     * @param string $methodName,... one or many methods that are expected to be called in this mock
      * @return \Mockery\Expectation
      */
-    public function shouldReceive($args);
+    public function shouldReceive($methodName);
 
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param mixed ...
+     * @param string $methodName,... one or many methods that are expected not to be called in this mock
      * @return \Mockery\Expectation
      */
-    public function shouldNotReceive($args);
+    public function shouldNotReceive($methodName);
 
     /**
      * Allows additional methods to be mocked that do not explicitly exist on mocked class

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -38,7 +38,7 @@ interface MockInterface
      * @param mixed ...
      * @return \Mockery\Expectation
      */
-    public function shouldReceive();
+    public function shouldReceive($args);
 
     /**
      * Shortcut method for setting an expectation that a method should not be called.
@@ -46,7 +46,7 @@ interface MockInterface
      * @param mixed ...
      * @return \Mockery\Expectation
      */
-    public function shouldNotReceive();
+    public function shouldNotReceive($args);
 
     /**
      * Allows additional methods to be mocked that do not explicitly exist on mocked class


### PR DESCRIPTION
I stumbled upon this after upgrading PhpStorm to version 9 (early access program).
It does currently mark all calls to `shouldReceive` and `shouldNotReceive`  with the following warning:

> Method call uses 1 parameters, but method signature uses 0 parameters

Looking at the `MockInterface` is also somewhat confusing since it does not define any parameters whatsoever. I am not sure why this is the case but I believe making them explicit at the interface is the least confusing solution.