### PR TITLE
Prevent trigger of error when exception occurs during unserialisation

### DIFF
--- a/library/Mockery/Instantiator.php
+++ b/library/Mockery/Instantiator.php
@@ -20,7 +20,6 @@
 namespace Mockery;
 
 use Closure;
-use Exception;
 use ReflectionClass;
 use UnexpectedValueException;
 use InvalidArgumentException;
@@ -135,7 +134,7 @@ final class Instantiator
 
         try {
             unserialize($serializedString);
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             restore_error_handler();
 
             throw new UnexpectedValueException("An exception was raised while trying to instantiate an instance of \"{$reflectionClass->getName()}\" via un-serialization", 0, $exception);


### PR DESCRIPTION
Fixes #512:

A fatal error is triggered when an exception occurs during instantiation using unserialisation:

> PHP Fatal error: Cannot use Exception as Exception because the name is already in use
Runtime: PHP 5.6.14-1+deb.sury.org~trusty+1 with Xdebug 2.3.2

The cause of this error is that \Exception is imported as Exception in \Mockery\Instantiator, while a class name Exception already exists in that namespace (\Mockery\Exception).

This commit fixes the name collision. I don't quite remember how I got a error to trigger during unserialisation, so there's no regression test.