### PR TITLE
Fix segfaults with a mocking class with __call

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -742,7 +742,8 @@ class Mock implements MockInterface
 
         if (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
-        } elseif ($this->_mockery_deferMissing && is_callable("parent::$method") && !$this->hasMethodOverloadingInParentClass()) {
+        } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")
+            && (!$this->hasMethodOverloadingInParentClass() || method_exists(get_parent_class($this), $method))) {
             return call_user_func_array("parent::$method", $args);
         } elseif ($method == '__toString') {
             // __toString is special because we force its addition to the class API regardless of the

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -742,7 +742,7 @@ class Mock implements MockInterface
 
         if (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
-        } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")) {
+        } elseif ($this->_mockery_deferMissing && is_callable("parent::$method") && !$this->hasMethodOverloadingInParentClass()) {
             return call_user_func_array("parent::$method", $args);
         } elseif ($method == '__toString') {
             // __toString is special because we force its addition to the class API regardless of the
@@ -793,6 +793,12 @@ class Mock implements MockInterface
         }
 
         return static::$_mockery_methods = $reflected->getMethods();
+    }
+
+    private function hasMethodOverloadingInParentClass()
+    {
+        // if there's __call any name would be callable
+        return is_callable('parent::' . uniqid(__FUNCTION__));
     }
 
     /**

--- a/tests/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Mockery/MockClassWithMethodOverloadingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class MockClassWithMethodOverloadingTest extends MockeryTestCase
+{
+    private $container;
+
+    protected function setUp()
+    {
+        $this->container = new \Mockery\Container;
+    }
+
+    protected function tearDown()
+    {
+        $this->container->mockery_close();
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testCreateMockForClassWithMethodOverloading()
+    {
+        $mock = $this->container->mock('test\Mockery\TestWithMethodOverloading')
+            ->makePartial();
+        $this->assertInstanceOf('test\Mockery\TestWithMethodOverloading', $mock);
+
+        // TestWithMethodOverloading::__call wouldn't be used. See Gotchas!.
+        $mock->randomMethod();
+    }
+}
+
+class TestWithMethodOverloading
+{
+    public function __call($name, $arguments)
+    {
+        return 1;
+    }
+}

--- a/tests/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Mockery/MockClassWithMethodOverloadingTest.php
@@ -30,11 +30,25 @@ class MockClassWithMethodOverloadingTest extends MockeryTestCase
         // TestWithMethodOverloading::__call wouldn't be used. See Gotchas!.
         $mock->randomMethod();
     }
+
+    public function testCreateMockForClassWithMethodOverloadingWithExistingMethod()
+    {
+        $mock = $this->container->mock('test\Mockery\TestWithMethodOverloading')
+            ->makePartial();
+        $this->assertInstanceOf('test\Mockery\TestWithMethodOverloading', $mock);
+
+        $this->assertSame(1, $mock->thisIsRealMethod());
+    }
 }
 
 class TestWithMethodOverloading
 {
     public function __call($name, $arguments)
+    {
+        return 1;
+    }
+
+    public function thisIsRealMethod()
     {
         return 1;
     }


### PR DESCRIPTION
I confirmed #564 with php 5.6.20 & xdebug. It says:

```
PHP Fatal error:  Maximum function nesting level of '256' reached, aborting! in /Users/nobu/projects/mockery/library/Mockery/Loader/EvalLoader.php(34) : eval()'d code on line 340
```

In the Mockery_0_test_Mockery_TestWithMethodOverloading:

```php
public function __call($method, $args) // line 340
{
    return $this->_mockery_handleMethodCall($method, $args);
}
```

This pull request attempts to avoid calling non-existing method infinitely and throws `BadMethodCallException` as the document says. Hope it helps.