### PR TITLE
Removed "--dev" option from composer install command

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,7 @@ filter:
     paths: [library/*]
     excluded_paths: [vendor/*, tests/*, examples/*]
 before_commands:
-    - 'composer install --dev --prefer-source'
+    - 'composer install --prefer-source'
 tools:
     external_code_coverage:
         timeout: 300

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ e.g. 0.8.
 
 To run the unit tests for Mockery, clone the git repository, download Composer using
 the instructions at [http://getcomposer.org/download/](http://getcomposer.org/download/),
-then install the dependencies with `php /path/to/composer.phar install --dev`.
+then install the dependencies with `php /path/to/composer.phar install`.
 
 This will install the required PHPUnit and Hamcrest dev dependencies and create the
 autoload files required by the unit tests. You may run the `vendor/bin/phpunit` command

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -33,11 +33,11 @@ $library = "$root/library";
 $tests   = "$root/tests";
 
 /**
- * Check that --dev composer installation was done
+ * Check that composer installation was done
  */
 if (!file_exists($root . '/vendor/autoload.php')) {
     throw new Exception(
-        'Please run "php composer.phar install --dev" in root directory '
+        'Please run "php composer.phar install" in root directory '
         . 'to setup unit test dependencies before running the tests'
     );
 }


### PR DESCRIPTION
The "--dev" option of the `composer install` command is deprecated and it shows a warning message when you use it. In this way, I've removed every occurrence of this options that I've found in the project:

- Contribution guidelines
- Exception messages
- Code comments
- Scrutinizer config file