### PR TITLE
allows() and expects() syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Removed object recorder feature
 * Bumped minimum PHP version to 5.6
 * `andThrow` will now throw anything `\Throwable`
+* Adds `allows` and `expects` syntax
  
 ## 0.9.4 (XXXX-XX-XX)
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ $double = Mockery::mock(BookRepository::class);
 $double->expects()->add($book);
 ```
 
-During the test, Mockery will ensure that the `add` method is called no more
-than once. After you have finished exercising the system under test, you need to
-tell Mockery to check that the method was called at all using the
+During the test, Mockery accept calls to the `add` method as prescribed.
+After you have finished exercising the system under test, you need to
+tell Mockery to check that the method was called as expected, using the 
 `Mockery::close` method. One way to do that is to add it to your `tearDown`
 method in PHPUnit.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ interface BookRepository {
 $double = Mockery::mock(BookRepository::class);
 ``` 
 
-## Method Stubs
+## Method Stubs 🎫
 
 A method stub is a mechanism for having your test double return canned responses
 to certain method calls. With stubs, you don't care how many times, if at all,
@@ -90,7 +90,7 @@ $double = Mockery::mock(BookRepository::class, [
 ]);
 ```
 
-## Method Call Expectations
+## Method Call Expectations 📲
 
 A Method call expectation is a mechanism to allow you to verify that a
 particular method has been called. You can specify the parameters and you can
@@ -126,7 +126,7 @@ this if you are expecting more calls.
 $double->expects()->add($book)->twice();
 ```
 
-## Test Spies
+## Test Spies 🕵️
 
 By default, all test doubles created with the `Mockery::mock` method will only
 accept calls that they have been configured to `allow` or `expect`. Sometimes we

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ version
 composer require --dev mockery/mockery
 ```
 
+⚠️️ The remainder of this README refers specifically to the master branch (1.0-dev).
+
 ## Test Doubles 
 
 Test doubles (often called mocks) simulate the behaviour of real objects. They are

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ class Book {}
 interface BookRepository {
     function find($id): Book;
     function findAll(): array;
+    function add(Book $book): void;
 }
 
 $double = Mockery::mock(BookRepository::class);
@@ -59,10 +60,14 @@ $double = Mockery::mock(BookRepository::class);
 ## Method Stubs
 
 A method stub is a mechanism for having your test double return canned responses
-to a certain method call. 
+to a certain method call. With stubs, you don't care how many times, if at all,
+the method is called. Stubs are used to provide indirect input to the system
+under test.
 
 ``` php
 $double->allows()->find(123)->andReturns(new Book());
+
+$book = $double->find(123);
 ```
 
 If your stub doesn't require specific arguments, you can also use this shortcut
@@ -83,7 +88,40 @@ $double = Mockery::mock(BookRepository::class, [
 ]);
 ```
 
-## Message Expectations
+## Method Call Expectations
+
+A Method call expectation is a mechanism to allow you to verify that a
+particular method has been called. You can specify the parameters and you can
+also specify how many times you expect it to be called.
+
+``` php
+$book = new Book();
+
+$double = Mockery::mock(BookRepository::class);
+$double->expects()->add($book);
+```
+
+During the test, Mockery will ensure that the `add` method is called no more
+than once. After you have finished exercising the system under test, you need to
+tell Mockery to check that the method was called at all using the
+`Mockery::close` method. One way to do that is to add it to your `tearDown`
+method in PHPUnit.
+
+``` php
+
+public function tearDown()
+{
+    Mockery::close();
+}
+```
+
+The `expects()` method automatically sets up an expectation that the method call
+(and matching parameters) is called once and once only. You can choose to change
+this if you are expecting more calls.
+
+``` php
+$double->expects()->add($book)->twice();
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,36 @@ this if you are expecting more calls.
 $double->expects()->add($book)->twice();
 ```
 
