### PR TITLE
[Docs] Enable php highlighting to php code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,3 +257,11 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     print sphinx_rtd_theme.get_html_theme_path()
+
+# load PhpLexer
+from sphinx.highlighting import lexers
+from pygments.lexers.web import PhpLexer
+
+# enable highlighting for PHP code not between <?php ... ?> by default
+lexers['php'] = PhpLexer(startinline=True)
+lexers['php-annotations'] = PhpLexer(startinline=True)


### PR DESCRIPTION
This lines enable the php highlighting to the `code-block`s when the code doesn't start with `<?php`