### PR TITLE
Fix StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,5 @@
 preset: psr2
+
+finder:
+  not-name:
+    - MockingParameterAndReturnTypesTest.php

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -173,7 +173,7 @@ class Mock implements MockInterface
     public function shouldReceive($methodName)
     {
         if (func_num_args() < 1) {
-            throw new \InvalidArgumentException("At least one method name is required"); 
+            throw new \InvalidArgumentException("At least one method name is required");
         }
 
         foreach (func_get_args() as $method) {


### PR DESCRIPTION
For now, StyleCI enforces PHP 5.6 compatible syntax. PHP 7 support is coming soon.