### PR TITLE
Add array-like objects support to hasKey/hasValue matchers

### DIFF
--- a/library/Mockery/Matcher/HasKey.php
+++ b/library/Mockery/Matcher/HasKey.php
@@ -24,7 +24,7 @@ class HasKey extends MatcherAbstract
             return false;
         }
 
-        return array_key_exists($this->_expected, $actual);
+        return array_key_exists($this->_expected, (array)$actual);
     }
 
     /**

--- a/library/Mockery/Matcher/HasKey.php
+++ b/library/Mockery/Matcher/HasKey.php
@@ -20,7 +20,7 @@ class HasKey extends MatcherAbstract
      */
     public function match(&$actual)
     {
-        if (!is_array($actual) && !is_object($actual)) {
+        if (!is_array($actual) && !$actual instanceof \ArrayAccess) {
             return false;
         }
 

--- a/library/Mockery/Matcher/HasKey.php
+++ b/library/Mockery/Matcher/HasKey.php
@@ -20,6 +20,10 @@ class HasKey extends MatcherAbstract
      */
     public function match(&$actual)
     {
+        if (!is_array($actual) && !is_object($actual)) {
+            return false;
+        }
+
         return array_key_exists($this->_expected, $actual);
     }
 

--- a/library/Mockery/Matcher/HasValue.php
+++ b/library/Mockery/Matcher/HasValue.php
@@ -20,7 +20,7 @@ class HasValue extends MatcherAbstract
      */
     public function match(&$actual)
     {
-        if (!is_array($actual) && !is_object($actual)) {
+        if (!is_array($actual) && !$actual instanceof \ArrayAccess) {
             return false;
         }
 

--- a/library/Mockery/Matcher/HasValue.php
+++ b/library/Mockery/Matcher/HasValue.php
@@ -20,6 +20,10 @@ class HasValue extends MatcherAbstract
      */
     public function match(&$actual)
     {
+        if (!is_array($actual) && !is_object($actual)) {
+            return false;
+        }
+
         return in_array($this->_expected, $actual);
     }
 

--- a/library/Mockery/Matcher/HasValue.php
+++ b/library/Mockery/Matcher/HasValue.php
@@ -34,7 +34,6 @@ class HasValue extends MatcherAbstract
      */
     public function __toString()
     {
-        $return = '<HasValue[' . (string) $this->_expected . ']>';
-        return $return;
+        return '<HasValue[' . (string)$this->_expected . ']>';
     }
 }

--- a/library/Mockery/Matcher/HasValue.php
+++ b/library/Mockery/Matcher/HasValue.php
@@ -24,7 +24,7 @@ class HasValue extends MatcherAbstract
             return false;
         }
 
-        return in_array($this->_expected, $actual);
+        return in_array($this->_expected, (array)$actual);
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2135,7 +2135,6 @@
       <code>MatcherAbstract</code>
     </DeprecatedClass>
     <MixedArgument>
-      <code>$actual</code>
       <code><![CDATA[$this->_expected]]></code>
     </MixedArgument>
   </file>
@@ -2143,9 +2142,6 @@
     <DeprecatedClass>
       <code>MatcherAbstract</code>
     </DeprecatedClass>
-    <MixedArgument>
-      <code>$actual</code>
-    </MixedArgument>
   </file>
   <file src="library/Mockery/Matcher/IsEqual.php">
     <DeprecatedClass>

--- a/tests/Mockery/Matcher/HasKeyTest.php
+++ b/tests/Mockery/Matcher/HasKeyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace test\Mockery\Matcher;
+
+use Mockery\Matcher\HasKey;
+use PHPUnit\Framework\TestCase;
+
+class HasKeyTest extends TestCase
+{
+    /** @test */
+    public function it_can_handle_a_non_array()
+    {
+        $matcher = new HasKey('dave');
+
+        $actual = null;
+
+        $this->assertFalse($matcher->match($actual));
+    }
+}

--- a/tests/Mockery/Matcher/HasKeyTest.php
+++ b/tests/Mockery/Matcher/HasKeyTest.php
@@ -16,4 +16,32 @@ class HasKeyTest extends TestCase
 
         $this->assertFalse($matcher->match($actual));
     }
+
+    /** @test */
+    public function it_matches_an_array()
+    {
+        $matcher = new HasKey('dave');
+
+        $actual = [
+            'foo' => 'bar',
+            'dave' => 123,
+            'bar' => 'baz',
+        ];
+
+        $this->assertTrue($matcher->match($actual));
+    }
+
+    /** @test */
+    public function it_matches_an_array_like_object()
+    {
+        $matcher = new HasKey('dave');
+
+        $actual = new \ArrayObject([
+            'foo' => 'bar',
+            'dave' => 123,
+            'bar' => 'baz',
+        ]);
+
+        $this->assertTrue($matcher->match($actual));
+    }
 }

--- a/tests/Mockery/Matcher/HasValueTest.php
+++ b/tests/Mockery/Matcher/HasValueTest.php
@@ -16,4 +16,32 @@ class HasValueTest extends TestCase
 
         $this->assertFalse($matcher->match($actual));
     }
+
+    /** @test */
+    public function it_matches_an_array()
+    {
+        $matcher = new HasValue(123);
+
+        $actual = [
+            'foo' => 'bar',
+            'dave' => 123,
+            'bar' => 'baz',
+        ];
+
+        $this->assertTrue($matcher->match($actual));
+    }
+
+    /** @test */
+    public function it_matches_an_array_like_object()
+    {
+        $matcher = new HasValue(123);
+
+        $actual = new \ArrayObject([
+            'foo' => 'bar',
+            'dave' => 123,
+            'bar' => 'baz',
+        ]);
+
+        $this->assertTrue($matcher->match($actual));
+    }
 }

--- a/tests/Mockery/Matcher/HasValueTest.php
+++ b/tests/Mockery/Matcher/HasValueTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace test\Mockery\Matcher;
+
+use Mockery\Matcher\HasValue;
+use PHPUnit\Framework\TestCase;
+
+class HasValueTest extends TestCase
+{
+    /** @test */
+    public function it_can_handle_a_non_array()
+    {
+        $matcher = new HasValue(123);
+
+        $actual = null;
+
+        $this->assertFalse($matcher->match($actual));
+    }
+}


### PR DESCRIPTION
Hello,

This is a draft version for #1353 that adds support of array-like objects to hasKey/hasValue matchers.

How it works. We use a guard clause to filter out values that are not arrays and objects (probably, the constraints should be more severe and besides arrays, it should accept the `ArrayAccess` implementations only). Then, we just cast the object to an array and perform the matching. For right now, it works with objects that implement the `ArrayAccess` interface and objects with public properties (for example, it can process an `stdClass` instance with some filled properties). 

If the feature looks interesting, I can elaborate it a little bit (including subset matcher).