### PR TITLE
Alternative shouldReceive syntax

### DIFF
--- a/library/Mockery/ExpectationBuilder.php
+++ b/library/Mockery/ExpectationBuilder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Mockery;
+
+class ExpectationBuilder 
+{
+    private $mock;
+
+    public function __construct(MockInterface $mock)
+    {
+        $this->mock = $mock;
+    }
+
+    /**
+     * @return Mockery\Expectation
+     */
+    public function __call($method, $args)
+    {
+        return $this->mock->shouldReceive($method)->withArgs($args);
+    }
+}

--- a/library/Mockery/ExpectationBuilder.php
+++ b/library/Mockery/ExpectationBuilder.php
@@ -5,10 +5,12 @@ namespace Mockery;
 class ExpectationBuilder 
 {
     private $mock;
+    private $method;
 
-    public function __construct(MockInterface $mock)
+    public function __construct(MockInterface $mock, $method)
     {
         $this->mock = $mock;
+        $this->method = $method;
     }
 
     /**
@@ -16,6 +18,12 @@ class ExpectationBuilder
      */
     public function __call($method, $args)
     {
-        return $this->mock->shouldReceive($method)->withArgs($args);
+        $expectation = $this->mock->{$this->method}($method);
+
+        if ($this->method !== "shouldNotHaveReceived") {
+            return $expectation->withArgs($args);
+        }
+
+        return $expectation;
     }
 }

--- a/library/Mockery/HigherOrderMessage.php
+++ b/library/Mockery/HigherOrderMessage.php
@@ -2,7 +2,7 @@
 
 namespace Mockery;
 
