### PR TITLE
stable hamcrest/hamcrest-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": ">=5.4.0",
         "lib-pcre": ">=7.0",
-        "hamcrest/hamcrest-php": "^2.0@dev"
+        "hamcrest/hamcrest-php": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Use a stable version (2.0+) of `hamcrest/hamcrest-php` instead of `dev-master`