### PR TITLE
Add AnyTypeOf matcher

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -395,6 +395,16 @@ class Mockery
     }
 
     /**
+     * Return instance of ANYTYPEOF matcher.
+     *
+     * @return \Mockery\Matcher\AnyTypeOf
+     */
+    public static function anyTypeOf()
+    {
+        return new \Mockery\Matcher\AnyTypeOf(func_get_args());
+    }
+
+    /**
      * Get the global configuration container.
      */
     public static function getConfiguration()

--- a/library/Mockery/Matcher/AnyTypeOf.php
+++ b/library/Mockery/Matcher/AnyTypeOf.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010-2014 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Matcher;
+
+class AnyTypeOf extends MatcherAbstract
+{
+    /**
+     * Check if the actual value does match the expected.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        foreach ($this->_expected as $exp) {
+            $matcher = new Type($exp);
+            if ($matcher->match($actual)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<AnyTypeOf>';
+    }
+}

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1793,6 +1793,54 @@ class ExpectationTest extends MockeryTestCase
         $this->container->mockery_verify();
     }
 
+    public function testAnyTypeOfConstraintMatchesArgument()
+    {
+        $this->mock->shouldReceive('foo')->with(Mockery::anyTypeOf('array', 'bool', 'callable', 'float', 'int', 'null', 'numeric', 'object', 'resource', 'scalar', 'string'))->times(22);
+        $this->mock->foo(array());
+        $this->mock->foo(array(null));
+        $this->mock->foo(array('bar'));
+        $this->mock->foo(array(array()));
+        $this->mock->foo(true);
+        $this->mock->foo(false);
+        $this->mock->foo('die');
+        $this->mock->foo(array($this, 'testAnyTypeOfConstraintMatchesArgument'));
+        $this->mock->foo(3.1415926536);
+        $this->mock->foo(-0.123456789);
+        $this->mock->foo(-1);
+        $this->mock->foo(0);
+        $this->mock->foo(42);
+        $this->mock->foo('0');
+        $this->mock->foo('1');
+        $this->mock->foo('0b10111');
+        $this->mock->foo('0.42e2');
+        $this->mock->foo($this);
+        $this->mock->foo(new stdClass());
+        $this->mock->foo('');
+        $this->mock->foo('string');
+        $this->mock->foo('null');
+        $this->container->mockery_verify();
+    }
+
+    public function testAnyTypeOfConstraintNonMatchingCase()
+    {
+        $this->mock->shouldReceive('foo')->times(3);
+        $this->mock->shouldReceive('foo')->with(1, Mockery::anyTypeOf('string'))->never();
+        $this->mock->foo(1);
+        $this->mock->foo('1');
+        $this->mock->foo(1, '2', 3);
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testAnyTypeOfConstraintThrowsExceptionWhenConstraintUnmatched()
+    {
+        $this->mock->shouldReceive('foo')->with(Mockery::anyTypeOf('array', 'object'))->once();
+        $this->mock->foo('bar');
+        $this->container->mockery_verify();
+    }
+
     /**
      * @expectedException \Mockery\Exception
      */


### PR DESCRIPTION
This pull request fixes #500.

What this pull request does:
* allow for *checking against a set of types*.

```php
$some_object = Mockery::mock( 'SomeClass' );
$some_object->shouldReceive( 'foo' )->with( Mockery::anyTypeOf( 'int', 'string' ) );
$some_object->foo( 1 );
```

I also included tests for the new matcher, however, due to the nature of the matcher you could come up with infinite test cases...

BTW, one could also add the according counterpart `notAnyTypeOf`.