### PR TITLE
Clear the _filesToCleanUp array after unlink.

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -149,6 +149,7 @@ class Mockery
         foreach (self::$_filesToCleanUp as $fileName) {
             @unlink($fileName);
         }
+        self::$_filesToCleanUp = [];
 
         if (is_null(self::$_container)) {
             return;


### PR DESCRIPTION
When multiple unit tests are run without process isolation, \Mockery::close will attempt to unlink files from the _filesToCleanUp array every time.
This patch will clear the _filesToCleanUp array after the unlink loop, so no new attempts will be made to clean up files which don't exist anymore anyway.