### PR TITLE
Clean-up temporary files on teardown

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -64,6 +64,11 @@ class Mockery
     protected static $_loader;
 
     /**
+     * @var array
+     */
+    private static $_filesToCleanUp = [];
+
+    /**
      * Static shortcut to \Mockery\Container::mock().
      *
      * @return \Mockery\MockInterface
@@ -136,6 +141,10 @@ class Mockery
      */
     public static function close()
     {
+        foreach (self::$_filesToCleanUp as $fileName) {
+            @unlink($fileName);
+        }
+
         if (is_null(self::$_container)) {
             return;
         }
@@ -737,5 +746,15 @@ class Mockery
     private static function noMoreElementsInChain(array $methodNames)
     {
         return empty($methodNames);
+    }
+
+    /**
+     * Register a file to be deleted on tearDown.
+     *
+     * @param string $fileName
+     */
+    public static function registerFileForCleanUp($fileName)
+    {
+        self::$_filesToCleanUp[] = $fileName;
     }
 }

--- a/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/ClassPass.php
@@ -36,6 +36,7 @@ class ClassPass implements Pass
             $tmpfname = tempnam(sys_get_temp_dir(), "Mockery");
             file_put_contents($tmpfname, $targetCode);
             require $tmpfname;
+            \Mockery::registerFileForCleanUp($tmpfname);
         }
 
         $code = str_replace(


### PR DESCRIPTION
When you mock a class that does not exist, or can't be found by autoloading, Mockery creates a temporary file, so the class can be required. The clean-up was left to the OS.

This change registers the files to be cleaned-up on teardown by Mockery.

See issue #487.