### PR TITLE
Update composer dependencies and clean up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,8 @@
         "hamcrest/hamcrest-php": "^2.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.6.10",
-        "symplify/easy-coding-standard": "^12.0.8"
+        "phpunit/phpunit": "^8.5 || ^9.6.17",
+        "symplify/easy-coding-standard": "^12.1.14"
     },
     "conflict": {
         "phpunit/phpunit": "<8.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36074fe1732f1856d7ba60964d9b79f8",
+    "content-hash": "e70f68192a56a148f93ad7a1c0779be3",
     "packages": [
         {
             "name": "hamcrest/hamcrest-php",
@@ -190,16 +190,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
                 "shasum": ""
             },
             "require": {
@@ -240,9 +240,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2023-12-10T21:03:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -357,23 +357,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
+            "version": "9.2.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -423,7 +423,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
             },
             "funding": [
                 {
@@ -431,7 +431,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-19T04:57:46+00:00"
+            "time": "2023-12-22T06:47:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -676,16 +676,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
             },
             "funding": [
                 {
@@ -775,7 +775,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-02-23T13:14:51+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1020,20 +1020,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1065,7 +1065,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1073,7 +1073,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1347,20 +1347,20 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1392,7 +1392,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -1400,7 +1400,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1743,25 +1743,25 @@
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "12.0.13",
+            "version": "12.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/easy-coding-standard/easy-coding-standard.git",
-                "reference": "d15707b14d50b7cb6d656f7a7a5e5b9a17099b3c"
+                "reference": "e3c4a241ee36704f7cf920d5931f39693e64afd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/d15707b14d50b7cb6d656f7a7a5e5b9a17099b3c",
-                "reference": "d15707b14d50b7cb6d656f7a7a5e5b9a17099b3c",
+                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/e3c4a241ee36704f7cf920d5931f39693e64afd5",
+                "reference": "e3c4a241ee36704f7cf920d5931f39693e64afd5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
             "conflict": {
-                "friendsofphp/php-cs-fixer": "<3.0",
-                "phpcsstandards/php_codesniffer": "<3.6",
-                "symplify/coding-standard": "<11.3"
+                "friendsofphp/php-cs-fixer": "<3.46",
+                "phpcsstandards/php_codesniffer": "<3.8",
+                "symplify/coding-standard": "<12.1"
             },
             "bin": [
                 "bin/ecs"
@@ -1785,7 +1785,7 @@
             ],
             "support": {
                 "issues": "https://github.com/easy-coding-standard/easy-coding-standard/issues",
-                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.0.13"
+                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.1.14"
             },
             "funding": [
                 {
@@ -1797,7 +1797,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-07T09:18:07+00:00"
+            "time": "2024-02-23T13:10:40+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -843,7 +843,7 @@ class Mockery
         $targetCode = '<?php ';
         $shortName = $fqn;
 
-        if (\mb_strpos($fqn, '\\')) {
+        if (\strpos($fqn, '\\')) {
             $parts = \explode('\\', $fqn);
 
             $shortName = \trim(\array_pop($parts));
@@ -933,7 +933,7 @@ class Mockery
                 $argument = '[' . \implode(', ', $sample) . ']';
             }
 
-            return (\mb_strlen($argument) > 1000) ? \mb_substr($argument, 0, 1000) . '...]' : $argument;
+            return (\strlen($argument) > 1000) ? \substr($argument, 0, 1000) . '...]' : $argument;
         }
 
         if (\is_bool($argument)) {

--- a/library/Mockery/Configuration.php
+++ b/library/Mockery/Configuration.php
@@ -23,8 +23,8 @@ use function array_merge;
 use function class_implements;
 use function get_parent_class;
 use function is_a;
-use function mb_strtolower;
 use function sprintf;
+use function strtolower;
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
@@ -216,8 +216,8 @@ class Configuration
      */
     public function getInternalClassMethodParamMap($class, $method)
     {
-        $class = mb_strtolower($class);
-        $method = mb_strtolower($method);
+        $class = strtolower($class);
+        $method = strtolower($method);
 
         if (
             array_key_exists($class, $this->_internalClassParamMap)
@@ -382,13 +382,13 @@ class Configuration
             );
         }
 
-        $class = mb_strtolower($class);
+        $class = strtolower($class);
 
         if (! array_key_exists($class, $this->_internalClassParamMap)) {
             $this->_internalClassParamMap[$class] = [];
         }
 
-        $this->_internalClassParamMap[$class][mb_strtolower($method)] = $map;
+        $this->_internalClassParamMap[$class][strtolower($method)] = $map;
     }
 
     /**

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -37,10 +37,10 @@ use function is_array;
 use function is_callable;
 use function is_object;
 use function is_string;
-use function mb_strlen;
-use function mb_strpos;
-use function mb_strtolower;
-use function mb_substr;
+use function strlen;
+use function strpos;
+use function strtolower;
+use function substr;
 use function md5;
 use function preg_grep;
 use function preg_match;
@@ -181,7 +181,7 @@ class Container
     public function isValidClassName($className)
     {
         if ($className[0] === '\\') {
-            $className = mb_substr($className, 1); // remove the first backslash
+            $className = substr($className, 1); // remove the first backslash
         }
         // all the namespaces and class name should match the regex
         return array_filter(
@@ -255,7 +255,7 @@ class Container
                         continue;
                     }
 
-                    if (mb_strpos($type, ',') && ! mb_strpos($type, ']')) {
+                    if (strpos($type, ',') && ! strpos($type, ']')) {
                         $interfaces = explode(',', str_replace(' ', '', $type));
 
                         $builder->addTargets($interfaces);
@@ -263,7 +263,7 @@ class Container
                         continue;
                     }
 
-                    if (mb_strpos($type, 'alias:') === 0) {
+                    if (strpos($type, 'alias:') === 0) {
                         $type = str_replace('alias:', '', $type);
 
                         $builder->addTarget('stdClass');
@@ -272,7 +272,7 @@ class Container
                         continue;
                     }
 
-                    if (mb_strpos($type, 'overload:') === 0) {
+                    if (strpos($type, 'overload:') === 0) {
                         $type = str_replace('overload:', '', $type);
 
                         $builder->setInstanceMock(true);
@@ -282,7 +282,7 @@ class Container
                         continue;
                     }
 
-                    if ($type[mb_strlen($type) - 1] === ']') {
+                    if ($type[strlen($type) - 1] === ']') {
                         $parts = explode('[', $type);
 
                         $class = $parts[0];
@@ -298,12 +298,12 @@ class Container
                         $builder->addTarget($class);
 
                         $partialMethods = array_filter(
-                            explode(',', mb_strtolower(rtrim(str_replace(' ', '', $parts[1]), ']')))
+                            explode(',', strtolower(rtrim(str_replace(' ', '', $parts[1]), ']')))
                         );
 
                         foreach ($partialMethods as $partialMethod) {
                             if ($partialMethod[0] === '!') {
-                                $builder->addBlackListedMethod(mb_substr($partialMethod, 1));
+                                $builder->addBlackListedMethod(substr($partialMethod, 1));
 
                                 continue;
                             }

--- a/library/Mockery/Instantiator.php
+++ b/library/Mockery/Instantiator.php
@@ -39,7 +39,7 @@ final class Instantiator
      *
      * @return TClass
      */
-    public function instantiate(string $className): object
+    public function instantiate($className): object
     {
         return $this->buildFactory($className)();
     }

--- a/library/Mockery/Instantiator.php
+++ b/library/Mockery/Instantiator.php
@@ -18,10 +18,10 @@ use ReflectionClass;
 use UnexpectedValueException;
 
 use function class_exists;
-use function mb_strlen;
 use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
+use function strlen;
 use function unserialize;
 
 /**
@@ -97,7 +97,7 @@ final class Instantiator
             };
         }
 
-        $serializedString = sprintf('O:%d:"%s":0:{}', mb_strlen($className), $className);
+        $serializedString = sprintf('O:%d:"%s":0:{}', strlen($className), $className);
 
         $this->attemptInstantiationViaUnSerialization($reflectionClass, $serializedString);
 

--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -27,9 +27,9 @@ use function array_merge;
 use function get_debug_type;
 use function implode;
 use function in_array;
-use function mb_strpos;
 use function method_exists;
 use function sprintf;
+use function strpos;
 
 use const PHP_VERSION_ID;
 
@@ -158,7 +158,7 @@ class Reflector
             return $typeHint;
         }
 
-        if (mb_strpos($typeHint, 'null') !== false) {
+        if (strpos($typeHint, 'null') !== false) {
             return $typeHint;
         }
 
@@ -224,7 +224,7 @@ class Reflector
                 '|',
                 array_map(
                     static function (string $type): string {
-                        return mb_strpos($type, '&') === false ? $type : sprintf('(%s)', $type);
+                        return strpos($type, '&') === false ? $type : sprintf('(%s)', $type);
                     },
                     $types
                 )


### PR DESCRIPTION
This patch includes updates to composer dev dependencies and reverts `mb_*` function calls to core functions for backward compatibility in the following files:

- `composer.json`
- `composer.lock`
- `library/Mockery.php`
- `library/Mockery/Configuration.php`
- `library/Mockery/Container.php`
- `library/Mockery/Instantiator.php`
- `library/Mockery/Reflector.php`