### PR TITLE
replacing func_get_args with variadic parameters for better IDE-support

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -72,12 +72,12 @@ class Mockery
     /**
      * Static shortcut to \Mockery\Container::mock().
      *
+     * @param array $args
+     *
      * @return \Mockery\MockInterface
      */
-    public static function mock()
+    public static function mock(...$args)
     {
-        $args = func_get_args();
-
         return call_user_func_array(array(self::getContainer(), 'mock'), $args);
     }
 
@@ -85,34 +85,36 @@ class Mockery
      * Static and semantic shortcut for getting a mock from the container
      * and applying the spy's expected behavior into it.
      *
+     * @param array $args
+     *
      * @return \Mockery\MockInterface
      */
-    public static function spy()
+    public static function spy(...$args)
     {
-        $args = func_get_args();
         return call_user_func_array(array(self::getContainer(), 'mock'), $args)->shouldIgnoreMissing();
     }
 
     /**
      * Static and Semantic shortcut to \Mockery\Container::mock().
      *
+     * @param array $args
+     *
      * @return \Mockery\MockInterface
      */
-    public static function instanceMock()
+    public static function instanceMock(...$args)
     {
-        $args = func_get_args();
-
         return call_user_func_array(array(self::getContainer(), 'mock'), $args);
     }
 
     /**
      * Static shortcut to \Mockery\Container::mock(), first argument names the mock.
      *
+     * @param array $args
+     *
      * @return \Mockery\MockInterface
      */
