### PR TITLE
Fixed PHPUnit deprecation warning

### DIFF
--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -1948,7 +1948,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testAnExampleWithSomeExpectationAmendsOnCallCounts_PHPUnitTest()
     {
-        $service = $this->getMock('MyService2');
+        $service = $this->createMock('MyService2');
         $service->expects($this->once())->method('login')->with('user', 'pass')->will($this->returnValue(true));
         $service->expects($this->exactly(3))->method('hasBookmarksTagged')->with('php')
             ->will($this->onConsecutiveCalls(false, true, true));
@@ -2088,7 +2088,7 @@ class ExpectationTest extends MockeryTestCase
             'Received ' . get_class($mock) .
             '::quack(), ' . 'but no expectations were specified'
         );
-        
+
         $mock->quack();
     }
 


### PR DESCRIPTION
One test was not passing because of a deprecation warning on PHPUnit's old `getMock()` method.