### PR TITLE
Fix `1.6.8` release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,9 +8,10 @@
 /docker export-ignore
 /fixtures export-ignore
 /tests export-ignore
-Makefile export-ignore
 codecov.yml export-ignore
+e2e-test.sh export-ignore
 ecs.php export-ignore
+Makefile export-ignore
 phpunit.xml.dist export-ignore
 psalm-baseline.xml export-ignore
 psalm.xml.dist export-ignore

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+# set -x
+
+#######################################################################################################################
+# This script runs semi end-to-end tests for Mockery.
+#
+# It clones the repositories listed in the `repos` array,
+# installs Mockery from the local filesystem,
+# and runs PHPUnit for each PHP version listed in the `php_versions` array.
+#
+# This is useful to test Mockery against different versions of other frameworks.
+#
+#######################################################################################################################
+
+php_versions=("8.2" "8.3")
+
+repos=("laravel/framework")
+
+mockery_path="$(pwd)"
+
+resources_path="$mockery_path/../mockery-resources"
+
+mockery_branch=$(git -C "$mockery_path" rev-parse --abbrev-ref HEAD)
+mockery_sha=$(git -C "$mockery_path" rev-parse HEAD | cut -c1-8)
+mockery_version="dev-$mockery_branch#$mockery_sha"
+
+echo "===> Running e2e tests"
+echo "PHP versions: [ ${php_versions[*]} ]"
+echo " "
+echo "Mockery branch: $mockery_branch"
+echo "Mockery SHA: $mockery_sha"
+echo "Mockery version: $mockery_version"
+echo "Mockery path: $mockery_path"
+echo "Resource path: $resources_path"
+echo " "
+
+
+mkdir -p "$resources_path" || { echo "Failed to create directory $resources_path"; exit 1; }
+cd "$resources_path" || { echo "Failed to change directory to $resources_path"; exit 1; }
+
+for repo in "${repos[@]}"
+do
+    repo_path="$resources_path/$repo"
+
+    if [ ! -d "$repo_path" ]; then
+        echo "Cloning $repo to $repo_path"
+
+        git clone "git@github.com:$repo.git" "$repo_path" --depth=10 || { echo "Failed to clone $repo"; exit 1; }
+    else
+        echo "Pulling $repo"
+
+        git -C "$repo_path" fetch --depth=10 || { echo "Failed to fetch $repo"; exit 1; }
+
+        git -C "$repo_path" pull || { echo "Failed to pull $repo"; exit 1; }
+    fi
+
+    cd "$repo_path" || { echo "Failed to change directory to $repo_path"; exit 1; }
+
+    echo "Installing Mockery version $mockery_version"
+
+    for php_version in "${php_versions[@]}"
+    do
+        echo "Running PHPUnit for PHP version $php_version"
+
+        docker run -it --rm -v "$mockery_path":/opt/mockery -v "$repo_path":/opt/workspace -w /opt/workspace ghcr.io/ghostwriter/php:"$php_version"-pcov sh -c "composer config repositories.local '{\"type\": \"path\", \"url\": \"/opt/mockery\"}' && composer require 'mockery/mockery:$mockery_version' --with-dependencies --ignore-platform-reqs --dev --no-interaction && php vendor/bin/phpunit" || { echo "Failed to run PHPUnit for $repo PHP version $php_version"; exit 1; }
+    done
+done
+
+rm -rf "$resources_path" || { echo "Failed to remove directory $resources_path"; exit 1; }

--- a/library/Mockery/Exception/BadMethodCallException.php
+++ b/library/Mockery/Exception/BadMethodCallException.php
@@ -21,10 +21,6 @@ class BadMethodCallException extends \BadMethodCallException implements MockeryE
         $this->dismissed = true;
         // we sometimes stack them
         $previous = $this->getPrevious();
-        if (! $previous instanceof Throwable) {
-            return;
-        }
-
         if (! $previous instanceof self) {
             return;
         }

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -202,7 +202,7 @@ class Mock implements MockInterface
 
         $this->_mockery_instanceMock = $instanceMock;
 
