### PR TITLE
Aliases expectation for boolean values

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -470,6 +470,16 @@ class Expectation implements ExpectationInterface
         return $this;
     }
 
+    public function andReturnFalse()
+    {
+        return $this->andReturn(false);
+    }
+
+    public function andReturnTrue()
+    {
+        return $this->andReturn(true);
+    }
+
     /**
      * Set Exception class and arguments to that class to be thrown
      *

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2038,6 +2038,18 @@ class ExpectationTest extends MockeryTestCase
         $this->assertSame($this->mock, $this->mock->foo());
     }
 
+    public function testReturnsTrueIfTrueIsReturnValue()
+    {
+        $this->mock->shouldReceive("foo")->andReturnTrue();
+        $this->assertSame(true, $this->mock->foo());
+    }
+
+    public function testReturnsFalseIfFalseIsReturnValue()
+    {
+        $this->mock->shouldReceive("foo")->andReturnFalse();
+        $this->assertSame(false, $this->mock->foo());
+    }
+
     public function testExpectationCanBeOverridden()
     {
         $this->mock->shouldReceive('foo')->once()->andReturn('green');


### PR DESCRIPTION
Hi,
I think that aliases for booleans are more readable in tests. 
How about that ? 