-    public static function namedMock()
+    public static function namedMock(...$args)
     {
-        $args = func_get_args();
         $name = array_shift($args);
 
         $builder = new MockConfigurationBuilder();
@@ -306,11 +308,13 @@ class Mockery
     /**
      * Return instance of DUCKTYPE matcher.
      *
+     * @param array $args
+     *
      * @return \Mockery\Matcher\Ducktype
      */
-    public static function ducktype()
+    public static function ducktype(...$args)
     {
-        return new \Mockery\Matcher\Ducktype(func_get_args());
+        return new \Mockery\Matcher\Ducktype($args);
     }
 
     /**
@@ -329,11 +333,13 @@ class Mockery
     /**
      * Return instance of CONTAINS matcher.
      *
+     * @param array $args
+     *
      * @return \Mockery\Matcher\Contains
      */
-    public static function contains()
+    public static function contains(...$args)
     {
-        return new \Mockery\Matcher\Contains(func_get_args());
+        return new \Mockery\Matcher\Contains($args);
     }
 
     /**
@@ -399,21 +405,25 @@ class Mockery
     /**
      * Return instance of ANYOF matcher.
      *
+     * @param array $args
+     *
      * @return \Mockery\Matcher\AnyOf
      */
-    public static function anyOf()
+    public static function anyOf(...$args)
     {
-        return new \Mockery\Matcher\AnyOf(func_get_args());
+        return new \Mockery\Matcher\AnyOf($args);
     }
 
     /**
      * Return instance of NOTANYOF matcher.
      *
+     * @param array $args
+     *
      * @return \Mockery\Matcher\NotAnyOf
      */
-    public static function notAnyOf()
+    public static function notAnyOf(...$args)
     {
-        return new \Mockery\Matcher\NotAnyOf(func_get_args());
+        return new \Mockery\Matcher\NotAnyOf($args);
     }
 
     /**

--- a/library/Mockery/CompositeExpectation.php
+++ b/library/Mockery/CompositeExpectation.php
@@ -43,9 +43,9 @@ class CompositeExpectation implements ExpectationInterface
     /**
      * @param mixed ...
      */
-    public function andReturn()
+    public function andReturn(...$args)
     {
-        return $this->__call(__FUNCTION__, func_get_args());
+        return $this->__call(__FUNCTION__, $args);
     }
 
     /**
@@ -54,9 +54,9 @@ class CompositeExpectation implements ExpectationInterface
      * @param mixed ...
      * @return self
      */
-    public function andReturns()
+    public function andReturns(...$args)
     {
-        return call_user_func_array([$this, 'andReturn'], func_get_args());
+        return call_user_func_array([$this, 'andReturn'], $args);
     }
 
     /**
@@ -115,9 +115,8 @@ class CompositeExpectation implements ExpectationInterface
      * @param mixed ...
      * @return \Mockery\Expectation
      */
-    public function shouldReceive()
+    public function shouldReceive(...$args)
     {
-        $args = func_get_args();
         reset($this->_expectations);
         $first = current($this->_expectations);
         return call_user_func_array(array($first->getMock(), 'shouldReceive'), $args);

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -85,17 +85,17 @@ class Container
      * names or partials - just so long as it's something that can be mocked.
      * I'll refactor it one day so it's easier to follow.
      *
+     * @param array $args
+     *
+     * @return Mock
      * @throws Exception\RuntimeException
-     * @throws Exception
-     * @return \Mockery\Mock
      */
-    public function mock()
+    public function mock(...$args)
     {
         $expectationClosure = null;
         $quickdefs = array();
         $constructorArgs = null;
         $blocks = array();
-        $args = func_get_args();
 
         if (count($args) > 1) {
             $finalArg = end($args);

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -374,12 +374,12 @@ class Expectation implements ExpectationInterface
     /**
      * Expected argument setter for the expectation
      *
-     * @param mixed ...
+     * @param mixed[] ...
      * @return self
      */
-    public function with()
+    public function with(...$args)
     {
-        return $this->withArgs(func_get_args());
+        return $this->withArgs($args);
     }
 
     /**
@@ -454,24 +454,24 @@ class Expectation implements ExpectationInterface
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed ...
+     * @param mixed[] ...
      * @return self
      */
-    public function andReturn()
+    public function andReturn(...$args)
     {
-        $this->_returnQueue = func_get_args();
+        $this->_returnQueue = $args;
         return $this;
     }
 
     /**
      * Set a return value, or sequential queue of return values
      *
-     * @param mixed ...
+     * @param mixed[] ...
      * @return self
      */
-    public function andReturns()
+    public function andReturns(...$args)
     {
-        return call_user_func_array([$this, 'andReturn'], func_get_args());
+        return call_user_func_array([$this, 'andReturn'], $args);
     }
 
     /**
@@ -501,12 +501,12 @@ class Expectation implements ExpectationInterface
      * values. The arguments passed to the expected method are passed to the
      * closures as parameters.
      *
-     * @param callable ...
+     * @param callable[] $args
      * @return self
      */
-    public function andReturnUsing()
+    public function andReturnUsing(...$args)
     {
-        $this->_closureQueue = func_get_args();
+        $this->_closureQueue = $args;
         return $this;
     }
 
@@ -582,13 +582,11 @@ class Expectation implements ExpectationInterface
      * Register values to be set to a public property each time this expectation occurs
      *
      * @param string $name
-     * @param mixed $value
+     * @param array $values
      * @return self
      */
-    public function andSet($name, $value)
+    public function andSet($name, ...$values)
     {
-        $values = func_get_args();
-        array_shift($values);
         $this->_setQueue[$name] = $values;
         return $this;
     }
@@ -620,7 +618,7 @@ class Expectation implements ExpectationInterface
      * Indicates the number of times this expectation should occur
      *
      * @param int $limit
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @return self
      */
     public function times($limit = null)

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -133,7 +133,7 @@ class Mock implements MockInterface
     /**
      * Just a local cache for this mock's target's methods
      *
-     * @var ReflectionMethod[]
+     * @var \ReflectionMethod[]
      */
     protected static $_mockery_methods;
 
@@ -177,16 +177,17 @@ class Mock implements MockInterface
     /**
      * Set expected method calls
      *
-     * @param null|string $methodName,... one or many methods that are expected to be called in this mock
+     * @param array $methodNames,... one or many methods that are expected to be called in this mock
+     *
      * @return \Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
      */
-    public function shouldReceive($methodName = null)
+    public function shouldReceive(...$methodNames)
     {
-        if ($methodName === null) {
+        if (count($methodNames) === 0) {
             return new HigherOrderMessage($this, "shouldReceive");
         }
 
-        foreach (func_get_args() as $method) {
+        foreach ($methodNames as $method) {
             if ("" == $method) {
                 throw new \InvalidArgumentException("Received empty method name");
             }
@@ -199,7 +200,7 @@ class Mock implements MockInterface
         $allowMockingProtectedMethods = $this->_mockery_allowMockingProtectedMethods;
 
         $lastExpectation = \Mockery::parseShouldReturnArgs(
-            $this, func_get_args(), function ($method) use ($self, $nonPublicMethods, $allowMockingProtectedMethods) {
+            $this, $methodNames, function ($method) use ($self, $nonPublicMethods, $allowMockingProtectedMethods) {
                 $rm = $self->mockery_getMethod($method);
                 if ($rm) {
                     if ($rm->isPrivate()) {
@@ -250,21 +251,20 @@ class Mock implements MockInterface
         return new ExpectsHigherOrderMessage($this);
     }
     // end method expects
-     
-     
+
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param null|string $methodName,... one or many methods that are expected not to be called in this mock
+     * @param array $methodNames one or many methods that are expected not to be called in this mock
      * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
      */
-    public function shouldNotReceive($methodName = null)
+    public function shouldNotReceive(...$methodNames)
     {
-        if ($methodName === null) {
+        if (count($methodNames) === 0) {
             return new HigherOrderMessage($this, "shouldNotReceive");
         }
 
-        $expectation = call_user_func_array(array($this, 'shouldReceive'), func_get_args());
+        $expectation = call_user_func_array(array($this, 'shouldReceive'), $methodNames);
         $expectation->never();
         return $expectation;
     }

--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -37,18 +37,19 @@ interface MockInterface
     /**
      * Set expected method calls
      *
-     * @param null|string $methodName,... one or many methods that are expected to be called in this mock
-     * @return mixed
+     * @param array ...$methodNames one or many methods that are expected to be called in this mock
+     *
+     * @return \Mockery\ExpectationInterface|\Mockery\HigherOrderMessage
      */
-    public function shouldReceive($methodName = null);
+    public function shouldReceive(...$methodNames);
 
     /**
      * Shortcut method for setting an expectation that a method should not be called.
      *
-     * @param null|string $methodName,... one or many methods that are expected not to be called in this mock
-     * @return mixed
+     * @param array $methodNames one or many methods that are expected not to be called in this mock
+     * @return \Mockery\Expectation|\Mockery\HigherOrderMessage
      */
-    public function shouldNotReceive($methodName);
+    public function shouldNotReceive(...$methodNames);
 
     /**
      * Allows additional methods to be mocked that do not explicitly exist on mocked class

--- a/library/Mockery/VerificationDirector.php
+++ b/library/Mockery/VerificationDirector.php
@@ -36,9 +36,9 @@ class VerificationDirector
         return $this->receivedMethodCalls->verify($this->expectation);
     }
 
-    public function with()
+    public function with(...$args)
     {
-        return $this->cloneApplyAndVerify("with", func_get_args());
+        return $this->cloneApplyAndVerify("with", $args);
     }
 
     public function withArgs($args)

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -22,20 +22,20 @@ use Mockery\Matcher\NoArgs;
  */
 
 if (!function_exists("mock")) {
-    function mock() {
-        return call_user_func_array([Mockery::class, "mock"], func_get_args());
+    function mock(...$args) {
+        return call_user_func_array([Mockery::class, "mock"], $args);
     }
 }
 
 if (!function_exists("spy")) {
-    function spy() {
-        return call_user_func_array([Mockery::class, "spy"], func_get_args());
+    function spy(...$args) {
+        return call_user_func_array([Mockery::class, "spy"], $args);
     }
 }
 
 if (!function_exists("namedMock")) {
-    function namedMock() {
-        return call_user_func_array([Mockery::class, "namedMock"], func_get_args());
+    function namedMock(...$args) {
+        return call_user_func_array([Mockery::class, "namedMock"], $args);
     }
 }
 

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1745,9 +1745,9 @@ class EmptyConstructorTest
 {
     public $numberOfConstructorArgs;
 
-    public function __construct()
+    public function __construct(...$args)
     {
-        $this->numberOfConstructorArgs = count(func_get_args());
+        $this->numberOfConstructorArgs = count($args);
     }
 
     public function foo()


### PR DESCRIPTION
Methods like "shouldReceive" may receive an arbitrary number of arguments. Yet according to the methods' signature no arguments are allowed. So many IDEs like PHPStorm assume a bug when the method is used as intended. The solution to this problem are variadic parameters, which are available since php5.6. I assume that at least 5.6 is required for the current master of Mockery. If 5.6 is the minimum requirement of the current stable version as well I will provide a patch for that version, too.