### PR TITLE
Fixing performance issue with uniqid

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -834,7 +834,7 @@ class Mock implements MockInterface
     private function hasMethodOverloadingInParentClass()
     {
         // if there's __call any name would be callable
-        return is_callable('parent::' . uniqid(__FUNCTION__));
+        return is_callable('parent::aFunctionNameThatNoOneWouldEverUseInRealLife12345');
     }
 
     /**


### PR DESCRIPTION
I was doing some profiling and found that 15% of all of our test time was taken in `uniqid`. This removes the usage of uniqid because it should not be truly needed. This caused this part of the code to go from taking 97 seconds to taking 0.2 seconds.

Note: Our tests are making 50k calls to `hasMethodOverloadingInParentClass`, via `_mockery_handleMethodCall` 

This is also when run on HHVM 3.14.5. Mainline PHP may or may not have a faster implementation.

## Before
<img width="725" alt="screen shot 2017-02-23 at 5 25 15 pm" src="https://cloud.githubusercontent.com/assets/46909/23286535/1e83bef2-f9ed-11e6-91c4-b4cd50c3fcfe.png">

## After
<img width="826" alt="screen shot 2017-02-23 at 5 25 25 pm" src="https://cloud.githubusercontent.com/assets/46909/23286534/1e826be2-f9ed-11e6-9b91-a48111ebc00a.png">
