### PR TITLE
Restore the PHPUnit listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Destructors (`__destruct`) are stubbed out where it makes sense
 * Allow passing a closure argument to `withArgs()` to validate multiple arguments at once. 
 * `Mockery\Adapter\Phpunit\TestListener` has been rewritten because it
-  incorrectly marks some tests as risky. It will no longer verify mock
+  incorrectly marked some tests as risky. It will no longer verify mock
   expectations but instead check that tests do that themselves.
  
 ## 0.9.4 (XXXX-XX-XX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * Destructors (`__destruct`) are stubbed out where it makes sense
 * Allow passing a closure argument to `withArgs()` to validate multiple arguments at once. 
-* `Mockery\Adapter\Phpunit\TestListener` has been removed because it
-  incorrectly marks some tests as risky.
+* `Mockery\Adapter\Phpunit\TestListener` has been rewritten because it
+  incorrectly marks some tests as risky. It will no longer verify mock
+  expectations but instead check that tests do that themselves.
  
 ## 0.9.4 (XXXX-XX-XX)
 

--- a/docs/reference/phpunit_integration.rst
+++ b/docs/reference/phpunit_integration.rst
@@ -104,15 +104,15 @@ Make sure Composer's or Mockery's autoloader is present in the bootstrap file
 or you will need to also define a "file" attribute pointing to the file of the
 ``TestListener`` class.
 
-If you are creating the test suite programatically you may add the listener
+If you are creating the test suite programmatically you may add the listener
 like this:
 
 .. code-block:: php
 
-    // Create Suite
+    // Create the suite.
     $suite = new PHPUnit_Framework_TestSuite();
 
-    // Create a result listener or add it
+    // Create the listener and add it to the suite.
     $result = new PHPUnit_Framework_TestResult();
     $result->addListener(new \Mockery\Adapter\Phpunit\TestListener());
 

--- a/docs/reference/phpunit_integration.rst
+++ b/docs/reference/phpunit_integration.rst
@@ -67,7 +67,7 @@ Composer generated autoloader file:
     the file name is updated for all your projects.)
 
 To integrate Mockery into PHPUnit and avoid having to call the close method
-and have Mockery remove itself from code coverage reports, use this in you
+and have Mockery remove itself from code coverage reports, use this in your
 suite:
 
 .. code-block:: php
@@ -86,6 +86,38 @@ An alternative is to use the supplied trait:
         use \Mockery\Adapter\PHPUnit\MockeryPHPUnitIntegration;
 
     }
+
+Mockery provides a PHPUnit listener that makes tests fail if
+``Mockery::close()`` has not been called. It can help identify tests where
+you've forgotten to include the trait or extend the ``MockeryTestCase``.
+
+If you are using PHPUnit's XML configuration approach, you can include the
+following to load the ``TestListener``:
+
+.. code-block:: xml
+
+    <listeners>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
+    </listeners>
+
+Make sure Composer's or Mockery's autoloader is present in the bootstrap file
+or you will need to also define a "file" attribute pointing to the file of the
+``TestListener`` class.
+
+If you are creating the test suite programatically you may add the listener
+like this:
+
+.. code-block:: php
+
+    // Create Suite
+    $suite = new PHPUnit_Framework_TestSuite();
+
+    // Create a result listener or add it
+    $result = new PHPUnit_Framework_TestResult();
+    $result->addListener(new \Mockery\Adapter\Phpunit\TestListener());
+
+    // Run the tests.
+    $suite->run($result);
 
 .. caution::
 

