### PR TITLE
Added new functionality to support `withArgs($closure)`to validate a list of arguments at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 1.0.0 (XXXX-XX-XX)
 
 * Destructors (`__destruct`) are stubbed out where it makes sense
-
+* Allow passing a closure argument to `withArgs()` to validate multiple arguments at once. 
+ 
 ## 0.9.4 (XXXX-XX-XX)
 
 * `shouldIgnoreMissing` will respect global `allowMockingNonExistentMethods`

--- a/docs/reference/argument_validation.rst
+++ b/docs/reference/argument_validation.rst
@@ -80,6 +80,37 @@ There is no Hamcrest version of this functionality.
 
 .. code-block:: php
 
+    withArgs(closure)
+
+You can also perform argument validation by passing a closure to ``withArgs()``
+method. The closure will receive all arguments passed in the call to the expected
+method and if it evaluates (i.e. returns) to boolean ``true``, then the list of
+arguments is assumed to have matched the expectation. The closure can also
+handle optional parameters, so if an optional parameter is missing in the call
+to the expected method, it doesn't necessary means that the list of arguments
+doesn't match the expectation.
+
+.. code-block:: php
+
+    $closure = function ($odd, $even, $sum = null) {
+        $result = ($odd % 2 != 0) && ($even % 2 == 0);
+        if (!is_null($sum)) {
+            return $result && ($odd + $even == $sum);
+        }
+        return $result;
+    };
+    $this->mock->shouldReceive('foo')->withArgs($closure);
+
+    $this->mock->foo(1, 2); // It matches the expectation: the optional argument is not needed
+    $this->mock->foo(1, 2, 3); // It also matches the expectation: the optional argument pass the validation
+    $this->mock->foo(1, 2, 4); // It doesn't match the expectation: the optional doesn't pass the validation
+    $this->mock->foo(1, 2, 4, 5); // It neither match the expectation: there are too many arguments
+    $this->mock->foo(1); // It neither match the expectation: there are too few arguments
+
+
+
+.. code-block:: php
+
     with('/^foo/') OR with(matchesPattern('/^foo/'))
 
 The argument declarator also assumes any given string may be a regular

--- a/docs/reference/argument_validation.rst
+++ b/docs/reference/argument_validation.rst
@@ -104,10 +104,6 @@ doesn't match the expectation.
     $this->mock->foo(1, 2); // It matches the expectation: the optional argument is not needed
     $this->mock->foo(1, 2, 3); // It also matches the expectation: the optional argument pass the validation
     $this->mock->foo(1, 2, 4); // It doesn't match the expectation: the optional doesn't pass the validation
-    $this->mock->foo(1, 2, 4, 5); // It neither match the expectation: there are too many arguments
-    $this->mock->foo(1); // It neither match the expectation: there are too few arguments
-
-
 
 .. code-block:: php
 

--- a/docs/reference/expectations.rst
+++ b/docs/reference/expectations.rst
@@ -73,8 +73,7 @@ Instead of providing a built-in matcher for each argument, you can provide a
 closure that matches all passed arguments at once. The given closure receives
 all the arguments passed in the call to the expected method. In this way, this
 expectation only applies to method calls where passed arguments make the closure
-evaluates to true. It can also handle optional arguments and takes care of the
-number of required arguments in the closure#
+evaluates to true.
 
 .. code-block:: php
 

--- a/docs/reference/expectations.rst
+++ b/docs/reference/expectations.rst
@@ -67,6 +67,17 @@ calls.
 
 .. code-block:: php
 
+    withArgs(closure)
+
+Instead of providing a built-in matcher for each argument, you can provide a
+closure that matches all passed arguments at once. The given closure receives
+all the arguments passed in the call to the expected method. In this way, this
+expectation only applies to method calls where passed arguments make the closure
+evaluates to true. It can also handle optional arguments and takes care of the
+number of required arguments in the closure#
+
+.. code-block:: php
+
     withAnyArgs()
 
 Declares that this expectation matches a method call regardless of what

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -285,15 +285,13 @@ class Expectation implements ExpectationInterface
             return true;
         }
         $expectedArgsCount = count($this->_expectedArgs);
