### PR TITLE
Throwing an exception when times() receives a non integer value as it's parameter.

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -53,7 +53,10 @@ class TestListener implements \PHPUnit_Framework_TestListener
         if (class_exists('\\PHP_CodeCoverage_Filter')
         && method_exists('\\PHP_CodeCoverage_Filter', 'getInstance')) {
             \PHP_CodeCoverage_Filter::getInstance()->addDirectoryToBlacklist(
-                 __DIR__.'/../../../Mockery/', '.php', '', 'PHPUNIT'
+                __DIR__ . '/../../../Mockery/',
+                '.php',
+                '',
+                'PHPUNIT'
             );
 
             \PHP_CodeCoverage_Filter::getInstance()->addFileToBlacklist(__DIR__.'/../../../Mockery.php', 'PHPUNIT');
@@ -66,7 +69,9 @@ class TestListener implements \PHPUnit_Framework_TestListener
     {
     }
 
-    public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time) {}
+    public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time)
+    {
+    }
 
     public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
     {

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -559,6 +559,7 @@ class Expectation implements ExpectationInterface
      * Indicates the number of times this expectation should occur
      *
      * @param int $limit
+     * @throws InvalidArgumentException
      * @return self
      */
     public function times($limit = null)

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -566,6 +566,9 @@ class Expectation implements ExpectationInterface
         if (is_null($limit)) {
             return $this;
         }
+        if (!is_int($limit)) {
+            throw new Exception('The passed Times limit should be an integer value');
+        }
         $this->_countValidators[] = new $this->_countValidatorClass($this, $limit);
         $this->_countValidatorClass = 'Mockery\CountValidator\Exact';
         return $this;

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -567,7 +567,7 @@ class Expectation implements ExpectationInterface
             return $this;
         }
         if (!is_int($limit)) {
-            throw new Exception('The passed Times limit should be an integer value');
+            throw new \InvalidArgumentException('The passed Times limit should be an integer value');
         }
         $this->_countValidators[] = new $this->_countValidatorClass($this, $limit);
         $this->_countValidatorClass = 'Mockery\CountValidator\Exact';

--- a/library/Mockery/Matcher/MultiArgumentClosure.php
+++ b/library/Mockery/Matcher/MultiArgumentClosure.php
@@ -20,7 +20,6 @@
 
 namespace Mockery\Matcher;
 
-
 class MultiArgumentClosure extends MatcherAbstract
 {
 

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2057,6 +2057,14 @@ class ExpectationTest extends MockeryTestCase
         $this->assertEquals($this->mock->foo(), 'green');
         $this->assertEquals($this->mock->foo(), 'blue');
     }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testTimesExpectationForbidsFloatNumbers()
+    {
+        $this->mock->shouldReceive('foo')->times(1.3);
+    }
 }
 
 class MockeryTest_SubjectCall1

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2059,7 +2059,7 @@ class ExpectationTest extends MockeryTestCase
     }
 
     /**
-     * @expectedException \Mockery\Exception
+     * @expectedException \InvalidArgumentException
      */
     public function testTimesExpectationForbidsFloatNumbers()
     {

--- a/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
+++ b/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
@@ -61,8 +61,6 @@ interface React_WritableStreamInterface extends React_StreamInterface
     public function write($data);
 }
 
-interface Chatroulette_ConnectionInterface extends
-    React_ReadableStreamInterface,
-    React_WritableStreamInterface
+interface Chatroulette_ConnectionInterface extends React_ReadableStreamInterface, React_WritableStreamInterface
 {
 }

--- a/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
+++ b/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
@@ -61,8 +61,8 @@ interface React_WritableStreamInterface extends React_StreamInterface
     public function write($data);
 }
 
-interface Chatroulette_ConnectionInterface
-    extends React_ReadableStreamInterface,
-            React_WritableStreamInterface
+interface Chatroulette_ConnectionInterface extends
+    React_ReadableStreamInterface,
+    React_WritableStreamInterface
 {
 }


### PR DESCRIPTION
Fixing [#549](https://github.com/padraic/mockery/issues/549) issue.