### PR TITLE
Use PRETTY_PRINT syntax and reorder keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,18 @@
 {
     "name": "mockery/mockery",
     "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-    "keywords": ["library", "testing", "test", "stub", "mock", "mockery", "test double", "tdd", "bdd", "mock objects"],
+    "keywords": [
+        "bdd",
+        "library",
+        "mock",
+        "mock objects",
+        "mockery",
+        "stub",
+        "tdd",
+        "test",
+        "test double",
+        "testing"
+    ],
     "homepage": "http://github.com/padraic/mockery",
     "license": "BSD-3-Clause",
     "authors": [
@@ -25,7 +36,9 @@
         "phpunit/phpunit": "~4.0"
     },
     "autoload": {
-        "psr-0": { "Mockery": "library/" }
+        "psr-0": {
+            "Mockery": "library/"
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Use PRETTY_PRINT syntax and reorder keywords - avoid commit noise when adding/updating a keyword