### PR TITLE
Updated the Magic Pass to use the proper standard for toString

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -40,7 +40,7 @@ class MagicMethodTypeHintsPass implements Pass
         '__unset',
         '__sleep',
         '__wakeup',
-        '__tostring',
+        '__toString',
         '__invoke',
         '__set_state',
         '__clone',

--- a/tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
+++ b/tests/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPassTest.php
@@ -210,7 +210,7 @@ class MagicDummy
         return false;
     }
 
-    public function __tostring() : string
+    public function __toString() : string
     {
         return '';
     }


### PR DESCRIPTION
`__toString` was not detected but `__tostring` was instead.
The test class was written was using the latter as well.