### PR TITLE
Mock return types on spies

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -217,31 +217,7 @@ class Expectation implements ExpectationInterface
             return current($this->_returnQueue);
         }
 
-        $rm = $this->_mock->mockery_getMethod($this->_name);
-        if ($rm && version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $rm->hasReturnType()) {
-            $type = (string) $rm->getReturnType();
-            switch ($type) {
-                case '':       return;
-                case 'string': return '';
-                case 'int':    return 0;
-                case 'float':  return 0.0;
-                case 'bool':   return false;
-                case 'array':  return [];
-
-                case 'callable':
-                case 'Closure':
-                    return function () {};
-
-                case 'Traversable':
-                case 'Generator':
-                    // Remove eval() when minimum version >=5.5
-                    $generator = eval('return function () { yield; };');
-                    return $generator();
-
-                default:
-                    return \Mockery::mock($type);
-            }
-        }
+        return $this->_mock->mockery_returnValueForMethod($this->_name);
     }
 
     /**

--- a/tests/Mockery/MockingParameterAndReturnTypesTest.php
+++ b/tests/Mockery/MockingParameterAndReturnTypesTest.php
@@ -50,7 +50,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
         $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
 
         $mock->shouldReceive("returnInteger");
-        $this->assertEquals(0, $mock->returnInteger());
+        $this->assertSame(0, $mock->returnInteger());
     }
 
     public function testMockingFloatReturnType()
@@ -107,6 +107,22 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
         $mock->shouldReceive("withScalarParameters");
         $mock->withScalarParameters(1, 1.0, true, 'string');
+    }
+
+    public function testIgnoringMissingReturnsType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldIgnoreMissing();
+
+        $this->assertSame('', $mock->returnString());
+        $this->assertSame(0, $mock->returnInteger());
+        $this->assertSame(0.0, $mock->returnFloat());
+        $this->assertSame(false, $mock->returnBoolean());
+        $this->assertSame([], $mock->returnArray());
+        $this->assertTrue(is_callable($mock->returnCallable()));
+        $this->assertInstanceOf("\Generator", $mock->returnGenerator());
+        $this->assertInstanceOf("test\Mockery\TestWithParameterAndReturnType", $mock->withClassReturnType());
     }
 }
 


### PR DESCRIPTION
This PR addresses #490 by creating a mock return value when `shouldIgnoreMissing()` is called on the mock object and subsequently a method is called on the mock without setting expectations.