### PR TITLE
allow mocking exceptions under hhvm

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -198,6 +198,13 @@ class Container
 
         $builder->addBlackListedMethods($blocks);
 
+        if (defined('HHVM_VERSION')
+            && isset($class)
+            && ($class === 'Exception' || is_subclass_of($class, 'Exception'))) {
+            $builder->addBlackListedMethod("setTraceOptions");
+            $builder->addBlackListedMethod("getTraceOptions");
+        }
+
         if (!is_null($constructorArgs)) {
             $builder->addBlackListedMethod("__construct"); // we need to pass through
         } else {

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -141,6 +141,13 @@ class Mockery_MockTest extends MockeryTestCase
         $this->assertInstanceOf('Exception', $exception);
     }
 
+    public function testCanMockSubclassOfException()
+    {
+        $errorException = Mockery::mock('ErrorException');
+        $this->assertInstanceOf('ErrorException', $errorException);
+        $this->assertInstanceOf('Exception', $errorException);
+    }
+
     public function testCallingShouldReceiveWithoutAValidMethodName()
     {
         $mock = Mockery::mock();


### PR DESCRIPTION
This makes the test introduced in https://github.com/padraic/mockery/pull/456/files pass under hhvm and adds a test for mocking subclasses of Exception.