### PR TITLE
Fix the namespace in the SubsetTest class

### DIFF
--- a/tests/Mockery/Matcher/SubsetTest.php
+++ b/tests/Mockery/Matcher/SubsetTest.php
@@ -18,7 +18,7 @@
  * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
  */
 
-namespace tests\Mockery\Matcher;
+namespace test\Mockery\Matcher;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Matcher\Subset;


### PR DESCRIPTION
Hello,

This PR fixes the namespace in the SubsetTest test class.