### PR TITLE
PHP 8.2 | Fix "Use of "parent" in callables is deprecated" notice

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -614,7 +614,7 @@ class Mock implements MockInterface
     public function __isset($name)
     {
         if (false === stripos($name, '_mockery_') && get_parent_class($this) && method_exists(get_parent_class($this), '__isset')) {
-            return call_user_func('parent::__isset', $name);
+            return call_user_func(get_parent_class($this) . '::__isset', $name);
         }
 
         return false;
@@ -637,9 +637,9 @@ class Mock implements MockInterface
     public function mockery_callSubjectMethod($name, array $args)
     {
         if (!method_exists($this, $name) && get_parent_class($this) && method_exists(get_parent_class($this), '__call')) {
-            return call_user_func('parent::__call', $name, $args);
+            return call_user_func(get_parent_class($this) . '::__call', $name, $args);
         }
-        return call_user_func_array('parent::' . $name, $args);
+        return call_user_func_array(get_parent_class($this) . '::' . $name, $args);
     }
 
     /**
@@ -858,7 +858,7 @@ class Mock implements MockInterface
                 // noop - there is no hasPrototype method
             }
 
-            return call_user_func_array("parent::$method", $args);
+            return call_user_func_array(get_parent_class($this) . '::' . $method, $args);
         }
 
         $handler = $this->_mockery_findExpectedMethodHandler($method);
@@ -877,18 +877,18 @@ class Mock implements MockInterface
             (method_exists($this->_mockery_partial, $method) || method_exists($this->_mockery_partial, '__call'))
         ) {
             return call_user_func_array(array($this->_mockery_partial, $method), $args);
-        } elseif ($this->_mockery_deferMissing && is_callable("parent::$method")
+        } elseif ($this->_mockery_deferMissing && is_callable(get_parent_class($this) . '::' . $method)
             && (!$this->hasMethodOverloadingInParentClass() || (get_parent_class($this) && method_exists(get_parent_class($this), $method)))) {
-            return call_user_func_array("parent::$method", $args);
+            return call_user_func_array(get_parent_class($this) . '::' . $method, $args);
         } elseif ($this->_mockery_deferMissing && get_parent_class($this) && method_exists(get_parent_class($this), '__call')) {
-            return call_user_func('parent::__call', $method, $args);
+            return call_user_func(get_parent_class($this) . '::__call', $method, $args);
         } elseif ($method == '__toString') {
             // __toString is special because we force its addition to the class API regardless of the
             // original implementation.  Thus, we should always return a string rather than honor
             // _mockery_ignoreMissing and break the API with an error.
             return sprintf("%s#%s", __CLASS__, spl_object_hash($this));
         } elseif ($this->_mockery_ignoreMissing) {
-            if (\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() || (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) || is_callable("parent::$method")) {
+            if (\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() || (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) || is_callable(get_parent_class($this) . '::' . $method)) {
                 if ($this->_mockery_defaultReturnValue instanceof \Mockery\Undefined) {
                     return call_user_func_array(array($this->_mockery_defaultReturnValue, $method), $args);
                 } elseif (null === $this->_mockery_defaultReturnValue) {
@@ -936,7 +936,7 @@ class Mock implements MockInterface
     private function hasMethodOverloadingInParentClass()
     {
         // if there's __call any name would be callable
-        return is_callable('parent::aFunctionNameThatNoOneWouldEverUseInRealLife12345');
+        return is_callable(get_parent_class($this) . '::aFunctionNameThatNoOneWouldEverUseInRealLife12345');
     }
 
     /**


### PR DESCRIPTION
I've searched the code base to see if I could find all affected callbacks. No guarantee I've found them all though, though a test run against PHP 8.2 with the testsuite of this codebase no longer shows this particular error with the patch applied.

Fixes #1168