-        if (count($args) !== $expectedArgsCount) {
-            if (
-                $expectedArgsCount == 1 &&
-                is_object($this->_expectedArgs[0]) &&
-                ($this->_expectedArgs[0] instanceof \Mockery\Matcher\MultiArgumentClosure) &&
-                $this->_matchArg($this->_expectedArgs[0], $args)
-            ) {
+        if ($expectedArgsCount === 1 && ($this->_expectedArgs[0] instanceof \Mockery\Matcher\MultiArgumentClosure)) {
+            if ($this->_matchArg($this->_expectedArgs[0], $args)) {
                 return true;
             }
+            return false;
+        }
+        if (count($args) !== $expectedArgsCount) {
             return false;
         }
         $argCount = count($args);

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -340,7 +340,7 @@ class Expectation implements ExpectationInterface
         if ($expected instanceof \Mockery\Matcher\MatcherAbstract) {
             return $expected->match($actual);
         }
-        if (is_a($expected, '\Hamcrest\Matcher') || is_a($expected, '\Hamcrest_Matcher')) {
+        if ($expected instanceof \Hamcrest\Matcher || $expected instanceof \Hamcrest_Matcher) {
             return $expected->matches($actual);
         }
         return false;

--- a/library/Mockery/Matcher/MultiArgumentClosure.php
+++ b/library/Mockery/Matcher/MultiArgumentClosure.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010-2014 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Matcher;
+
+
+class MultiArgumentClosure extends MatcherAbstract
+{
+
+    /**
+     * Check if the actual value matches the expected.
+     * Actual passed by reference to preserve reference trail (where applicable)
+     * back to the original method parameter.
+     *
+     * @param mixed $actual
+     * @return bool
+     */
+    public function match(&$actual)
+    {
+        $closure = $this->_expected;
+        $requiredParamsNumber = (new \ReflectionFunction($closure))->getNumberOfRequiredParameters();
+        if (count($actual) != $requiredParamsNumber) {
+            return false;
+        }
+        return true === call_user_func_array($closure, $actual);
+    }
+
+    /**
+     * Return a string representation of this Matcher
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return '<MultiArgumentClosure===true>';
+    }
+}

--- a/library/Mockery/Matcher/MultiArgumentClosure.php
+++ b/library/Mockery/Matcher/MultiArgumentClosure.php
@@ -35,10 +35,6 @@ class MultiArgumentClosure extends MatcherAbstract
     public function match(&$actual)
     {
         $closure = $this->_expected;
-        $requiredParamsNumber = (new \ReflectionFunction($closure))->getNumberOfRequiredParameters();
-        if (count($actual) != $requiredParamsNumber) {
-            return false;
-        }
         return true === call_user_func_array($closure, $actual);
     }
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -767,6 +767,17 @@ class ContainerTest extends MockeryTestCase
         $this->assertEquals(1, $b);
     }
 
+    public function testMethodParamsPassedByReferenceThroughWithArgsHaveReferencePreserved()
+    {
+        $m = $this->container->mock('MockeryTestRef1');
+        $m->shouldReceive('foo')->withArgs(function (&$a, $b) {$a += 1; $b += 1; return true;});
+        $a = 1;
+        $b = 1;
+        $m->foo($a, $b);
+        $this->assertEquals(2, $a);
+        $this->assertEquals(1, $b);
+    }
+
     /**
      * Meant to test the same logic as
      * testCanOverrideExpectedParametersOfExtensionPHPClassesToPreserveRefs,

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -400,20 +400,7 @@ class ExpectationTest extends MockeryTestCase
         $this->container->mockery_verify();
     }
 
-    /**
-     * @expectedException \Mockery\Exception
-     */
-    public function testExpectsArgumentsArrayThrowsExceptionWhenReceivedNumberOfArgumentsDoNotMatchClosureNumberOfArguments()
-    {
-        $closure = function ($odd, $even) {
-            return ($odd % 2 != 0) && ($even % 2 == 0);
-        };
-        $this->mock->shouldReceive('foo')->withArgs($closure);
-        $this->mock->foo(1, 4, 2);
-        $this->container->mockery_verify();
-    }
-
-    public function testExpectsArgumentsArrayClosureIsAbleToHandleOptionalArguments()
+    public function testExpectsArgumentsArrayClosureDoesNotThrowExceptionIfOptionalArgumentsAreMissing()
     {
         $closure = function ($odd, $even, $sum = null) {
             $result = ($odd % 2 != 0) && ($even % 2 == 0);
@@ -427,10 +414,24 @@ class ExpectationTest extends MockeryTestCase
         $this->container->mockery_verify();
     }
 
+    public function testExpectsArgumentsArrayClosureDoesNotThrowExceptionIfOptionalArgumentsMathTheExpectation()
+    {
+        $closure = function ($odd, $even, $sum = null) {
+            $result = ($odd % 2 != 0) && ($even % 2 == 0);
+            if (!is_null($sum)) {
+                return $result && ($odd + $even == $sum);
+            }
+            return $result;
+        };
+        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->foo(1, 4, 5);
+        $this->container->mockery_verify();
+    }
+
     /**
      * @expectedException \Mockery\Exception
      */
-    public function testExpectsArgumentsArrayThrowsAnExceptionIfClosureDoesNotMatchOptionalArguments()
+    public function testExpectsArgumentsArrayClosureThrowsExceptionIfOptionalArgumentsDontMatchTheExpectation()
     {
         $closure = function ($odd, $even, $sum = null) {
             $result = ($odd % 2 != 0) && ($even % 2 == 0);

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -368,6 +368,82 @@ class ExpectationTest extends MockeryTestCase
         $this->mock->foo(null);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /invalid argument (.+), only array and closure are allowed/
+     */
+    public function testExpectsArgumentsArrayThrowsExceptionIfPassedWrongArgumentType()
+    {
+        $this->mock->shouldReceive('foo')->withArgs(5);
+    }
+
+    public function testExpectsArgumentsArrayAcceptAClosureThatValidatesPassedArguments()
+    {
+        $closure = function ($odd, $even) {
+            return ($odd % 2 != 0) && ($even % 2 == 0);
+        };
+        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->foo(1, 2);
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testExpectsArgumentsArrayThrowsExceptionWhenClosureEvaluatesToFalse()
+    {
+        $closure = function ($odd, $even) {
+            return ($odd % 2 != 0) && ($even % 2 == 0);
+        };
+        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->foo(4, 2);
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testExpectsArgumentsArrayThrowsExceptionWhenReceivedNumberOfArgumentsDoNotMatchClosureNumberOfArguments()
+    {
+        $closure = function ($odd, $even) {
+            return ($odd % 2 != 0) && ($even % 2 == 0);
+        };
+        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->foo(1, 4, 2);
+        $this->container->mockery_verify();
+    }
+
+    public function testExpectsArgumentsArrayClosureIsAbleToHandleOptionalArguments()
+    {
+        $closure = function ($odd, $even, $sum = null) {
+            $result = ($odd % 2 != 0) && ($even % 2 == 0);
+            if (!is_null($sum)) {
+                return $result && ($odd + $even == $sum);
+            }
+            return $result;
+        };
+        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->foo(1, 4);
+        $this->container->mockery_verify();
+    }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testExpectsArgumentsArrayThrowsAnExceptionIfClosureDoesNotMatchOptionalArguments()
+    {
+        $closure = function ($odd, $even, $sum = null) {
+            $result = ($odd % 2 != 0) && ($even % 2 == 0);
+            if (!is_null($sum)) {
+                return $result && ($odd + $even == $sum);
+            }
+            return $result;
+        };
+        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->foo(1, 4, 2);
+        $this->container->mockery_verify();
+    }
+
     public function testExpectsAnyArguments()
     {
         $this->mock->shouldReceive('foo')->withAnyArgs();
@@ -1557,6 +1633,14 @@ class ExpectationTest extends MockeryTestCase
         $function = function ($arg) {return $arg % 2 == 0;};
         $this->mock->shouldReceive('foo')->with(Mockery::on($function))->once();
         $this->mock->foo(4);
+        $this->container->mockery_verify();
+    }
+
+    public function testOnConstraintMatchesArgumentOfTypeArray_ClosureEvaluatesToTrue()
+    {
+        $function = function ($arg) {return is_array($arg);};
+        $this->mock->shouldReceive('foo')->with(Mockery::on($function))->once();
+        $this->mock->foo([4, 5]);
         $this->container->mockery_verify();
     }
 


### PR DESCRIPTION
This PR adds the new functionality requested in #459 . In this way, from now on it is possible to pass a closure to `withArgs()` method in order to validate a list of arguments at once. All the arguments passed in the call to the expected method will be passed to the closure, and if it evaluates to true, then the list of
arguments is assumed to have matched the expectation.