### PR TITLE
Avoid warnings in PHP 7.2 from count()

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -310,7 +310,8 @@ class Expectation implements ExpectationInterface
         if (empty($this->_expectedArgs) && !$this->_noArgsExpectation) {
             return true;
         }
-        if (count($args) !== count($this->_expectedArgs)) {
+        $expected = is_array($this->_expectedArgs) ? count($this->_expectedArgs) : 0;
+        if (count($args) !== $expected) {
             return false;
         }
         $argCount = count($args);


### PR DESCRIPTION
PHP 7.2 introduces a warning when you try to count something that isn't countable. Sometimes `$this->_expectedArgs` is null:

```
count(): Parameter must be an array or an object that implements Countable

/tmp/vendor/mockery/mockery/library/Mockery/Expectation.php:313
/tmp/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:173
/tmp/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:138
/tmp/vendor/mockery/mockery/library/Mockery/ExpectationDirector.php:91
/tmp/test.php:7
```