### PR TITLE
Apply MagicMethodTypeHintsPass to interfaces

### DIFF
--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -57,6 +57,9 @@ class MagicMethodTypeHintsPass implements Pass
     public function apply($code, MockConfiguration $config)
     {
         $magicMethods = $this->getMagicMethods($config->getTargetClass());
+        foreach ($config->getTargetInterfaces() as $interface) {
+            $magicMethods = array_merge($this->getMagicMethods($interface));
+        }
 
         foreach ($magicMethods as $method) {
             $code = $this->applyMagicTypeHints($code, $method);


### PR DESCRIPTION
Resolves #661 

Just expanded on the work done in #585 by making sure that MagicMethodTypeHintsPass looks at interfaces as well as the class and modifying the tests to look at both the class and the interface cases.