### PR TITLE
Fixing issue #557

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -3,6 +3,7 @@
 namespace Mockery\Generator\StringManipulation\Pass;
 
 use Mockery\Generator\Method;
+use Mockery\Generator\Parameter;
 use Mockery\Generator\MockConfiguration;
 
 class MethodDefinitionPass implements Pass
@@ -49,7 +50,7 @@ class MethodDefinitionPass implements Pass
         $methodParams = array();
         $params = $method->getParameters();
         foreach ($params as $param) {
-            $paramDef = '\\'.$param->getTypeHintAsString().' ';
+            $paramDef = $this->renderTypeHint($param);
             $paramDef .= $param->isPassedByReference() ? '&' : '';
             $paramDef .= $param->isVariadic() ? '...' : '';
             $paramDef .= '$' . $param->getName();
@@ -78,6 +79,27 @@ class MethodDefinitionPass implements Pass
         $lastBrace = strrpos($class, "}");
         $class = substr($class, 0, $lastBrace) . $code . "\n    }\n";
         return $class;
+    }
+
+    private function renderTypeHint(Parameter $param)
+    {
+        $languageTypeHints = array(
+            'self',
+            'array',
+            'callable',
+            // Up to php 7
+            'bool',
+            'float',
+            'int',
+            'string'
+        );
+        $typeHint = trim($param->getTypeHintAsString());
+
+        if (!empty($typeHint) && !in_array($typeHint, $languageTypeHints)) {
+            $typeHint = '\\'.$typeHint;
+        }
+
+        return $typeHint .= ' ';
     }
 
     private function renderMethodBody($method, $config)

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -49,7 +49,7 @@ class MethodDefinitionPass implements Pass
         $methodParams = array();
         $params = $method->getParameters();
         foreach ($params as $param) {
-            $paramDef = $param->getTypeHintAsString();
+            $paramDef = '\\'.$param->getTypeHintAsString().' ';
             $paramDef .= $param->isPassedByReference() ? '&' : '';
             $paramDef .= $param->isVariadic() ? '...' : '';
             $paramDef .= '$' . $param->getName();

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -81,7 +81,7 @@ class MethodDefinitionPass implements Pass
         return $class;
     }
 
-    private function renderTypeHint(Parameter $param)
+    protected function renderTypeHint(Parameter $param)
     {
         $languageTypeHints = array(
             'self',

--- a/tests/Mockery/DummyClasses/Namespaced.php
+++ b/tests/Mockery/DummyClasses/Namespaced.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010-2014 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Nature
+{
+    class Plant
+    {
+    }
+}
+
+namespace
+{
+    abstract class Gardiner
+    {
+        abstract function water(Nature\Plant $plant);
+    }
+}

--- a/tests/Mockery/DummyClasses/Namespaced.php
+++ b/tests/Mockery/DummyClasses/Namespaced.php
@@ -30,6 +30,6 @@ namespace
 {
     abstract class Gardiner
     {
-        abstract function water(Nature\Plant $plant);
+        abstract public function water(Nature\Plant $plant);
     }
 }

--- a/tests/Mockery/DummyClasses/Namespaced.php
+++ b/tests/Mockery/DummyClasses/Namespaced.php
@@ -28,7 +28,7 @@ namespace Nature
 
 namespace
 {
-    abstract class Gardiner
+    abstract class Gardener
     {
         abstract public function water(Nature\Plant $plant);
     }

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -55,17 +55,6 @@ class NamedMockTest extends MockeryTestCase
     }
 
     /** @test */
-    public function itCreatesConcreteImplementationOfMethodsAndClasses()
-    {
-        $orchid = new \Nature\Plant();
-        $gardiner = Mockery::namedMock(
-            "GenericNamespace\\genericName",
-            Gardiner::class
-        );
-        $gardiner->water($orchid);
-    }
-
-    /** @test */
     public function itCreatesConcreteMethodImplementationWithReturnType()
     {
         $cactus = new \Nature\Plant();

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -58,11 +58,11 @@ class NamedMockTest extends MockeryTestCase
     public function itCreatesConcreteMethodImplementationWithReturnType()
     {
         $cactus = new \Nature\Plant();
-        $gardiner = Mockery::namedMock(
+        $gardener = Mockery::namedMock(
             "NewNamespace\\ClassName",
-            Gardiner::class,
+            Gardener::class,
             array('water' => true)
         );
-        $this->assertTrue($gardiner->water($cactus));
+        $this->assertTrue($gardener->water($cactus));
     }
 }

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -19,6 +19,8 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
+require_once __DIR__.'/DummyClasses/Namespaced.php';
+
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class NamedMockTest extends MockeryTestCase
@@ -50,5 +52,28 @@ class NamedMockTest extends MockeryTestCase
     {
         $mock = Mockery::namedMock("Mockery\Dave7");
         $mock = Mockery::namedMock("Mockery\Dave7", "DateTime");
+    }
+
+    /** @test */
+    public function itCreatesConcreteImplementationOfMethodsAndClasses()
+    {
+        $orchid = new \Nature\Plant();
+        $gardiner = Mockery::namedMock(
+            "GenericNamespace\\genericName",
+            Gardiner::class
+        );
+        $gardiner->water($orchid);
+    }
+
+    /** @test */
+    public function itCreatesConcreteMethodImplementationWithReturnType()
+    {
+        $cactus = new \Nature\Plant();
+        $gardiner = Mockery::namedMock(
+            "NewNamespace\\ClassName",
+            Gardiner::class,
+            array('water' => true)
+        );
+        $this->assertTrue($gardiner->water($cactus));
     }
 }

--- a/tests/Mockery/NamedMockTest.php
+++ b/tests/Mockery/NamedMockTest.php
@@ -60,7 +60,7 @@ class NamedMockTest extends MockeryTestCase
         $cactus = new \Nature\Plant();
         $gardener = Mockery::namedMock(
             "NewNamespace\\ClassName",
-            Gardener::class,
+            "Gardener",
             array('water' => true)
         );
         $this->assertTrue($gardener->water($cactus));


### PR DESCRIPTION
Fixing issue [#557](https://github.com/padraic/mockery/issues/557).

Notes on the changes:

I've created a new file to include classes that are going to be used as dummy inside the tests. I've done this because I needed to use different namespaces, and to be able to do that, I needed to include a file called `Namespaced.php`.

In `MethodDefinitionPass.php` at line 86, I've created an array to hold the TypeHints to be used in the method definition. The problem with this is that the code is not maintainable neither reusable. I  researched in the project for similar arrays, and I found at least three uses of those in the following files:
* `MockConfigurationBuilder` at line 9 
* `KeywordPatch` at line 66. 

I suggest to put those arrays in a `functions.php` file or any other file that can make this code more reusable and maintainable.