### PR TITLE
Include only call count constrained expectations in expectation count

### DIFF
--- a/library/Mockery/ExpectationDirector.php
+++ b/library/Mockery/ExpectationDirector.php
@@ -213,6 +213,12 @@ class ExpectationDirector
      */
     public function getExpectationCount()
     {
-        return count($this->getExpectations());
+        $count = 0;
+        foreach ($this->getExpectations() as $expectation) {
+            if ($expectation->isCallCountConstrained()) {
+                $count++;
+            }
+        }
+        return $count;
     }
 }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -476,7 +476,7 @@ class ContainerTest extends MockeryTestCase
     public function testCanMockClassUsingMagicCallMethodsInPlaceOfNormalMethods()
     {
         $m = Mockery::mock('Gateway');
-        $m->shouldReceive('iDoSomethingReallyCoolHere');
+        $m->shouldReceive('iDoSomethingReallyCoolHere')->once();
         $m->iDoSomethingReallyCoolHere();
     }
 
@@ -486,7 +486,7 @@ class ContainerTest extends MockeryTestCase
     public function testCanPartialMockObjectUsingMagicCallMethodsInPlaceOfNormalMethods()
     {
         $m = Mockery::mock(new Gateway);
-        $m->shouldReceive('iDoSomethingReallyCoolHere');
+        $m->shouldReceive('iDoSomethingReallyCoolHere')->once();
         $m->iDoSomethingReallyCoolHere();
     }
 
@@ -913,7 +913,7 @@ class ContainerTest extends MockeryTestCase
     {
         $m = mock();
         $m->shouldReceive('foo')->andReturn('bar');
-        $this->assertEquals(1, Mockery::getContainer()->mockery_getExpectationCount());
+        $this->assertEquals(0, Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     public function testMethodsReturningParamsByReferenceDoesNotErrorOut()

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -340,7 +340,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testExpectsNoArguments()
     {
-        $this->mock->shouldReceive('foo')->withNoArgs();
+        $this->mock->shouldReceive('foo')->withNoArgs()->once();
         $this->mock->foo();
     }
 
@@ -356,7 +356,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testExpectsArgumentsArray()
     {
-        $this->mock->shouldReceive('foo')->withArgs(array(1, 2));
+        $this->mock->shouldReceive('foo')->withArgs(array(1, 2))->once();
         $this->mock->foo(1, 2);
     }
 
@@ -416,7 +416,7 @@ class ExpectationTest extends MockeryTestCase
         $closure = function ($odd, $even) {
             return ($odd % 2 != 0) && ($even % 2 == 0);
         };
-        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->shouldReceive('foo')->withArgs($closure)->once();
         $this->mock->foo(1, 2);
     }
 
@@ -442,7 +442,7 @@ class ExpectationTest extends MockeryTestCase
             }
             return $result;
         };
-        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->shouldReceive('foo')->withArgs($closure)->once();
         $this->mock->foo(1, 4);
     }
 
@@ -455,7 +455,7 @@ class ExpectationTest extends MockeryTestCase
             }
             return $result;
         };
-        $this->mock->shouldReceive('foo')->withArgs($closure);
+        $this->mock->shouldReceive('foo')->withArgs($closure)->once();
         $this->mock->foo(1, 4, 5);
     }
 
