### PR TITLE
Add PHPUnit 10+ attributes

### DIFF
--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -11,6 +11,8 @@
 namespace Mockery\Adapter\Phpunit;
 
 use Mockery;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 
 /**
  * Integrates Mockery into PHPUnit. Ensures Mockery expectations are verified
@@ -62,6 +64,7 @@ trait MockeryPHPUnitIntegration
     /**
      * @before
      */
+    #[Before]
     protected function startMockery()
     {
         $this->mockeryOpen = true;
@@ -70,6 +73,7 @@ trait MockeryPHPUnitIntegration
     /**
      * @after
      */
+    #[After]
     protected function purgeMockeryContainer()
     {
         if ($this->mockeryOpen) {


### PR DESCRIPTION
Fixes #1359

While upgrading to PHPUnit 11 I noticed the following deprecation:

Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

If we add the attribute too, it stops complaining. So this most be a way to support PHPUnit 11 and older versions.

If we ship this, we reduce a few errors. Most of the things just work fine.