-class ExpectationBuilder 
+class HigherOrderMessage 
 {
     private $mock;
     private $method;

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -176,13 +176,13 @@ class Mock implements MockInterface
     /**
      * Set expected method calls
      *
-     * @param string $methodName,... one or many methods that are expected to be called in this mock
-     * @return \Mockery\ExpectationInterface
+     * @param null|string $methodName,... one or many methods that are expected to be called in this mock
+     * @return \Mockery\ExpectationInterface|\Mockery\ExpectationBuilder
      */
     public function shouldReceive($methodName = null)
     {
         if ($methodName === null) {
-            return new ExpectationBuilder($this);
+            return new ExpectationBuilder($this, "shouldReceive");
         }
 
         foreach (func_get_args() as $method) {
@@ -225,11 +225,15 @@ class Mock implements MockInterface
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param string $methodName,... one or many methods that are expected not to be called in this mock
-     * @return \Mockery\Expectation
+     * @param null|string $methodName,... one or many methods that are expected not to be called in this mock
+     * @return \Mockery\Expectation|\Mockery\ExpectationBuilder
      */
-    public function shouldNotReceive($methodName)
+    public function shouldNotReceive($methodName = null)
     {
+        if ($methodName === null) {
+            return new ExpectationBuilder($this, "shouldNotReceive");
+        }
+
         $expectation = call_user_func_array(array($this, 'shouldReceive'), func_get_args());
         $expectation->never();
         return $expectation;
@@ -667,8 +671,12 @@ class Mock implements MockInterface
         }
     }
 
-    public function shouldHaveReceived($method, $args = null)
+    public function shouldHaveReceived($method = null, $args = null)
     {
+        if ($method === null) {
+            return new ExpectationBuilder($this, "shouldHaveReceived");
+        }
+
         $expectation = new \Mockery\VerificationExpectation($this, $method);
         if (null !== $args) {
             $expectation->withArgs($args);
@@ -680,8 +688,12 @@ class Mock implements MockInterface
         return $director;
     }
 
-    public function shouldNotHaveReceived($method, $args = null)
+    public function shouldNotHaveReceived($method = null, $args = null)
     {
+        if ($method === null) {
+            return new ExpectationBuilder($this, "shouldNotHaveReceived");
+        }
+
         $expectation = new \Mockery\VerificationExpectation($this, $method);
         if (null !== $args) {
             $expectation->withArgs($args);

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -20,6 +20,7 @@
 
 namespace Mockery;
 
+use Mockery\ExpectationBuilder;
 use Mockery\MockInterface;
 
 class Mock implements MockInterface
@@ -178,10 +179,10 @@ class Mock implements MockInterface
      * @param string $methodName,... one or many methods that are expected to be called in this mock
      * @return \Mockery\ExpectationInterface
      */
-    public function shouldReceive($methodName)
+    public function shouldReceive($methodName = null)
     {
-        if (func_num_args() < 1) {
-            throw new \InvalidArgumentException("At least one method name is required");
+        if ($methodName === null) {
+            return new ExpectationBuilder($this);
         }
 
         foreach (func_get_args() as $method) {

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -20,7 +20,7 @@
 
 namespace Mockery;
 
-use Mockery\ExpectationBuilder;
+use Mockery\HigherOrderMessage;
 use Mockery\MockInterface;
 
 class Mock implements MockInterface
@@ -177,12 +177,12 @@ class Mock implements MockInterface
      * Set expected method calls
      *
      * @param null|string $methodName,... one or many methods that are expected to be called in this mock
-     * @return \Mockery\ExpectationInterface|\Mockery\ExpectationBuilder
+     * @return \Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
      */
     public function shouldReceive($methodName = null)
     {
         if ($methodName === null) {
-            return new ExpectationBuilder($this, "shouldReceive");
+            return new HigherOrderMessage($this, "shouldReceive");
         }
 
         foreach (func_get_args() as $method) {
@@ -226,12 +226,12 @@ class Mock implements MockInterface
      * Shortcut method for setting an expectation that a method should not be called.
      *
      * @param null|string $methodName,... one or many methods that are expected not to be called in this mock
-     * @return \Mockery\Expectation|\Mockery\ExpectationBuilder
+     * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
      */
     public function shouldNotReceive($methodName = null)
     {
         if ($methodName === null) {
-            return new ExpectationBuilder($this, "shouldNotReceive");
+            return new HigherOrderMessage($this, "shouldNotReceive");
         }
 
         $expectation = call_user_func_array(array($this, 'shouldReceive'), func_get_args());
@@ -674,7 +674,7 @@ class Mock implements MockInterface
     public function shouldHaveReceived($method = null, $args = null)
     {
         if ($method === null) {
-            return new ExpectationBuilder($this, "shouldHaveReceived");
+            return new HigherOrderMessage($this, "shouldHaveReceived");
         }
 
         $expectation = new \Mockery\VerificationExpectation($this, $method);
@@ -691,7 +691,7 @@ class Mock implements MockInterface
     public function shouldNotHaveReceived($method = null, $args = null)
     {
         if ($method === null) {
-            return new ExpectationBuilder($this, "shouldNotHaveReceived");
+            return new HigherOrderMessage($this, "shouldNotHaveReceived");
         }
 
         $expectation = new \Mockery\VerificationExpectation($this, $method);

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -34,16 +34,16 @@ interface MockInterface
     /**
      * Set expected method calls
      *
-     * @param string $methodName,... one or many methods that are expected to be called in this mock
-     * @return \Mockery\Expectation
+     * @param null|string $methodName,... one or many methods that are expected to be called in this mock
+     * @return mixed
      */
-    public function shouldReceive($methodName);
+    public function shouldReceive($methodName = null);
 
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param string $methodName,... one or many methods that are expected not to be called in this mock
-     * @return \Mockery\Expectation
+     * @param null|string $methodName,... one or many methods that are expected not to be called in this mock
+     * @return mixed
      */
     public function shouldNotReceive($methodName);
 
@@ -80,16 +80,16 @@ interface MockInterface
     public function makePartial();
 
     /**
-     * @param $method
+     * @param null|string $method
      * @param null $args
-     * @return \Mockery\Expectation
+     * @return mixed
      */
     public function shouldHaveReceived($method, $args = null);
 
     /**
-     * @param $method
+     * @param null|string $method
      * @param null $args
-     * @return null
+     * @return mixed
      */
     public function shouldNotHaveReceived($method, $args = null);
 


### PR DESCRIPTION
Not sure what people think about this, it just gets away from using strings for method names...

``` php
$mock->shouldReceive()->foo("bar")->andReturn(123);
```
