### PR TITLE
Resolving expectation count issue when using Spy related assertions.

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -32,6 +32,14 @@ class Mock implements MockInterface
     protected $_mockery_expectations = array();
 
     /**
+     * Stores an inital number of expectations that can be manipulated
+     * while using the getter method.
+     *
+     * @var int
+     */
+    protected $_mockery_expectations_count = 0;
+
+    /**
      * Flag to indicate whether we can ignore method calls missing from our
      * expectations
      *
@@ -480,7 +488,7 @@ class Mock implements MockInterface
      */
     public function mockery_getExpectationCount()
     {
-        $count = 0;
+        $count = $this->_mockery_expectations_count;
         foreach ($this->_mockery_expectations as $director) {
             $count += $director->getExpectationCount();
         }
@@ -678,6 +686,7 @@ class Mock implements MockInterface
         }
         $expectation->atLeast()->once();
         $director = new \Mockery\VerificationDirector($this->_mockery_getReceivedMethodCalls(), $expectation);
+        $this->_mockery_expectations_count++;
         $director->verify();
         return $director;
     }
@@ -690,6 +699,7 @@ class Mock implements MockInterface
         }
         $expectation->never();
         $director = new \Mockery\VerificationDirector($this->_mockery_getReceivedMethodCalls(), $expectation);
+        $this->_mockery_expectations_count++;
         $director->verify();
         return null;
     }

--- a/tests/Mockery/SpyTest.php
+++ b/tests/Mockery/SpyTest.php
@@ -75,4 +75,21 @@ class SpyTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException("Mockery\Exception\InvalidCountException");
         $spy->shouldHaveReceived("myMethod")->with(123);
     }
+
+    /** @test */
+    public function itIncrementsExpectationCountWhenShouldHaveReceivedIsUsed()
+    {
+        $spy = m::spy();
+        $spy->myMethod('param1', 'param2');
+        $spy->shouldHaveReceived('myMethod')->with('param1', 'param2');
+        $this->assertEquals(1, $spy->mockery_getExpectationCount());
+    }
+
+    /** @test */
+    public function itIncrementExpectationCountWhenShouldNotHaveReceivedIsUsed()
+    {
+        $spy = m::spy();
+        $spy->shouldNotHaveReceived('method');
+        $this->assertEquals(1, $spy->mockery_getExpectationCount());
+    }
 }

--- a/tests/Mockery/SpyTest.php
+++ b/tests/Mockery/SpyTest.php
@@ -86,7 +86,7 @@ class SpyTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function itIncrementExpectationCountWhenShouldNotHaveReceivedIsUsed()
+    public function itIncrementsExpectationCountWhenShouldNotHaveReceivedIsUsed()
     {
         $spy = m::spy();
         $spy->shouldNotHaveReceived('method');


### PR DESCRIPTION
Solving [issue 440](https://github.com/padraic/mockery/issues/440).

Notes about changes:
- This solution merely adds a protected count property used while retrieving expectation counts.
- The property is then incremented when shouldHaveReceived and it's opposite are called.

The problems with this solution: 
- We're not treating the count in the expected framework's way:
    - Adding the VerificationDirector, using the method `mockery_setExpectationsFor` within `Mock.php`.
    - Retrieve the count inside the iteration on line 489 of the same file.
- It's not possible to get the VerificationDirector using the mockery_getExpectationsFor method in `Mock.php`.
- It's not possible to find an specific expectation using `mockery_findExpectation` method on line 529 in `Mock.php`.
- All other methods that manipulate $_mockery_expectations won't know about the Verification's Director and Expectation classes.

Suggested way to solve the problem, taking into account the above issues:
- Use a contract describing the Director's public interface, so later on we could have less decoupled type hints.
- Add `getExpectationCount` method's definition to this interface.
- Abstract the ExpectationDirector's `call` method within this interface. Used on line 742 of `Mock.php`.
- Make both Expectation and Verification Directors implement this interface.
- Start adding VerificationDirector inside the mock class, using `mockery_setExpectationsFor`.
