### PR TITLE
Fix 8.3 get_parent_class without arguments deprecation

### DIFF
--- a/tests/Mockery/RegExpCompatability.php
+++ b/tests/Mockery/RegExpCompatability.php
@@ -6,7 +6,7 @@ trait RegExpCompatability
 {
     public function expectExceptionMessageRegEx($regularExpression)
     {
-        if (method_exists(get_parent_class(), 'expectExceptionMessageRegExp')) {
+        if (method_exists(get_parent_class(__CLASS__), 'expectExceptionMessageRegExp')) {
             return parent::expectExceptionMessageRegExp($regularExpression);
         }
 
@@ -15,7 +15,7 @@ trait RegExpCompatability
 
     public static function assertMatchesRegEx($pattern, $string, $message = '')
     {
-        if (method_exists(get_parent_class(), 'assertMatchesRegularExpression')) {
+        if (method_exists(get_parent_class(__CLASS__), 'assertMatchesRegularExpression')) {
             return parent::assertMatchesRegularExpression($pattern, $string, $message);
         }
 


### PR DESCRIPTION
Hello,

This PR fixes fail of tests with `Calling get_parent_class() without arguments is deprecated` on PHP 8.3.
Just in case, here is the link to a [php.watch article](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated) with more information about this deprecation.