### PR TITLE
Adding specific message when calling method without any expectations on mock.

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -759,8 +759,17 @@ class Mock implements MockInterface
                 }
             }
         }
+
+        $message = 'Method ' . __CLASS__ . '::' . $method .
+            '() does not exist on this mock object';
+
+        if (!is_null($rm)) {
+            $message = 'Received ' . __CLASS__ .
+                '::' . $method . '(), but no expectations were specified';
+        }
+
         throw new \BadMethodCallException(
-            'Method ' . __CLASS__ . '::' . $method . '() does not exist on this mock object'
+            $message
         );
     }
 

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2065,6 +2065,32 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->times(1.3);
     }
+
+    public function testIfExceptionIndicatesAbsenceOfMethodAndExpectationsOnMock()
+    {
+        $mock = $this->container->mock('Mockery_Duck');
+
+        $this->setExpectedException(
+            '\BadMethodCallException',
+            'Method ' . get_class($mock) .
+            '::nonExistent() does not exist on this mock object'
+        );
+
+        $mock->nonExistent();
+    }
+
+    public function testIfCallingMethodWithNoExpectationsHasSpecificExceptionMessage()
+    {
+        $mock = $this->container->mock('Mockery_Duck');
+
+        $this->setExpectedException(
+            '\BadMethodCallException',
+            'Received ' . get_class($mock) .
+            '::quack(), ' . 'but no expectations were specified'
+        );
+        
+        $mock->quack();
+    }
 }
 
 class MockeryTest_SubjectCall1


### PR DESCRIPTION
Fixes [issue #475](https://github.com/padraic/mockery/issues/475).