### PR TITLE
Add note about shouldDeferMissing

### DIFF
--- a/docs/reference/startup_methods.rst
+++ b/docs/reference/startup_methods.rst
@@ -228,3 +228,7 @@ objects discussed later), this form of mock object will defer all methods not
 subject to an expectation to the parent class of the mock, i.e. ``MyClass``.
 Whereas the previous ``shouldIgnoreMissing()`` returned ``null``, this
 behaviour simply calls the parent's matching method.
+
+.. note::
+
+'not subject to an expectation to the parent class of the mock' includes also expectations where parameter signature don't match real received parameters by parent's method's.


### PR DESCRIPTION
I think it's good to clarify that real parent's method's will be called if expected parameters signature not match.