+## Test Spies
+
+By default, all test doubles created with the `Mockery::mock` method will only
+accept calls that they have been configured to `allow` or `expect`. Sometimes we
+don't necessarily care about all of the calls that are going to be made to an
+object. To facilitate this, we can tell Mockery to ignore any calls it has been
+told to expect or allow. To do so, we can tell a test double
+`shouldIgnoreMissing`, or we can create the double using the `Mocker::spy`
+shortcut.
+
+``` php
+// $double = Mockery::mock()->shouldIgnoreMissing();
+$double = Mockery::spy(); 
+
+$double->foo(); // null
+$double->bar(); // null
+```
+
+Further to this, sometimes we want to have the object accept any call during the test execution
+and then verify the calls afterwards. For these purposes, we need our test
+double to act as a Spy. All mockery test doubles record the calls that are made
+to them for verification afterwards by default:
+
+``` php
+$double->baz(123);
+
+$double->shouldHaveReceived()->baz(123); // null
+$double->shouldHaveReceived()->baz(12345); // Uncaught Exception Mockery\Exception\InvalidCountException...
+```
+
 ## Documentation
 
 The current version can be seen at [docs.mockery.io](http://docs.mockery.io).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $double = Mockery::mock(BookRepository::class);
 ## Method Stubs
 
 A method stub is a mechanism for having your test double return canned responses
-to a certain method call. With stubs, you don't care how many times, if at all,
+to certain method calls. With stubs, you don't care how many times, if at all,
 the method is called. Stubs are used to provide indirect input to the system
 under test.
 
@@ -92,7 +92,8 @@ $double = Mockery::mock(BookRepository::class, [
 
 A Method call expectation is a mechanism to allow you to verify that a
 particular method has been called. You can specify the parameters and you can
-also specify how many times you expect it to be called.
+also specify how many times you expect it to be called. Method call expectations
+are used to verify indirect output of the system under test.
 
 ``` php
 $book = new Book();

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Mockery
 [![Latest Stable Version](https://poser.pugx.org/mockery/mockery/v/stable.png)](https://packagist.org/packages/mockery/mockery)
 [![Total Downloads](https://poser.pugx.org/mockery/mockery/downloads.png)](https://packagist.org/packages/mockery/mockery)
 
-
 Mockery is a simple yet flexible PHP mock object framework for use in unit testing
 with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a
 test double framework with a succinct API capable of clearly defining all possible
@@ -25,24 +24,66 @@ version
 composer require --dev mockery/mockery
 ```
 
-If you want to run the tests:
+## Test Doubles 
 
-```sh
-vendor/bin/phpunit
-```
-
-## Mock Objects
-
-In unit tests, mock objects simulate the behaviour of real objects. They are
+Test doubles (often called mocks) simulate the behaviour of real objects. They are
 commonly utilised to offer test isolation, to stand in for objects which do not
 yet exist, or to allow for the exploratory design of class APIs without
 requiring actual implementation up front.
 
-The benefits of a mock object framework are to allow for the flexible generation
-of such mock objects (and stubs). They allow the setting of expected method calls
-and return values using a flexible API which is capable of capturing every
+The benefits of a test double framework are to allow for the flexible generation
+and configuration of test doubles. They allow the setting of expected method calls
+and/or return values using a flexible API which is capable of capturing every
 possible real object behaviour in way that is stated as close as possible to a
-natural language description.
+natural language description. Use the `Mockery::mock` method to create a test
+double.
+
+``` php
+$double = Mockery::mock();
+```
+
+If you need Mockery to create a test double to satisfy a particular type hint,
+you can pass the type to the `mock` method.
+
+``` php
+class Book {}
+
+interface BookRepository {
+    function find($id): Book;
+    function findAll(): array;
+}
+
+$double = Mockery::mock(BookRepository::class);
+``` 
+
+## Method Stubs
+
+A method stub is a mechanism for having your test double return canned responses
+to a certain method call. 
+
+``` php
+$double->allows()->find(123)->andReturns(new Book());
+```
+
+If your stub doesn't require specific arguments, you can also use this shortcut
+for setting up multiple calls at once:
+
+``` php
+$double->allows([
+    "findAll" => [new Book(), new Book()], 
+]);
+```
+
+You can also use this shortcut, which creates a double and sets up some stubs in
+one call:
+
+``` php
+$double = Mockery::mock(BookRepository::class, [
+    "findAll" => [new Book(), new Book()], 
+]);
+```
+
+## Message Expectations
 
 ## Documentation
 

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -33,6 +33,7 @@ use Mockery\Generator\StringManipulation\Pass\InterfacePass;
 use Mockery\Generator\StringManipulation\Pass\MethodDefinitionPass;
 use Mockery\Generator\StringManipulation\Pass\RemoveBuiltinMethodsThatAreFinalPass;
 use Mockery\Generator\StringManipulation\Pass\RemoveUnserializeForInternalSerializableClassesPass;
+use Mockery\Generator\StringManipulation\Pass\AvoidMethodClashPass;
 use Mockery\Loader\EvalLoader;
 use Mockery\Loader\Loader;
 

--- a/library/Mockery/CompositeExpectation.php
+++ b/library/Mockery/CompositeExpectation.php
@@ -49,6 +49,17 @@ class CompositeExpectation implements ExpectationInterface
     }
 
     /**
+     * Set a return value, or sequential queue of return values
+     *
+     * @param mixed ...
+     * @return self
+     */
+    public function andReturns()
+    {
+        return call_user_func_array([$this, 'andReturn'], func_get_args());
+    }
+
+    /**
      * Intercept any expectation calls and direct against all expectations
      *
      * @param string $method

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -473,6 +473,17 @@ class Expectation implements ExpectationInterface
     }
 
     /**
+     * Set a return value, or sequential queue of return values
+     *
+     * @param mixed ...
+     * @return self
+     */
+    public function andReturns()
+    {
+        return call_user_func_array([$this, 'andReturn'], func_get_args());
+    }
+
+    /**
      * Return this mock, like a fluent interface
      *
      * @return self

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -456,6 +456,7 @@ class Expectation implements ExpectationInterface
      */
     public function withAnyArgs()
     {
+        $this->_noArgsExpectation = false;
         $this->_expectedArgs = array();
         return $this;
     }

--- a/library/Mockery/ExpectationInterface.php
+++ b/library/Mockery/ExpectationInterface.php
@@ -37,4 +37,9 @@ interface ExpectationInterface
      * @return self
      */
     public function andReturn();
+
+    /**
+     * @return self
+     */
+    public function andReturns();
 }

--- a/library/Mockery/ExpectsHigherOrderMessage.php
+++ b/library/Mockery/ExpectsHigherOrderMessage.php
@@ -1,4 +1,22 @@
 <?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
 
 namespace Mockery;
 

--- a/library/Mockery/ExpectsHigherOrderMessage.php
+++ b/library/Mockery/ExpectsHigherOrderMessage.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mockery;
+
+class ExpectsHigherOrderMessage extends HigherOrderMessage
+{
+    public function __construct(MockInterface $mock)
+    {
+        return parent::__construct($mock, "shouldReceive");
+    }
+    /**
+     * @return Mockery\Expectation
+     */
+    public function __call($method, $args)
+    {
+        $expectation = parent::__call($method, $args);
+
+        return $expectation->once();
+    }
+}

--- a/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
@@ -28,7 +28,7 @@ class AvoidMethodClashPass implements Pass
 {
     public function apply($code, MockConfiguration $config)
     {
-        $names = array_map(function ($method) { 
+        $names = array_map(function ($method) {
             return $method->getName();
         }, $config->getMethodsToMock());
 

--- a/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
@@ -30,13 +30,16 @@ class AvoidMethodClashPass implements Pass
     {
         $names = array_map(function ($method) { return $method->getName();}, $config->getMethodsToMock());
 
-        if (in_array("allows", $names)) {
+        foreach (["allows", "expects"] as $method) {
+            if (in_array($method, $names)) {
 
-            $code = preg_replace(
-                "#// start method allows.*// end method allows#ms", 
-                "",
-                $code
-            );
+                $code = preg_replace(
+                    "#// start method {$method}.*// end method {$method}#ms", 
+                    "",
+                    $code
+                );
+            }
+
         }
 
         return $code;

--- a/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace Mockery\Generator\StringManipulation\Pass;
+
+use Mockery\Generator\Method;
+use Mockery\Generator\Parameter;
+use Mockery\Generator\MockConfiguration;
+
+class AvoidMethodClashPass implements Pass
+{
+    public function apply($code, MockConfiguration $config)
+    {
+        $names = array_map(function ($method) { return $method->getName();}, $config->getMethodsToMock());
+
+        if (in_array("allows", $names)) {
+
+            $code = preg_replace(
+                "#// start method allows.*// end method allows#ms", 
+                "",
+                $code
+            );
+        }
+
+        return $code;
+    }
+}

--- a/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php
@@ -28,18 +28,18 @@ class AvoidMethodClashPass implements Pass
 {
     public function apply($code, MockConfiguration $config)
     {
-        $names = array_map(function ($method) { return $method->getName();}, $config->getMethodsToMock());
+        $names = array_map(function ($method) { 
+            return $method->getName();
+        }, $config->getMethodsToMock());
 
         foreach (["allows", "expects"] as $method) {
             if (in_array($method, $names)) {
-
                 $code = preg_replace(
-                    "#// start method {$method}.*// end method {$method}#ms", 
+                    "#// start method {$method}.*// end method {$method}#ms",
                     "",
                     $code
                 );
             }
-
         }
 
         return $code;

--- a/library/Mockery/Generator/StringManipulationGenerator.php
+++ b/library/Mockery/Generator/StringManipulationGenerator.php
@@ -31,6 +31,7 @@ use Mockery\Generator\StringManipulation\Pass\InterfacePass;
 use Mockery\Generator\StringManipulation\Pass\MethodDefinitionPass;
 use Mockery\Generator\StringManipulation\Pass\RemoveBuiltinMethodsThatAreFinalPass;
 use Mockery\Generator\StringManipulation\Pass\RemoveUnserializeForInternalSerializableClassesPass;
+use Mockery\Generator\StringManipulation\Pass\AvoidMethodClashPass;
 
 class StringManipulationGenerator implements Generator
 {
@@ -50,6 +51,7 @@ class StringManipulationGenerator implements Generator
             new ClassNamePass(),
             new InstanceMockPass(),
             new InterfacePass(),
+            new AvoidMethodClashPass(),
             new MethodDefinitionPass(),
             new RemoveUnserializeForInternalSerializableClassesPass(),
             new RemoveBuiltinMethodsThatAreFinalPass(),

--- a/library/Mockery/Generator/StringManipulationGenerator.php
+++ b/library/Mockery/Generator/StringManipulationGenerator.php
@@ -39,7 +39,7 @@ class StringManipulationGenerator implements Generator
 
     /**
      * Creates a new StringManipulationGenerator with the default passes
-     * 
+     *
      * @return StringManipulationGenerator
      */
     public static function withDefaultPasses()

--- a/library/Mockery/HigherOrderMessage.php
+++ b/library/Mockery/HigherOrderMessage.php
@@ -1,4 +1,22 @@
 <?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/blob/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
 
 namespace Mockery;
 

--- a/library/Mockery/HigherOrderMessage.php
+++ b/library/Mockery/HigherOrderMessage.php
@@ -20,7 +20,7 @@
 
 namespace Mockery;
 
-class HigherOrderMessage 
+class HigherOrderMessage
 {
     private $mock;
     private $method;

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -227,9 +227,17 @@ class Mock implements MockInterface
     /**
      * @return HigherOrderMessage
      */
-    public function allows()
+    public function allows(array $stubs = [])
     {
-        return $this->shouldReceive();
+        if (empty($stubs)) {
+            return $this->shouldReceive();
+        }
+
+        foreach ($stubs as $method => $returnValue) {
+            $this->shouldReceive($method)->andReturn($returnValue);
+        }
+
+        return $this;
     }
     // end method allows
 

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -22,6 +22,7 @@ namespace Mockery;
 
 use Mockery\HigherOrderMessage;
 use Mockery\MockInterface;
+use Mockery\ExpectsHigherOrderMessage;
 
 class Mock implements MockInterface
 {
@@ -232,6 +233,17 @@ class Mock implements MockInterface
     }
     // end method allows
 
+    // start method expects
+    /**
+     * @return ExpectsHigherOrderMessage
+     */
+    public function expects()
+    {
+        return new ExpectsHigherOrderMessage($this);
+    }
+    // end method expects
+     
+     
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -222,6 +222,16 @@ class Mock implements MockInterface
         return $lastExpectation;
     }
 
+    // start method allows
+    /**
+     * @return HigherOrderMessage
+     */
+    public function allows()
+    {
+        return $this->shouldReceive();
+    }
+    // end method allows
+
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -55,7 +55,7 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function generateSkipsAllowsMethodIfAlreadyExists()
     {
-        $stub = m::mock(ClassWithAllowsMethod::class);
+        $stub = m::mock("test\Mockery\ClassWithAllowsMethod");
 
         $stub->shouldReceive('allows')->andReturn(123);
 
@@ -68,14 +68,14 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
         $mock = m::mock();
         $mock->expects()->foo(123);
 
-        $this->setExpectedException(InvalidCountException::class);
+        $this->setExpectedException("Mockery\Exception\InvalidCountException");
         m::close();
     }
 
     /** @test */
     public function generateSkipsExpectsMethodIfAlreadyExists()
     {
-        $stub = m::mock(ClassWithExpectsMethod::class);
+        $stub = m::mock("test\Mockery\ClassWithExpectsMethod");
 
         $stub->shouldReceive('expects')->andReturn(123);
 

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -66,6 +66,15 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function expects_can_optionally_match_on_any_arguments()
+    {
+        $mock = m::mock();
+        $mock->allows()->foo()->withAnyArgs()->andReturns(123);
+
+        $this->assertEquals(123, $mock->foo(456, 789));
+    }
+
+    /** @test */
     public function generateSkipsAllowsMethodIfAlreadyExists()
     {
         $stub = m::mock("test\Mockery\ClassWithAllowsMethod");

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -41,7 +41,7 @@ class ClassWithExpectsMethod
     }
 }
 
-class SpyTest extends \PHPUnit_Framework_TestCase
+class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
     public function allowsSetsUpMethodStub()

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Mockery
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://github.com/padraic/mockery/master/LICENSE
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to padraic@php.net so we can send you a copy immediately.
+ *
+ * @category   Mockery
+ * @package    Mockery
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
+ * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
+ */
+
+namespace test\Mockery;
+
+use Mockery as m;
+use Mockery\Spy;
+
+class ClassWithAllowsMethod
+{
+    public function allows()
+    {
+        return 123;
+    }
+}
+
+class ClassWithExpectsMethod
+{
+    public function expects()
+    {
+        return 123;
+    }
+}
+
+class SpyTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function allowsSetsUpMethodStub()
+    {
+        $stub = m::mock();
+        $stub->allows()->foo(123)->andReturns(456);
+
+        $this->assertEquals(456, $stub->foo(123));
+    }
+
+    /** @test */
+    public function generateSkipsAllowsMethodIfAlreadyExists()
+    {
+        $stub = m::mock(ClassWithAllowsMethod::class);
+
+        $stub->shouldReceive('allows')->andReturn(123);
+
+        $this->assertEquals(123, $stub->allows());
+    }
+}

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -86,6 +86,17 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function callVerificationCountCanBeOverridenAfterExpects()
+    {
+        $mock = m::mock();
+        $mock->expects()->foo(123)->twice();
+
+        $mock->foo(123);
+        $this->setExpectedException("Mockery\Exception\InvalidCountException");
+        m::close();
+    }
+
+    /** @test */
     public function generateSkipsExpectsMethodIfAlreadyExists()
     {
         $stub = m::mock("test\Mockery\ClassWithExpectsMethod");

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -23,6 +23,7 @@ namespace test\Mockery;
 
 use Mockery as m;
 use Mockery\Spy;
+use Mockery\Exception\InvalidCountException;
 
 class ClassWithAllowsMethod
 {
@@ -59,5 +60,25 @@ class SpyTest extends \PHPUnit_Framework_TestCase
         $stub->shouldReceive('allows')->andReturn(123);
 
         $this->assertEquals(123, $stub->allows());
+    }
+
+    /** @test */
+    public function expectsSetsUpExpectationOfOneCall()
+    {
+        $mock = m::mock();
+        $mock->expects()->foo(123);
+
+        $this->setExpectedException(InvalidCountException::class);
+        m::close();
+    }
+
+    /** @test */
+    public function generateSkipsExpectsMethodIfAlreadyExists()
+    {
+        $stub = m::mock(ClassWithExpectsMethod::class);
+
+        $stub->shouldReceive('expects')->andReturn(123);
+
+        $this->assertEquals(123, $stub->expects());
     }
 }

--- a/tests/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Mockery/AllowsExpectsSyntaxTest.php
@@ -53,6 +53,19 @@ class AllowsExpectsSyntaxTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function allowsCanTakeAnArrayOfCalls()
+    {
+        $stub = m::mock();
+        $stub->allows([
+            "foo" => "bar",
+            "bar" => "baz",
+        ]);
+
+        $this->assertEquals("bar", $stub->foo());
+        $this->assertEquals("baz", $stub->bar());
+    }
+
+    /** @test */
     public function generateSkipsAllowsMethodIfAlreadyExists()
     {
         $stub = m::mock("test\Mockery\ClassWithAllowsMethod");


### PR DESCRIPTION
Further to #598 

## `expects()`  for setting up mock expectations

``` php
<?php

// old
$mock->shouldReceive("foo")->with(123)->andReturn(true)->once();
// or
$mock->shouldReceive()->foo(123)->andReturn(true)->once();

// new
$mock->expects()->foo(123)->andReturns(true);

```

## `allows()` for stubbing methods

``` php
<?php

// old
$stub->shouldReceive("foo")->with(123)->andReturn(true);
// or
$stub->shouldReceive()->foo(123)->andReturn(true);

// new
$stub->allows()->foo(123)->andReturns(true);

```

Despite the new methods on the mocks, this is fully BC as they are skipped if the class to be mocked contains matching methods.

I personally prefer this syntax, but I haven't put it to much use. It's always bothered me that `shouldReceive()` starts with `should`, when it doesn't actually form a mock expectation without the additional call to `->once()` or one of the other count methods.

My objectives here are not to remove the existing methods, but rather try and encourage the new methods going forward.

Todo

- [x] Basic docs in README
- [x] No args vs not caring about args