### PR TITLE
Exclude SemiReservedWordsAsMethods.php on StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,3 +3,4 @@ preset: psr2
 finder:
   not-name:
     - MockingParameterAndReturnTypesTest.php
+    - SemiReservedWordsAsMethods.php


### PR DESCRIPTION
Sorry this file can't be fixed by StyleCI right now. We do hope to fix that soon, but in the meanwhile, this should be suffice.