@@ -478,7 +478,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testExpectsAnyArguments()
     {
-        $this->mock->shouldReceive('foo')->withAnyArgs();
+        $this->mock->shouldReceive('foo')->withAnyArgs()->times(3);
         $this->mock->foo();
         $this->mock->foo(1);
         $this->mock->foo(1, 'k', new stdClass);
@@ -486,7 +486,7 @@ class ExpectationTest extends MockeryTestCase
 
     public function testExpectsArgumentMatchingObjectType()
     {
-        $this->mock->shouldReceive('foo')->with('\stdClass');
+        $this->mock->shouldReceive('foo')->with('\stdClass')->once();
         $this->mock->foo(new stdClass);
     }
 
@@ -781,8 +781,8 @@ class ExpectationTest extends MockeryTestCase
 
     public function testOrderedCallsWithoutError()
     {
-        $this->mock->shouldReceive('foo')->ordered();
-        $this->mock->shouldReceive('bar')->ordered();
+        $this->mock->shouldReceive('foo')->ordered()->once();
+        $this->mock->shouldReceive('bar')->ordered()->once();
         $this->mock->foo();
         $this->mock->bar();
     }
@@ -801,8 +801,8 @@ class ExpectationTest extends MockeryTestCase
 
     public function testDifferentArgumentsAndOrderingsPassWithoutException()
     {
-        $this->mock->shouldReceive('foo')->with(1)->ordered();
-        $this->mock->shouldReceive('foo')->with(2)->ordered();
+        $this->mock->shouldReceive('foo')->with(1)->ordered()->once();
+        $this->mock->shouldReceive('foo')->with(2)->ordered()->once();
         $this->mock->foo(1);
         $this->mock->foo(2);
     }
@@ -821,9 +821,9 @@ class ExpectationTest extends MockeryTestCase
 
     public function testUnorderedCallsIgnoredForOrdering()
     {
-        $this->mock->shouldReceive('foo')->with(1)->ordered();
-        $this->mock->shouldReceive('foo')->with(2);
-        $this->mock->shouldReceive('foo')->with(3)->ordered();
+        $this->mock->shouldReceive('foo')->with(1)->ordered()->once();
+        $this->mock->shouldReceive('foo')->with(2)->times(3);
+        $this->mock->shouldReceive('foo')->with(3)->ordered()->once();
         $this->mock->foo(2);
         $this->mock->foo(1);
         $this->mock->foo(2);
@@ -833,8 +833,8 @@ class ExpectationTest extends MockeryTestCase
 
     public function testOrderingOfDefaultGrouping()
     {
-        $this->mock->shouldReceive('foo')->ordered();
-        $this->mock->shouldReceive('bar')->ordered();
+        $this->mock->shouldReceive('foo')->ordered()->once();
+        $this->mock->shouldReceive('bar')->ordered()->once();
         $this->mock->foo();
         $this->mock->bar();
     }
@@ -853,10 +853,10 @@ class ExpectationTest extends MockeryTestCase
 
     public function testOrderingUsingNumberedGroups()
     {
-        $this->mock->shouldReceive('start')->ordered(1);
-        $this->mock->shouldReceive('foo')->ordered(2);
-        $this->mock->shouldReceive('bar')->ordered(2);
-        $this->mock->shouldReceive('final')->ordered();
+        $this->mock->shouldReceive('start')->ordered(1)->once();
+        $this->mock->shouldReceive('foo')->ordered(2)->once();
+        $this->mock->shouldReceive('bar')->ordered(2)->twice();
+        $this->mock->shouldReceive('final')->ordered()->once();
         $this->mock->start();
         $this->mock->bar();
         $this->mock->foo();
@@ -866,10 +866,10 @@ class ExpectationTest extends MockeryTestCase
 
     public function testOrderingUsingNamedGroups()
     {
-        $this->mock->shouldReceive('start')->ordered('start');
-        $this->mock->shouldReceive('foo')->ordered('foobar');
-        $this->mock->shouldReceive('bar')->ordered('foobar');
-        $this->mock->shouldReceive('final')->ordered();
+        $this->mock->shouldReceive('start')->ordered('start')->once();
+        $this->mock->shouldReceive('foo')->ordered('foobar')->once();
+        $this->mock->shouldReceive('bar')->ordered('foobar')->twice();
+        $this->mock->shouldReceive('final')->ordered()->once();
         $this->mock->start();
         $this->mock->bar();
         $this->mock->foo();
@@ -923,9 +923,9 @@ class ExpectationTest extends MockeryTestCase
 
     public function testEnsuresOrderingIsNotCrossMockByDefault()
     {
-        $this->mock->shouldReceive('foo')->ordered();
+        $this->mock->shouldReceive('foo')->ordered()->once();
         $mock2 = mock('bar');
-        $mock2->shouldReceive('bar')->ordered();
+        $mock2->shouldReceive('bar')->ordered()->once();
         $mock2->bar();
         $this->mock->foo();
     }
@@ -1020,8 +1020,8 @@ class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')->ordered()->byDefault();
         $this->mock->shouldReceive('bar')->ordered()->byDefault();
-        $this->mock->shouldReceive('bar')->ordered();
-        $this->mock->shouldReceive('foo')->ordered();
+        $this->mock->shouldReceive('bar')->ordered()->once();
+        $this->mock->shouldReceive('foo')->ordered()->once();
         $this->mock->bar();
         $this->mock->foo();
     }

--- a/tests/Mockery/MockTest.php
+++ b/tests/Mockery/MockTest.php
@@ -28,7 +28,7 @@ class Mockery_MockTest extends MockeryTestCase
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $m = mock();
         $m->shouldReceive("test123")->andReturn(true);
-        assertThat($m->test123(), equalTo(true));
+        $this->assertTrue($m->test123());
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
     }
 
@@ -38,7 +38,7 @@ class Mockery_MockTest extends MockeryTestCase
         $m = mock('ExampleClassForTestingNonExistentMethod');
         $m->shouldAllowMockingMethod('testSomeNonExistentMethod');
         $m->shouldReceive("testSomeNonExistentMethod")->andReturn(true);
-        assertThat($m->testSomeNonExistentMethod(), equalTo(true));
+        $this->assertTrue($m->testSomeNonExistentMethod());
         \Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
     }
 
@@ -105,24 +105,24 @@ class Mockery_MockTest extends MockeryTestCase
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
-        assertThat(nullValue($mock->foo()));
+        $this->assertNull($mock->foo());
         $mock->shouldReceive('bar')->passthru();
-        assertThat($mock->bar(), equalTo('bar'));
+        $this->assertSame('bar', $mock->bar());
     }
 
     public function testShouldIgnoreMissingCallingNonExistentMethods()
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
         $mock = mock('ClassWithMethods')->shouldIgnoreMissing();
