### PR TITLE
Mock's mockery_isAnonymous method now checks against implemented interfaces.

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -586,7 +586,8 @@ class Mock implements MockInterface
     public function mockery_isAnonymous()
     {
         $rfc = new \ReflectionClass($this);
-        return false === $rfc->getParentClass();
+        $onlyImplementsMock = count($rfc->getInterfaces()) == 1;
+        return (false === $rfc->getParentClass()) && $onlyImplementsMock;
     }
 
     public function __wakeup()

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2071,6 +2071,20 @@ class ExpectationTest extends MockeryTestCase
         $waterMock = $this->container->mock('IWater');
         $this->assertFalse($waterMock->mockery_isAnonymous());
     }
+
+    /**
+     * @expectedException \Mockery\Exception
+     */
+    public function testWetherMockWithInterfaceOnlyCanNotImplementNonExistingMethods()
+    {
+        \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
+        $waterMock = \Mockery::mock('IWater');
+        $waterMock
+            ->shouldReceive('nonExistentMethod')
+            ->once()
+            ->andReturnNull();
+        \Mockery::close();
+    }
 }
 
 interface IWater

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2065,6 +2065,17 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->times(1.3);
     }
+
+    public function testMockShouldNotBeAnonymousWhenImplementingSpecificInterface()
+    {
+        $waterMock = $this->container->mock('IWater');
+        $this->assertFalse($waterMock->mockery_isAnonymous());
+    }
+}
+
+interface IWater
+{
+    public function dry();
 }
 
 class MockeryTest_SubjectCall1


### PR DESCRIPTION
Fixes [issue #529](https://github.com/padraic/mockery/issues/529).

Notes about changes:
- `mockery_isAnonymous` now checks if the current mock implements more interfaces rather than implementing only the `Mock` one.
- If, at some day, Mock start to implement more interfaces, this check will fail and will need to be corrected.

Suggestions:
- The Exception thrown when mocking non existent methods should be more specific, maybe with only a name specifying the situation.