### PR TITLE
fix #472 throw exception if given class name is invalid

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -539,8 +539,9 @@ class Container
             $className = substr($className, 1); // remove the first backslash
         }
         // all the namespaces and class name should match the regex
-        return empty(array_filter(explode('\\', $className), function ($name) {
+        $invalidNames = array_filter(explode('\\', $className), function ($name) {
             return !preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name);
-        }));
+        });
+        return empty($invalidNames);
     }
 }

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -167,6 +167,9 @@ class Container
                 $builder->addTarget($class);
                 continue;
             } elseif (is_string($arg)) {
+                if (!$this->isValidClassName($arg)) {
+                    throw new \Mockery\Exception('Class name contains invalid characters');
+                }
                 $class = array_shift($args);
                 $builder->addTarget($class);
                 continue;
@@ -522,5 +525,22 @@ class Container
         }
 
         $this->_namedMocks[$name] = $hash;
+    }
+
+    /**
+     * see http://php.net/manual/en/language.oop5.basic.php
+     * @param string $className
+     * @return bool
+     */
+    public function isValidClassName($className)
+    {
+        $pos = strpos($className, '\\');
+        if ($pos === 0) {
+            $className = substr($className, 1); // remove the first backslash
+        }
+        // all the namespaces and class name should match the regex
+        return empty(array_filter(explode('\\', $className), function ($name) {
+            return !preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name);
+        }));
     }
 }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1311,6 +1311,26 @@ class ContainerTest extends MockeryTestCase
         $mock = $this->container->mock("ArrayObject");
         $this->assertInstanceOf("Serializable", $mock);
     }
+
+    /**
+     * @dataProvider classNameProvider
+     */
+    public function testIsValidClassName($expected, $className)
+    {
+        $container = new \Mockery\Container;
+        $this->assertSame($expected, $container->isValidClassName($className));
+    }
+
+    public function classNameProvider()
+    {
+        return array(
+            array(false, ' '), // just a space
+            array(false, 'ClassName.WithDot'),
+            array(false, '\\\\TooManyBackSlashes'),
+            array(true,  'Foo'),
+            array(true,  '\\Foo\\Bar'),
+        );
+    }
 }
 
 class MockeryTest_CallStatic

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -148,6 +148,14 @@ class Mockery_MockTest extends MockeryTestCase
         $this->setExpectedException("InvalidArgumentException", "Received empty method name");
         $mock->shouldReceive("");
     }
+
+    /**
+     * @expectedException Mockery\Exception
+     */
+    public function testShouldThrowExceptionWithInvalidClassName()
+    {
+        $this->container->mock('ClassName.CannotContainDot');
+    }
 }
 
 


### PR DESCRIPTION
This PR is attempting to fix #472. While Mockery gets a parse error with `Mockery::mock('this-is-invalid')` this fix throws a Mockery\Exception error with friendlier message. It uses [the regex on the official document](http://php.net/manual/en/language.oop5.basic.php) and I'm assuming that namespaces follow the same rule.

It might be a little too strict since it currently allows a parameter like `mock('\\\\Foo')`. Please let me know if there's any better way.