-        assertThat(nullValue($mock->foo()));
-        assertThat(nullValue($mock->bar()));
-        assertThat(nullValue($mock->nonExistentMethod()));
+        $this->assertNull($mock->foo());
+        $this->assertNull($mock->bar());
+        $this->assertNull($mock->nonExistentMethod());
 
         $mock->shouldReceive(array('foo' => 'new_foo', 'nonExistentMethod' => 'result'));
         $mock->shouldReceive('bar')->passthru();
-        assertThat($mock->foo(), equalTo('new_foo'));
-        assertThat($mock->bar(), equalTo('bar'));
-        assertThat($mock->nonExistentMethod(), equalTo('result'));
+        $this->assertSame('new_foo', $mock->foo());
+        $this->assertSame('bar', $mock->bar());
+        $this->assertSame('result', $mock->nonExistentMethod());
     }
 
     public function testCanMockException()

--- a/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
+++ b/tests/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php
@@ -30,6 +30,8 @@ class GeneratorTest extends MockeryTestCase
     {
         $container = new \Mockery\Container;
         $mock = $container->mock('Mockery\Tests\Evenement_EventEmitter', 'Mockery\Tests\Chatroulette_ConnectionInterface');
+
+        $this->assertInstanceOf('Mockery\Tests\Evenement_EventEmitterInterface', $mock);
     }
 }
 

--- a/tests/Mockery/MockingNullableMethodsTest.php
+++ b/tests/Mockery/MockingNullableMethodsTest.php
@@ -49,7 +49,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nonNullablePrimitive')->andReturn('a string');
+        $mock->shouldReceive('nonNullablePrimitive')->andReturn('a string')->once();
         $mock->nonNullablePrimitive();
     }
 
@@ -61,7 +61,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nonNullablePrimitive')->andReturn(null);
+        $mock->shouldReceive('nonNullablePrimitive')->andReturn(null)->once();
         $mock->nonNullablePrimitive();
     }
 
@@ -72,7 +72,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nullablePrimitive')->andReturn(null);
+        $mock->shouldReceive('nullablePrimitive')->andReturn(null)->once();
         $mock->nullablePrimitive();
     }
 
