### PR TITLE
Change parameter type integer to int

### DIFF
--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -61,7 +61,7 @@ class Parameter
 
         if (preg_match('/^Parameter #[0-9]+ \[ \<(required|optional)\> (?<typehint>\S+ )?.*\$' . $this->rfp->getName() . ' .*\]$/', $this->rfp->__toString(), $typehintMatch)) {
             if (!empty($typehintMatch['typehint'])) {
-                return $typehintMatch['typehint'];
+                return str_replace('integer', 'int', $typehintMatch['typehint']);
             }
         }
 

--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -61,7 +61,9 @@ class Parameter
 
         if (preg_match('/^Parameter #[0-9]+ \[ \<(required|optional)\> (?<typehint>\S+ )?.*\$' . $this->rfp->getName() . ' .*\]$/', $this->rfp->__toString(), $typehintMatch)) {
             if (!empty($typehintMatch['typehint'])) {
-                return str_replace('integer', 'int', $typehintMatch['typehint']);
+                $invalid = ['integer','boolean'];
+                $valid = ['int','bool'];
+                return str_replace($invalid, $valid, $typehintMatch['typehint']);
             }
         }
 


### PR DESCRIPTION
Change parameter type integer to int to fix php 7 type definition.

Example:
This code:
```
class php7

public function getId(int $id)
{
}
```
Generate:
```
class php7

public function getId(integer $id)
{
}
```

But is don't work because php don't recognize it code.

With replace genarete:
```
class php7

public function getId(int $id)
{
}
```