### PR TITLE
Fixing increased visibility issue(497).

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -204,7 +204,7 @@ class Mock implements MockInterface
                         throw new \InvalidArgumentException("$method() cannot be mocked as it is a private method");
                     }
                     if (!$allowMockingProtectedMethods && $rm->isProtected()) {
-                        throw new \InvalidArgumentException("$method() cannot be mocked as it a protected method and mocking protected methods is not allowed for this mock");
+                        throw new \InvalidArgumentException("$method() cannot be mocked as it is a protected method and mocking protected methods is not enabled for the currently used mock object.");
                     }
                 }
 

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -355,24 +355,6 @@ class Mock implements MockInterface
         return $this->__call('__toString', array());
     }
 
-    /**public function __set($name, $value)
-    {
-        $this->_mockery_mockableProperties[$name] = $value;
-        return $this;
-    }
-
-    public function __get($name)
-    {
-        if (isset($this->_mockery_mockableProperties[$name])) {
-            return $this->_mockery_mockableProperties[$name];
-        } elseif(isset($this->{$name})) {
-            return $this->{$name};
-        }
-        throw new \InvalidArgumentException (
-            'Property ' . __CLASS__ . '::' . $name . ' does not exist on this mock object'
-        );
-    }**/
-
     /**
      * Iterate across all expectation directors and validate each
      *

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -782,6 +782,12 @@ class Mock implements MockInterface
         );
     }
 
+    /**
+     * Uses reflection to get the list of all
+     * methods within the current mock object
+     * 
+     * @return array
+     */
     protected function mockery_getMethods()
     {
         if (static::$_mockery_methods) {
@@ -792,22 +798,10 @@ class Mock implements MockInterface
 
         if (isset($this->_mockery_partial)) {
             $reflected = new \ReflectionObject($this->_mockery_partial);
-            $methods = $reflected->getMethods();
         } else {
             $reflected = new \ReflectionClass($this);
-            foreach ($reflected->getMethods() as $method) {
-                try {
-                    $methods[] = $method->getPrototype();
-                } catch (\ReflectionException $re) {
-                    /**
-                     * For some reason, private methods don't have a prototype
-                     */
-                    if ($method->isPrivate()) {
-                        $methods[] = $method;
-                    }
-                }
-            }
         }
+        $methods = $reflected->getMethods();
 
         return static::$_mockery_methods = $methods;
     }

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -767,7 +767,7 @@ class Mock implements MockInterface
     /**
      * Uses reflection to get the list of all
      * methods within the current mock object
-     * 
+     *
      * @return array
      */
     protected function mockery_getMethods()

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -776,16 +776,13 @@ class Mock implements MockInterface
             return static::$_mockery_methods;
         }
 
-        $methods = array();
-
         if (isset($this->_mockery_partial)) {
             $reflected = new \ReflectionObject($this->_mockery_partial);
         } else {
             $reflected = new \ReflectionClass($this);
         }
-        $methods = $reflected->getMethods();
 
-        return static::$_mockery_methods = $methods;
+        return static::$_mockery_methods = $reflected->getMethods();
     }
 
     /**

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -104,20 +104,6 @@ interface MockInterface
     public function byDefault();
 
     /**
-     * Capture calls to this mock and check against expectations
-     *
-     * @param string $method
-     * @param array $args
-     * @return mixed
-     */
-        /**
-         * Unfortunately we need to allow type hinting agnostic __call()
-         * definitions since any interface/class being mocked can go either
-         * way.
-         */
-    //public function __call($method, array $args);
-
-    /**
      * Iterate across all expectation directors and validate each
      *
      * @throws \Mockery\CountValidator\Exception

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1141,7 +1141,7 @@ class ContainerTest extends MockeryTestCase
     /**
      * @group issue/154
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage protectedMethod() cannot be mocked as it a protected method and mocking protected methods is not allowed for this mock
+     * @expectedExceptionMessage protectedMethod() cannot be mocked as it is a protected method and mocking protected methods is not enabled for the currently used mock object.
      */
     public function testShouldThrowIfAttemptingToStubProtectedMethod()
     {

--- a/tests/Mockery/MockingProtectedMethodsTest.php
+++ b/tests/Mockery/MockingProtectedMethodsTest.php
@@ -130,10 +130,14 @@ abstract class TestWithProtectedMethods
 
 class TestIncreasedVisibilityParent
 {
-    protected function foobar() {}
+    protected function foobar()
+    {
+    }
 }
 
 class TestIncreasedVisibilityChild extends TestIncreasedVisibilityParent
 {
-    public function foobar() {}
+    public function foobar()
+    {
+    }
 }

--- a/tests/Mockery/MockingProtectedMethodsTest.php
+++ b/tests/Mockery/MockingProtectedMethodsTest.php
@@ -97,6 +97,14 @@ class MockingProtectedMethodsTest extends MockeryTestCase
         $mock->shouldReceive("abstractProtected")->andReturn("abstractProtected");
         $this->assertEquals("abstractProtected", $mock->foo());
     }
+
+    /** @test */
+    public function shouldAllowMockingIncreasedVisabilityMethods()
+    {
+        $mock = $this->container->mock("test\Mockery\TestIncreasedVisibilityChild");
+        $mock->shouldReceive('foobar')->andReturn("foobar");
+        $this->assertEquals('foobar', $mock->foobar());
+    }
 }
 
 
@@ -118,4 +126,14 @@ abstract class TestWithProtectedMethods
     {
         return 'bar';
     }
+}
+
+class TestIncreasedVisibilityParent
+{
+    protected function foobar() {}
+}
+
+class TestIncreasedVisibilityChild extends TestIncreasedVisibilityParent
+{
+    public function foobar() {}
 }


### PR DESCRIPTION
Fixing [issue 497](https://github.com/padraic/mockery/issues/497).

Notes about changes:

- I've changed the `mockery_getMethods` method in the `Mock` class. 
- The method now doesn't treat prototypes, it just lists the reflection methods of the current class.
- If there's a real reason for treating prototype methods, it's not being covered by the tests.
- I've changed the description of  an exception thrown when trying to mock a protected method, it's an attempt to be more accurate. The change can be seen in the `Mock.php` file, at line 207.
- I've removed unused commented code from `Mock` and `MockInterface` source.