### PR TITLE
Raise a descriptive error when a required class is missing

### DIFF
--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -166,6 +166,8 @@ class Container
                 $class = array_shift($args);
                 $builder->addTarget($class);
                 continue;
+            } elseif (is_string($arg) && !\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() && (!class_exists($arg, true) && !interface_exists($arg, true))) {
+                throw new \Mockery\Exception("Mockery can't find '$arg' so can't mock it");
             } elseif (is_string($arg)) {
                 if (!$this->isValidClassName($arg)) {
                     throw new \Mockery\Exception('Class name contains invalid characters');

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1890,7 +1890,7 @@ class ExpectationTest extends MockeryTestCase
 
     /**
      * @expectedException \Mockery\Exception
-     * @expectedExceptionMessage Mockery's configuration currently forbids mocking
+     * @expectedExceptionMessage Mockery can't find 'SomeMadeUpClass' so can't mock it
      */
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnAutoDeclaredClasses()
     {


### PR DESCRIPTION
Currently when Mockery has been configured not to allow mocking non-existent methods, attempting to mock a non-existent class gives a confusing error. It complains that it can't mock methods that don't exist on the specified class, but actually the error is that mockery can't find the referenced class to mock it and verify the methods it's allowed to mock.

This commit changes that behaviour so that attempting to mock a class that doesn't exist throws an exception that explicitly says that the specified class doesn't exist, however it only does so while mockery is configured not to allow mocking of non-existent methods.

I'm not entirely certain that this is the right way to make this change, so feedback is appreciated. Also appreciated is feedback on if this change is considered desirable; no hard feelings if it's not!