### PR TITLE
PhpStorm and magic __call methods

### DIFF
--- a/library/Mockery/ExpectationInterface.php
+++ b/library/Mockery/ExpectationInterface.php
@@ -21,6 +21,16 @@
 
 namespace Mockery;
 
+/**
+ * @method Expectation once()
+ * @method Expectation zeroOrMoreTimes()
+ * @method Expectation twice()
+ * @method Expectation times(int $limit)
+ * @method Expectation never()
+ * @method Expectation atLeast()
+ * @method Expectation atMost()
+ * @method Expectation between()
+ */
 interface ExpectationInterface
 {
     /**


### PR DESCRIPTION
Problem: PhpStorm not always can follow to __call method and inspector may yell that it can not find method.
![before](https://cloud.githubusercontent.com/assets/1012620/23702495/d17d1838-03fb-11e7-8c27-b4ae670fffa6.jpg)

Solution: Add PHPDoc with methods descriptions
![after](https://cloud.githubusercontent.com/assets/1012620/23702501/d6e5d4e0-03fb-11e7-8539-88e97b1b5183.jpg)