--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Adapter\Phpunit;
+
+class TestListener extends \PHPUnit_Framework_BaseTestListener
+{
+    /**
+     * endTest is called after each test and checks if \Mockery::close() has
+     * been called, and will let the test fail if it hasn't.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  float                  $time
+     */
+    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    {
+        try {
+            // The self() call is used as a sentinel. Anything that throws if
+            // the container is closed already will do.
+            \Mockery::self();
+        } catch (\LogicException $_) {
+            return;
+        }
+
+        $e = new \PHPUnit_Framework_ExpectationFailedException(sprintf(
+            "Mockery's expectations have not been verified. Make sure that \Mockery::close() is called at the end of the test. Consider using %s\MockeryPHPUnitIntegration or extending %s\MockeryTestCase.",
+            __NAMESPACE__,
+            __NAMESPACE__
+        ));
+        $result = $test->getTestResultObject();
+        $result->addFailure($test, $e, $time);
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/TestListener.php
+++ b/library/Mockery/Adapter/Phpunit/TestListener.php
@@ -31,6 +31,20 @@ class TestListener extends \PHPUnit_Framework_BaseTestListener
      */
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
+        if (!$test instanceof \PHPUnit_Framework_TestCase) {
+            // We need the getTestResultObject and getStatus methods which are
+            // not part of the interface.
+            return;
+        }
+
+        if ($test->getStatus() !== \PHPUnit_Runner_BaseTestRunner::STATUS_PASSED) {
+            // If the test didn't pass there is no guarantee that
+            // verifyMockObjects and assertPostConditions have been called.
+            // And even if it did, the point here is to prevent false
+            // negatives, not to make failing tests fail for more reasons.
+            return;
+        }
+
         try {
             // The self() call is used as a sentinel. Anything that throws if
             // the container is closed already will do.

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+class Mockery_Adapter_Phpunit_TestListenerTest extends PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        // We intentionally test the static container here. That is what the
+        // listener will check.
+        $this->container = \Mockery::getContainer();
+        $this->listener = new \Mockery\Adapter\Phpunit\TestListener();
+        $this->testResult = new \PHPUnit_Framework_TestResult();
+        $this->test = new \Mockery_Adapter_Phpunit_EmptyTestCase();
+
+        $this->test->setTestResultObject($this->testResult);
+        $this->testResult->addListener($this->listener);
+
+        $this->assertTrue($this->testResult->wasSuccessful(), 'sanity check: empty test results should be considered successful');
+    }
+
+    public function testSuccessOnClose()
+    {
+        $mock = $this->container->mock('foo');
+        $mock->shouldReceive('bar')->once();
+        $mock->bar();
+
+        // This is what MockeryPHPUnitIntegration and MockeryTestCase trait
+        // will do. We intentionally call the static close method.
+        $this->test->addToAssertionCount($this->container->mockery_getExpectationCount());
+        \Mockery::close();
+
+        $this->listener->endTest($this->test, 0);
+        $this->assertTrue($this->testResult->wasSuccessful(), 'expected test result to indicate success');
+    }
+
+    public function testFailureOnMissingClose()
+    {
+        $mock = $this->container->mock('foo');
+        $mock->shouldReceive('bar')->once();
+
+        $this->listener->endTest($this->test, 0);
+        $this->assertFalse($this->testResult->wasSuccessful(), 'expected test result to indicate failure');
+
+        // Satisfy the expectation and close the global container now so we
+        // don't taint the environment.
+        $mock->bar();
+        \Mockery::close();
+    }
+}
+
+class Mockery_Adapter_Phpunit_EmptyTestCase extends PHPUnit_Framework_TestCase
+{
+    public function testNothing()
+    {
+    }
+}

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -64,11 +64,19 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends PHPUnit_Framework_TestCas
         $mock->bar();
         \Mockery::close();
     }
+
+    /** @expectedException Mockery\Exception\InvalidCountException */
+    public function testSpy()
+    {
+        $spy = $this->container->mock('foo');
+        $spy->shouldHaveReceived("foo")->with("bar")->twice();
+    }
 }
 
 class Mockery_Adapter_Phpunit_EmptyTestCase extends PHPUnit_Framework_TestCase
 {
-    public function testNothing()
+    public function getStatus()
     {
+        return \PHPUnit_Runner_BaseTestRunner::STATUS_PASSED;
     }
 }

--- a/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -38,7 +38,7 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends PHPUnit_Framework_TestCas
 
     public function testSuccessOnClose()
     {
-        $mock = $this->container->mock('foo');
+        $mock = $this->container->mock();
         $mock->shouldReceive('bar')->once();
         $mock->bar();
 
@@ -53,7 +53,7 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends PHPUnit_Framework_TestCas
 
     public function testFailureOnMissingClose()
     {
-        $mock = $this->container->mock('foo');
+        $mock = $this->container->mock();
         $mock->shouldReceive('bar')->once();
 
         $this->listener->endTest($this->test, 0);
@@ -63,13 +63,6 @@ class Mockery_Adapter_Phpunit_TestListenerTest extends PHPUnit_Framework_TestCas
         // don't taint the environment.
         $mock->bar();
         \Mockery::close();
-    }
-
-    /** @expectedException Mockery\Exception\InvalidCountException */
-    public function testSpy()
-    {
-        $spy = $this->container->mock('foo');
-        $spy->shouldHaveReceived("foo")->with("bar")->twice();
     }
 }
 


### PR DESCRIPTION
The listener has been removed in ede143167ae34e because it is called too
late in the test lifecycle. This marks tests incorrectly as risky, if
there are no other assertions in the test.

Simply removing the listener silently breaks existing testsuites for
PHPUnit <5.5.6, which will not complain about missing listeners.

The listener added in this commit will no longer verify mock assertions.
Instead, the listener will mark tests as failed if they don't verify the
mock assertions themselves.

This will surface the change for existing users of the listener and help them
migrate to the trait or base class. Is also serves as an opt-in safefail for
new Mockery users.

This is how it looks in action:

```
$ bin/phpunit 
PHPUnit 5.3.5 by Sebastian Bergmann and contributors.

...........F

Time: 595 ms, Memory: 43.25MB

There was 1 failure:

1) Classmarkets\Tests\Search\AnalysisRunnerTest::testRunAnalysis
Mockery's expectations have not been verified. Make sure that \Mockery::close() is called at the end of the test. Consider using Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration or extending Mockery\Adapter\Phpunit\MockeryTestCase.

/home/pschultz/src/mockery/library/Mockery/Adapter/Phpunit/TestListener.php:42

FAILURES!
Tests: 12, Assertions: 45, Failures: 1.
```

Fixes #636