### PR TITLE
Adding TypeHint to getMagicMethods(), on MagicMethodTypeHintsPass.

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -21,8 +21,7 @@
 namespace Mockery\Generator\StringManipulation\Pass;
 
 use Mockery\Generator\MockConfiguration;
-use Mockery\Generator\DefinedTargetClass;
-use Mockery\Generator\UndefinedTargetClass;
+use Mockery\Generator\TargetClassInterface;
 use Mockery\Generator\Method;
 
 class MagicMethodTypeHintsPass implements Pass
@@ -70,14 +69,13 @@ class MagicMethodTypeHintsPass implements Pass
      * Returns the magic methods within the
      * passed DefinedTargetClass.
      *
-     * @param $class
+     * @param TargetClassInterface $class
      * @return array
      */
-    public function getMagicMethods($class)
-    {
-        if (!$class ||
-            !($class instanceof DefinedTargetClass) &&
-            !($class instanceof UndefinedTargetClass)) {
+    public function getMagicMethods(
+        TargetClassInterface $class = null
+    ) {
+        if (is_null($class)) {
             return array();
         }
         return array_filter($class->getMethods(), function (Method $method) {

--- a/tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
@@ -178,7 +178,7 @@ class MagicMethodTypeHintsPassTest extends \PHPUnit_Framework_TestCase
      */
     public function itShouldReturnEmptyArrayIfClassTypeIsNotExpected()
     {
-        $magicMethods = $this->pass->getMagicMethods(new \StdClass);
+        $magicMethods = $this->pass->getMagicMethods(null);
         $this->assertInternalType('array', $magicMethods);
         $this->assertEmpty($magicMethods);
     }


### PR DESCRIPTION
This is just a small refactor, instead of checking against classes, I've added the interface(`TargetClassInterface`) as the type hint. Changes on `getMagicMethods()`, within `MagicMethodTypeHintsPass`.