### PR TITLE
allow code completion for andReturnSelf()

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -527,7 +527,7 @@ class Expectation implements ExpectationInterface
     /**
      * Return this mock, like a fluent interface
      *
-     * @return self
+     * @return self|LegacyMockInterface|MockInterface
      */
     public function andReturnSelf()
     {


### PR DESCRIPTION
This PR allows code completion for the `andReturnSelf()`-method by adding the `MockInterface` as return type.
It uses the same return types as the `getMock()`-method.

---

For this example, code completion would now the way we'd expect:

```php
$builder->shouldReceive('addThis')
	->andReturnSelf()
	->shouldReceive('addThat')
	->with(13)
	->andReturnSelf()
	->shouldReceive('get')
	->with(23)
	->andReturn($object);
```
_updated to add parameter example_