### PR TITLE
HHVM nightly is no longer supported on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: hhvm
-    - php: hhvm-nightly
 
 sudo: false
 


### PR DESCRIPTION
HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220