### PR TITLE
Uses a MatcherAbstracts string form in error output

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -25,6 +25,7 @@ use Mockery\Generator\MockConfigurationBuilder;
 use Mockery\Generator\StringManipulationGenerator;
 use Mockery\Loader\EvalLoader;
 use Mockery\Loader\Loader;
+use Mockery\Matcher\MatcherAbstract;
 
 class Mockery
 {
@@ -463,6 +464,10 @@ class Mockery
      */
     private static function formatArgument($argument, $depth = 0)
     {
+        if ($argument instanceOf MatcherAbstract) {
+            return (string) $argument;
+        }
+
         if (is_object($argument)) {
             return 'object(' . get_class($argument) . ')';
         }

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -20,6 +20,7 @@
  */
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Exception\InvalidCountException;
 
 class ExpectationTest extends MockeryTestCase
 {
@@ -2132,6 +2133,22 @@ class ExpectationTest extends MockeryTestCase
             ->andReturnNull();
         \Mockery::close();
     }
+
+    /** @test */
+    public function it_uses_a_matchers_to_string_method_in_the_exception_output()
+    {
+        $mock = Mockery::mock();
+
+        $mock->expects()->foo(Mockery::hasKey('foo'));
+
+        $this->setExpectedException(
+            InvalidCountException::class,
+            "Method foo(<HasKey[foo]>)"
+        );
+
+        Mockery::close();
+    }
+
 }
 
 interface IWater


### PR DESCRIPTION
Fixes #697 

I don't think it's a good idea to use `__toString` for arbitrary objects for now as we really can't guarantee a reasonable error message if we do so. Going forward, I plan to use sebastianbergmann/comparator or possibly just it's dependencies to provide better output.