@@ -83,7 +83,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nullablePrimitive')->andReturn('a string');
+        $mock->shouldReceive('nullablePrimitive')->andReturn('a string')->once();
         $mock->nullablePrimitive();
     }
 
@@ -94,7 +94,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nonNullableSelf')->andReturn(new MethodWithNullableReturnType());
+        $mock->shouldReceive('nonNullableSelf')->andReturn(new MethodWithNullableReturnType())->once();
         $mock->nonNullableSelf();
     }
 
@@ -106,7 +106,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nonNullableSelf')->andReturn(null);
+        $mock->shouldReceive('nonNullableSelf')->andReturn(null)->once();
         $mock->nonNullableSelf();
     }
 
@@ -117,7 +117,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nullableSelf')->andReturn(new MethodWithNullableReturnType());
+        $mock->shouldReceive('nullableSelf')->andReturn(new MethodWithNullableReturnType())->once();
         $mock->nullableSelf();
     }
 
@@ -128,7 +128,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nullableSelf')->andReturn(null);
+        $mock->shouldReceive('nullableSelf')->andReturn(null)->once();
         $mock->nullableSelf();
     }
 
@@ -139,7 +139,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nonNullableClass')->andReturn(new MethodWithNullableReturnType());
+        $mock->shouldReceive('nonNullableClass')->andReturn(new MethodWithNullableReturnType())->once();
         $mock->nonNullableClass();
     }
 
@@ -151,7 +151,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nonNullableClass')->andReturn(null);
+        $mock->shouldReceive('nonNullableClass')->andReturn(null)->once();
         $mock->nonNullableClass();
     }
 
@@ -162,7 +162,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nullableClass')->andReturn(new MethodWithNullableReturnType());
+        $mock->shouldReceive('nullableClass')->andReturn(new MethodWithNullableReturnType())->once();
         $mock->nullableClass();
     }
 
@@ -173,7 +173,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithNullableReturnType");
 
-        $mock->shouldReceive('nullableClass')->andReturn(null);
+        $mock->shouldReceive('nullableClass')->andReturn(null)->once();
         $mock->nullableClass();
     }
 
@@ -182,7 +182,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $double= \Mockery::mock(MethodWithNullableReturnType::class);
 
-        $double->shouldReceive("nullableClass")->andReturnNull();
+        $double->shouldReceive("nullableClass")->andReturnNull()->once();
 
         $this->assertNull($double->nullableClass());
     }
@@ -192,7 +192,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $double= \Mockery::mock(MethodWithNullableReturnType::class);
 
-        $double->shouldReceive("nullableString")->andReturnNull();
+        $double->shouldReceive("nullableString")->andReturnNull()->once();
 
         $this->assertNull($double->nullableString());
     }
@@ -202,7 +202,7 @@ class MockingNullableMethodsTest extends MockeryTestCase
     {
         $double= \Mockery::mock(MethodWithNullableReturnType::class);
 
-        $double->shouldReceive("nullableInt")->andReturnNull();
+        $double->shouldReceive("nullableInt")->andReturnNull()->once();
 
         $this->assertNull($double->nullableInt());
     }

--- a/tests/Mockery/MockingParameterAndReturnTypesTest.php
+++ b/tests/Mockery/MockingParameterAndReturnTypesTest.php
@@ -95,7 +95,7 @@ class MockingParameterAndReturnTypesTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\TestWithParameterAndReturnType");
 
-        $mock->shouldReceive("withScalarParameters");
+        $mock->shouldReceive("withScalarParameters")->once();
         $mock->withScalarParameters(1, 1.0, true, 'string');
     }
 

--- a/tests/Mockery/MockingVoidMethodsTest.php
+++ b/tests/Mockery/MockingVoidMethodsTest.php
@@ -47,7 +47,7 @@ class MockingVoidMethodsTest extends MockeryTestCase
     {
         $mock = mock("test\Mockery\Fixtures\MethodWithVoidReturnType");
 
-        $mock->shouldReceive("foo");
+        $mock->shouldReceive("foo")->once();
         $mock->foo();
     }
 }


### PR DESCRIPTION
An attempt at #249, not sure if it's the right approach.

The `once()` calls in tests are to make them not be risky.