-        $this->parentClass = get_parent_class($this);
+        $this->_mockery_parentClass = get_parent_class($this);
     }
 
     /**
@@ -644,15 +644,15 @@ class Mock implements MockInterface
             return false;
         }
 
-        if (!$this->parentClass) {
+        if (!$this->_mockery_parentClass) {
             return false;
         }
 
-        if (!method_exists($this->parentClass, '__isset')) {
+        if (!method_exists($this->_mockery_parentClass, '__isset')) {
             return false;
         }
 
-        return call_user_func($this->parentClass . '::__isset', $name);
+        return call_user_func($this->_mockery_parentClass . '::__isset', $name);
     }
 
     public function mockery_getExpectations()
@@ -671,11 +671,11 @@ class Mock implements MockInterface
      */
     public function mockery_callSubjectMethod($name, array $args)
     {
-        if (!method_exists($this, $name) && $this->parentClass && method_exists($this->parentClass, '__call')) {
-            return call_user_func($this->parentClass . '::__call', $name, $args);
+        if (!method_exists($this, $name) && $this->_mockery_parentClass && method_exists($this->_mockery_parentClass, '__call')) {
+            return call_user_func($this->_mockery_parentClass . '::__call', $name, $args);
         }
 
-        return call_user_func_array($this->parentClass . '::' . $name, $args);
+        return call_user_func_array($this->_mockery_parentClass . '::' . $name, $args);
     }
 
     /**
@@ -910,7 +910,7 @@ class Mock implements MockInterface
                 // noop - there is no hasPrototype method
             }
 
-            return call_user_func_array($this->parentClass . '::' . $method, $args);
+            return call_user_func_array($this->_mockery_parentClass . '::' . $method, $args);
         }
 
         $handler = $this->_mockery_findExpectedMethodHandler($method);
@@ -930,13 +930,13 @@ class Mock implements MockInterface
             return $this->_mockery_partial->{$method}(...$args);
         }
 
-        if ($this->_mockery_deferMissing && is_callable($this->parentClass . '::' . $method)
-            && (!$this->hasMethodOverloadingInParentClass() || ($this->parentClass && method_exists($this->parentClass, $method)))) {
-            return call_user_func_array($this->parentClass . '::' . $method, $args);
+        if ($this->_mockery_deferMissing && is_callable($this->_mockery_parentClass . '::' . $method)
+            && (!$this->hasMethodOverloadingInParentClass() || ($this->_mockery_parentClass && method_exists($this->_mockery_parentClass, $method)))) {
+            return call_user_func_array($this->_mockery_parentClass . '::' . $method, $args);
         }
 
-        if ($this->_mockery_deferMissing && $this->parentClass && method_exists($this->parentClass, '__call')) {
-            return call_user_func($this->parentClass . '::__call', $method, $args);
+        if ($this->_mockery_deferMissing && $this->_mockery_parentClass && method_exists($this->_mockery_parentClass, '__call')) {
+            return call_user_func($this->_mockery_parentClass . '::__call', $method, $args);
         }
 
         if ($method === '__toString') {
@@ -946,7 +946,7 @@ class Mock implements MockInterface
             return sprintf('%s#%s', self::class, spl_object_hash($this));
         }
 
-        if ($this->_mockery_ignoreMissing && (\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() || (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) || is_callable($this->parentClass . '::' . $method))) {
+        if ($this->_mockery_ignoreMissing && (\Mockery::getConfiguration()->mockingNonExistentMethodsAllowed() || (!is_null($this->_mockery_partial) && method_exists($this->_mockery_partial, $method)) || is_callable($this->_mockery_parentClass . '::' . $method))) {
             if ($this->_mockery_defaultReturnValue instanceof Undefined) {
                 return $this->_mockery_defaultReturnValue->{$method}(...$args);
             }
@@ -995,7 +995,7 @@ class Mock implements MockInterface
     private function hasMethodOverloadingInParentClass()
     {
         // if there's __call any name would be callable
-        return is_callable($this->parentClass . '::aFunctionNameThatNoOneWouldEverUseInRealLife12345');
+        return is_callable($this->_mockery_parentClass . '::aFunctionNameThatNoOneWouldEverUseInRealLife12345');
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -335,6 +335,7 @@
       <code>allowMockingNonExistentMethods</code>
       <code>disableReflectionCache</code>
       <code>enableReflectionCache</code>
+      <code>getDefaultMatcher</code>
       <code>getInternalClassMethodParamMap</code>
       <code>mockingMethodsUnnecessarilyAllowed</code>
       <code>reflectionCacheEnabled</code>
@@ -791,7 +792,6 @@
       <code>mockery_allocateOrder</code>
       <code>mockery_getGroups</code>
       <code>mockery_setGroup</code>
-      <code>new $matcher($expected)</code>
       <code>validate</code>
     </MixedMethodCall>
     <MixedReturnStatement>

--- a/tests/Mockery/ExpectationTest.php
+++ b/tests/Mockery/ExpectationTest.php
@@ -2158,6 +2158,20 @@ class ExpectationTest extends MockeryTestCase
 
         Mockery::close();
     }
+
+    public function testNonObjectEqualsExpectation()
+    {
+        $input = ['club_id' => 1, 'user_id' => 1, 'is_admin' => 1];
+
+        $foo = Mockery::mock();
+
+        $foo->shouldReceive('foo')->with($input)->andReturn('foobar');
+
+        // only sort the input to change the order but not the values.
+        ksort($input);
+
+        self::assertSame('foobar', $foo->foo($input));
+    }
 }
 
 interface IWater


### PR DESCRIPTION
This patch fixes an issue in the `1.6.8` release.

To test it out, you can include the following in your `composer.json`:

```
"require": {
    "mockery/mockery": "dev-fix/1.6.8-release"
}
```
And then run `composer update` to fetch the latest changes from the `fix/1.6.8-release` branch.