### PR TITLE
Merge `main` branch into `1.6.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4.x-dev"
+            "dev-master": "1.6.x-dev"
         }
     }
 }


### PR DESCRIPTION
This pull request addresses the need to correctly rebase the `main` branch into the `1.6.x` branch prior to merging `1.6.x` back into `main`.

Currently, the default branch `main` and the `1.6.x` branch have diverged due to various commits and changes. To ensure a clean and seamless merge, it is essential to rebase the default branch onto `1.6.x`, allowing the changes in the `main` branch to be incorporated into the `1.6.x` branch while maintaining a linear commit history.