### PR TITLE
Backport commits for PHP 7 support

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -217,6 +217,32 @@ class Expectation implements ExpectationInterface
         } elseif (count($this->_returnQueue) > 0) {
             return current($this->_returnQueue);
         }
+
+        $rm = $this->_mock->mockery_getMethod($this->_name);
+        if ($rm && version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $rm->hasReturnType()) {
+            $type = (string) $rm->getReturnType();
+            switch ($type) {
+                case '':       return;
+                case 'string': return '';
+                case 'int':    return 0;
+                case 'float':  return 0.0;
+                case 'bool':   return false;
+                case 'array':  return [];
+
+                case 'callable':
+                case 'Closure':
+                    return function () {};
+
+                case 'Traversable':
+                case 'Generator':
+                    // Remove eval() when minimum version >=5.5
+                    $generator = eval('return function () { yield; };');
+                    return $generator();
+
+                default:
+                    return \Mockery::mock($type);
+            }
+        }
     }
 
     /**

--- a/library/Mockery/Generator/Method.php
+++ b/library/Mockery/Generator/Method.php
@@ -22,4 +22,12 @@ class Method
             return new Parameter($parameter);
         }, $this->method->getParameters());
     }
+
+    public function getReturnType()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $this->method->hasReturnType()) {
+            return (string) $this->method->getReturnType();
+        }
+        return '';
+    }
 }

--- a/library/Mockery/Generator/Parameter.php
+++ b/library/Mockery/Generator/Parameter.php
@@ -55,6 +55,10 @@ class Parameter
             }
         }
 
+        if (version_compare(PHP_VERSION, '7.0.0-dev') >= 0 && $this->rfp->hasType()) {
+            return (string) $this->rfp->getType();
+        }
+
         if (preg_match('/^Parameter #[0-9]+ \[ \<(required|optional)\> (?<typehint>\S+ )?.*\$' . $this->rfp->getName() . ' .*\]$/', $this->rfp->__toString(), $typehintMatch)) {
             if (!empty($typehintMatch['typehint'])) {
                 return $typehintMatch['typehint'];

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -26,6 +26,7 @@ class MethodDefinitionPass implements Pass
             $methodDef .= $method->returnsReference() ? ' & ' : '';
             $methodDef .= $method->getName();
             $methodDef .= $this->renderParams($method, $config);
+            $methodDef .= $this->renderReturnType($method);
             $methodDef .= $this->renderMethodBody($method, $config);
 
             $code = $this->appendToClass($code, $methodDef);
@@ -64,6 +65,12 @@ class MethodDefinitionPass implements Pass
             $methodParams[] = $paramDef;
         }
         return '(' . implode(', ', $methodParams) . ')';
+    }
+
+    protected function renderReturnType(Method $method)
+    {
+        $type = $method->getReturnType();
+        return $type ? sprintf(': %s', $type) : '';
     }
 
     protected function appendToClass($class, $code)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,9 @@
         <testsuite name="Mockery Test Suite">
             <directory suffix="Test.php">./tests</directory>
             <exclude>./tests/Mockery/MockingVariadicArgumentsTest.php</exclude>
+            <exclude>./tests/Mockery/MockingParameterAndReturnTypesTest.php</exclude>
             <file phpVersion="5.6.0" phpVersionOperator=">=">./tests/Mockery/MockingVariadicArgumentsTest.php</file>
+            <file phpVersion="7.0.0-dev" phpVersionOperator=">=">./tests/Mockery/MockingParameterAndReturnTypesTest.php</file>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
+++ b/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
@@ -61,8 +61,6 @@ interface React_WritableStreamInterface extends React_StreamInterface
     public function write($data);
 }
 
-interface Chatroulette_ConnectionInterface
-    extends React_ReadableStreamInterface,
-            React_WritableStreamInterface
+interface Chatroulette_ConnectionInterface extends React_ReadableStreamInterface, React_WritableStreamInterface
 {
 }

--- a/tests/Mockery/MockingParameterAndReturnTypesTest.php
+++ b/tests/Mockery/MockingParameterAndReturnTypesTest.php
@@ -113,21 +113,39 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
 
 abstract class TestWithParameterAndReturnType
 {
-    public function returnString(): string {}
+    public function returnString(): string
+    {
+    }
 
-    public function returnInteger(): int {}
+    public function returnInteger(): int
+    {
+    }
 
-    public function returnFloat(): float {}
+    public function returnFloat(): float
+    {
+    }
 
-    public function returnBoolean(): bool {}
+    public function returnBoolean(): bool
+    {
+    }
 
-    public function returnArray(): array {}
+    public function returnArray(): array
+    {
+    }
 
-    public function returnCallable(): callable {}
+    public function returnCallable(): callable
+    {
+    }
 
-    public function returnGenerator(): \Generator {}
+    public function returnGenerator(): \Generator
+    {
+    }
 
-    public function withClassReturnType(): TestWithParameterAndReturnType {}
+    public function withClassReturnType(): TestWithParameterAndReturnType
+    {
+    }
 
-    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string) {}
+    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string)
+    {
+    }
 }

--- a/tests/Mockery/MockingParameterAndReturnTypesTest.php
+++ b/tests/Mockery/MockingParameterAndReturnTypesTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010-2014 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+declare(strict_types=1); // Use strict types to ensure exact types are returned or passed
+
+namespace test\Mockery;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class MockingParameterAndReturnTypesTest extends MockeryTestCase
+{
+    public function setup()
+    {
+        $this->container = new \Mockery\Container;
+    }
+
+    public function teardown()
+    {
+        $this->container->mockery_close();
+    }
+
+    public function testMockingStringReturnType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnString");
+        $this->assertSame("", $mock->returnString());
+    }
+
+    public function testMockingIntegerReturnType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnInteger");
+        $this->assertEquals(0, $mock->returnInteger());
+    }
+
+    public function testMockingFloatReturnType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnFloat");
+        $this->assertSame(0.0, $mock->returnFloat());
+    }
+
+    public function testMockingBooleanReturnType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnBoolean");
+        $this->assertSame(false, $mock->returnBoolean());
+    }
+
+    public function testMockingArrayReturnType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnArray");
+        $this->assertSame([], $mock->returnArray());
+    }
+
+    public function testMockingGeneratorReturnTyps()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnGenerator");
+        $this->assertInstanceOf("\Generator", $mock->returnGenerator());
+    }
+
+    public function testMockingCallableReturnType()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("returnCallable");
+        $this->assertTrue(is_callable($mock->returnCallable()));
+    }
+
+    public function testMockingClassReturnTypes()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("withClassReturnType");
+        $this->assertInstanceOf("test\Mockery\TestWithParameterAndReturnType", $mock->withClassReturnType());
+    }
+
+    public function testMockingParameterTypes()
+    {
+        $mock = $this->container->mock("test\Mockery\TestWithParameterAndReturnType");
+
+        $mock->shouldReceive("withScalarParameters");
+        $mock->withScalarParameters(1, 1.0, true, 'string');
+    }
+}
+
+
+abstract class TestWithParameterAndReturnType
+{
+    public function returnString(): string {}
+
+    public function returnInteger(): int {}
+
+    public function returnFloat(): float {}
+
+    public function returnBoolean(): bool {}
+
+    public function returnArray(): array {}
+
+    public function returnCallable(): callable {}
+
+    public function returnGenerator(): \Generator {}
+
+    public function withClassReturnType(): TestWithParameterAndReturnType {}
+
+    public function withScalarParameters(int $integer, float $float, bool $boolean, string $string) {}
+}


### PR DESCRIPTION
[This pull request](https://github.com/padraic/mockery/commit/3dd65d5181a3ffe4e5e406e7725928358e5967c7) adds support for PHP 7's scalar typehints and return type declarations. This PR adds that functionality to `0.9.x`. The changes seem to be backwards compatible as far as I can tell, so tagging either a new `0.9.5` or a `0.10.0` would be acceptable per SemVer.

This addresses: #561 (and, I think, #499)