### PR TITLE
Deprecate `hamcrest/hamcrest-php` package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To run the unit tests for Mockery, clone the git repository, download Composer u
 the instructions at [http://getcomposer.org/download/](http://getcomposer.org/download/),
 then install the dependencies with `php /path/to/composer.phar install`.
 
-This will install the required PHPUnit and Hamcrest dev dependencies and create the
+This will install the required dev dependencies and create the
 autoload files required by the unit tests. You may run the `vendor/bin/phpunit` command
 to run the unit tests. If everything goes to plan, there will be no failed tests!
 

--- a/docs/getting_started/upgrading.rst
+++ b/docs/getting_started/upgrading.rst
@@ -30,7 +30,7 @@ Read the documentation for a detailed overview of ":doc:`/reference/phpunit_inte
 +++++++++++++++++++++++++++++++++++++++++
 
 As of 1.0.0 the ``\Mockery\Matcher\MustBe`` matcher is deprecated and will be removed in
-Mockery 2.0.0. We recommend instead to use the PHPUnit or Hamcrest equivalents of the
+Mockery 2.0.0. We recommend instead to use the PHPUnit equivalents of the
 MustBe matcher.
 
 ``allows`` and ``expects``

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -264,7 +264,7 @@ class Configuration
         }
 
         if ($isHamcrest) {
-            trigger_error('Hamcrest matcher has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+            trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
         }
 
         $this->_defaultMatchers[$class] = $matcherClass;

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -253,15 +253,20 @@ class Configuration
      */
     public function setDefaultMatcher($class, $matcherClass)
     {
-        if (!is_a($matcherClass, \Mockery\Matcher\MatcherAbstract::class, true) &&
-            !is_a($matcherClass, \Hamcrest\Matcher::class, true) &&
-            !is_a($matcherClass, \Hamcrest_Matcher::class, true)
+        $isHamcrest = is_a($matcherClass, \Hamcrest\Matcher::class, true) || is_a($matcherClass, \Hamcrest_Matcher::class, true);
+        if (
+            !is_a($matcherClass, \Mockery\Matcher\MatcherAbstract::class, true) &&
+            !$isHamcrest
         ) {
             throw new \InvalidArgumentException(
-                "Matcher class must be either Hamcrest matcher or extend \Mockery\Matcher\MatcherAbstract, " .
-                  "'$matcherClass' given."
+                "Matcher class must extend " .MatcherAbstract::class. ", '".$matcherClass."' given."
             );
         }
+
+        if ($isHamcrest) {
+            trigger_error('Hamcrest matcher has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+        }
+
         $this->_defaultMatchers[$class] = $matcherClass;
     }
 

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -264,7 +264,7 @@ class Configuration
         }
 
         if ($isHamcrest) {
-            trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+            @trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
         }
 
         $this->_defaultMatchers[$class] = $matcherClass;

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -259,7 +259,7 @@ class Configuration
             !$isHamcrest
         ) {
             throw new \InvalidArgumentException(
-                "Matcher class must extend " .MatcherAbstract::class. ", '".$matcherClass."' given."
+                "Matcher class must extend " . MatcherAbstract::class . ", '" . $matcherClass . "' given."
             );
         }
 

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -259,7 +259,8 @@ class Configuration
             !$isHamcrest
         ) {
             throw new \InvalidArgumentException(
-                "Matcher class must extend " . MatcherAbstract::class . ", '" . $matcherClass . "' given."
+                "Matcher class must extend \Mockery\Matcher\MatcherAbstract, " .
+                "'$matcherClass' given."
             );
         }
 

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -399,6 +399,8 @@ class Expectation implements ExpectationInterface
             return $expected->match($actual);
         }
         if ($expected instanceof \Hamcrest\Matcher || $expected instanceof \Hamcrest_Matcher) {
+            trigger_error('Hamcrest matcher has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+
             return $expected->matches($actual);
         }
         return false;

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -399,7 +399,7 @@ class Expectation implements ExpectationInterface
             return $expected->match($actual);
         }
         if ($expected instanceof \Hamcrest\Matcher || $expected instanceof \Hamcrest_Matcher) {
-            trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+            @trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
 
             return $expected->matches($actual);
         }

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -399,7 +399,7 @@ class Expectation implements ExpectationInterface
             return $expected->match($actual);
         }
         if ($expected instanceof \Hamcrest\Matcher || $expected instanceof \Hamcrest_Matcher) {
-            trigger_error('Hamcrest matcher has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
+            trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);
 
             return $expected->matches($actual);
         }

--- a/library/Mockery/Matcher/MustBe.php
+++ b/library/Mockery/Matcher/MustBe.php
@@ -21,7 +21,7 @@
 namespace Mockery\Matcher;
 
 /**
- * @deprecated 2.0 Due to ambiguity, use Hamcrest or PHPUnit equivalents
+ * @deprecated 2.0 Due to ambiguity, use PHPUnit equivalents
  */
 class MustBe extends MatcherAbstract
 {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -361,6 +361,9 @@
     <MixedInferredReturnType>
       <code>array|null</code>
     </MixedInferredReturnType>
+    <MixedOperand>
+      <code>MatcherAbstract::class</code>
+    </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$this->_internalClassParamMap[strtolower($class)][strtolower($method)]]]></code>
     </MixedReturnStatement>
@@ -386,6 +389,7 @@
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
     <UndefinedClass>
+      <code>MatcherAbstract</code>
       <code>\Hamcrest_Matcher</code>
     </UndefinedClass>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -361,9 +361,6 @@
     <MixedInferredReturnType>
       <code>array|null</code>
     </MixedInferredReturnType>
-    <MixedOperand>
-      <code>MatcherAbstract::class</code>
-    </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$this->_internalClassParamMap[strtolower($class)][strtolower($method)]]]></code>
     </MixedReturnStatement>
@@ -389,7 +386,6 @@
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
     <UndefinedClass>
-      <code>MatcherAbstract</code>
       <code>\Hamcrest_Matcher</code>
     </UndefinedClass>
   </file>


### PR DESCRIPTION
This patch is part of #1227, has the following changes:

 - Adds `@trigger_error('Hamcrest package has been deprecated and will be removed in 2.0', E_USER_DEPRECATED);`
 - Remove the recommendation to use Hamcrest