### PR TITLE
Add to "require-dev" instead of "require" in composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install Mockery, run the command below and you will get the latest
 version
 
 ```sh
-composer require mockery/mockery
+composer require --dev mockery/mockery
 ```
 
 If you want to run the tests:


### PR DESCRIPTION
Also for consistency with [Installation guide](https://github.com/padraic/mockery/blob/master/docs/getting_started/installation.rst).