### PR TITLE
Allowed mocking __clone method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
     "autoload": {
         "psr-0": { "Mockery": "library/" }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "MockeryTest\\": "tests/Mockery"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.9.x-dev"

--- a/library/Mockery/Generator/MockConfigurationBuilder.php
+++ b/library/Mockery/Generator/MockConfigurationBuilder.php
@@ -8,7 +8,6 @@ class MockConfigurationBuilder
     protected $blackListedMethods = array(
         '__call',
         '__callStatic',
-        '__clone',
         '__wakeup',
         '__set',
         '__get',

--- a/tests/Mockery/Fixtures/CloneInterface.php
+++ b/tests/Mockery/Fixtures/CloneInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace MockeryTest\Fixtures;
+
+interface CloneInterface
+{
+    public function __clone();
+}

--- a/tests/Mockery/Fixtures/MethodWithNullableReturnType.php
+++ b/tests/Mockery/Fixtures/MethodWithNullableReturnType.php
@@ -19,7 +19,7 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-namespace test\Mockery\Fixtures;
+namespace MockeryTest\Fixtures;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -152,6 +152,14 @@ class Mockery_MockTest extends MockeryTestCase
         $exception = Mockery::mock('Exception');
         $this->assertInstanceOf('Exception', $exception);
     }
+
+    public function testCanMockCloneMethod()
+    {
+        self::assertInstanceOf(
+            'MockeryTest\Fixtures\CloneInterface',
+            Mockery::mock('MockeryTest\Fixtures\CloneInterface')
+        );
+    }
 }
 
 

--- a/tests/Mockery/MockingNullableMethodsTest.php
+++ b/tests/Mockery/MockingNullableMethodsTest.php
@@ -23,7 +23,7 @@ namespace test\Mockery;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\Method;
-use test\Mockery\Fixtures\MethodWithNullableReturnType;
+use MockeryTest\Fixtures\MethodWithNullableReturnType;
 
 /**
  * @requires PHP 7.1.0RC3
@@ -37,8 +37,6 @@ class MockingNullableMethodsTest extends MockeryTestCase
 
     protected function setUp()
     {
-        require_once __DIR__."/Fixtures/MethodWithNullableReturnType.php";
-
         $this->container = new \Mockery\Container;
     }
 
@@ -52,7 +50,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNonNullableTypeToBeSet()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nonNullablePrimitive')->andReturn('a string');
         $mock->nonNullablePrimitive();
@@ -64,7 +62,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldNotAllowNonNullToBeNull()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nonNullablePrimitive')->andReturn(null);
         $mock->nonNullablePrimitive();
@@ -75,7 +73,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowPrimitiveNullableToBeNull()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nullablePrimitive')->andReturn(null);
         $mock->nullablePrimitive();
@@ -86,7 +84,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowPrimitiveNullabeToBeSet()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nullablePrimitive')->andReturn('a string');
         $mock->nullablePrimitive();
@@ -97,7 +95,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowSelfToBeSet()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nonNullableSelf')->andReturn(new MethodWithNullableReturnType());
         $mock->nonNullableSelf();
@@ -109,7 +107,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldNotAllowSelfToBeNull()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nonNullableSelf')->andReturn(null);
         $mock->nonNullableSelf();
@@ -120,7 +118,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullableSelfToBeSet()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nullableSelf')->andReturn(new MethodWithNullableReturnType());
         $mock->nullableSelf();
@@ -131,7 +129,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullableSelfToBeNull()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nullableSelf')->andReturn(null);
         $mock->nullableSelf();
@@ -142,7 +140,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowClassToBeSet()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nonNullableClass')->andReturn(new MethodWithNullableReturnType());
         $mock->nonNullableClass();
@@ -154,7 +152,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldNotAllowClassToBeNull()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nonNullableClass')->andReturn(null);
         $mock->nonNullableClass();
@@ -165,7 +163,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullalbeClassToBeSet()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nullableClass')->andReturn(new MethodWithNullableReturnType());
         $mock->nullableClass();
@@ -176,7 +174,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
      */
     public function itShouldAllowNullableClassToBeNull()
     {
-        $mock = $this->container->mock('test\Mockery\Fixtures\MethodWithNullableReturnType');
+        $mock = $this->container->mock('MockeryTest\Fixtures\MethodWithNullableReturnType');
 
         $mock->shouldReceive('nullableClass')->andReturn(null);
         $mock->nullableClass();


### PR DESCRIPTION
There does not seem to be any compelling reason why void magic methods such `__construct`, `__destruct` or `__clone` should not be mockable. However, this PR only seeks to add `__clone` support.

As a bonus, added test namespace (`MockeryTest`) to Composer autoloader to save manually including test fixtures (and other test files) in tests.

Resolves #669.