### PR TITLE
Update example to call mockery close

### DIFF
--- a/examples/starship/StarshipTest.php
+++ b/examples/starship/StarshipTest.php
@@ -17,5 +17,6 @@ class StarshipTest extends PHPUnit_Framework_TestCase
 
         $starship = new Starship($mock);
         $starship->enterOrbit();
+        M::close();
     }
 }


### PR DESCRIPTION
Now, this test does not fail even if I change test case like below.
So I think it is better to update the example.

```php
//does not fail even if call once
$mock->shouldReceive('disengageWarp')->never()->ordered();
```