### PR TITLE
Support PHP 8.2 `true` Literal Type

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -730,6 +730,7 @@ class Mock implements MockInterface
             case 'int':    return 0;
             case 'float':  return 0.0;
             case 'bool':   return false;
+            case 'true':   return true;
 
             case 'array':
             case 'iterable':

--- a/tests/PHP82/Php82LanguageFeaturesTest.php
+++ b/tests/PHP82/Php82LanguageFeaturesTest.php
@@ -26,6 +26,24 @@ class Php82LanguageFeaturesTest extends MockeryTestCase
 
         $this->assertSame('bar', $class->foo);
     }
+
+    public function testCanMockReservedWordTrue(): void
+    {
+        $mock = mock(HasReservedWordTrue::class);
+
+        $mock->expects('testTrueMethod')->once();
+
+        self::assertTrue($mock->testTrueMethod());
+        self::assertInstanceOf(HasReservedWordTrue::class, $mock);
+    }
+}
+
+class HasReservedWordTrue
+{
+    public function testTrueMethod(): true
+    {
+        return true;
+    }
 }
 
 class HasNullReturnType


### PR DESCRIPTION
This pull request introduces support for [Literal Types](https://www.php.net/manual/en/language.types.literal.php) in PHP 8.2, specifically focusing on the `true` literal type.

Fixes #1269