### PR TITLE
Clear the _filesToCleanUp array after unlink.

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -143,6 +143,7 @@ class Mockery
         foreach (self::$_filesToCleanUp as $fileName) {
             @unlink($fileName);
         }
+        self::$_filesToCleanUp = [];
 
         if (is_null(self::$_container)) {
             return;

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -143,7 +143,7 @@ class Mockery
         foreach (self::$_filesToCleanUp as $fileName) {
             @unlink($fileName);
         }
-        self::$_filesToCleanUp = [];
+        self::$_filesToCleanUp = array();
 
         if (is_null(self::$_container)) {
             return;


### PR DESCRIPTION
See 00f4baf148c9daeac172b89672a9d7baa7036e51.