### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -247,7 +247,7 @@ class Mockery
      *
      * @return string
      */
-    public static function formatArgs($method, array $arguments = null)
+    public static function formatArgs($method, ?array $arguments = null)
     {
         if ($arguments === null) {
             return $method . '()';
@@ -266,7 +266,7 @@ class Mockery
      *
      * @return string
      */
-    public static function formatObjects(array $objects = null)
+    public static function formatObjects(?array $objects = null)
     {
         static $formatting;
 

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -101,7 +101,7 @@ class Container
      */
     protected $instantiator;
 
-    public function __construct(Generator $generator = null, LoaderInterface $loader = null, Instantiator $instantiator = null)
+    public function __construct(?Generator $generator = null, ?LoaderInterface $loader = null, ?Instantiator $instantiator = null)
     {
         $this->_generator = $generator instanceof Generator ? $generator : Mockery::getDefaultGenerator();
         $this->_loader = $loader instanceof LoaderInterface ? $loader : Mockery::getDefaultLoader();

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -362,7 +362,7 @@ class Expectation implements ExpectationInterface
      *
      * @return self
      */
-    public function andThrow($exception, $message = '', $code = 0, \Exception $previous = null)
+    public function andThrow($exception, $message = '', $code = 0, ?\Exception $previous = null)
     {
         $this->_throw = true;
 
@@ -391,7 +391,7 @@ class Expectation implements ExpectationInterface
         return $this->andReturnValues($exceptions);
     }
 
-    public function andThrows($exception, $message = '', $code = 0, \Exception $previous = null)
+    public function andThrows($exception, $message = '', $code = 0, ?\Exception $previous = null)
     {
         return $this->andThrow($exception, $message, $code, $previous);
     }

--- a/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MagicMethodTypeHintsPass.php
@@ -79,7 +79,7 @@ class MagicMethodTypeHintsPass implements Pass
      *
      * @return array
      */
-    public function getMagicMethods(TargetClassInterface $class = null)
+    public function getMagicMethods(?TargetClassInterface $class = null)
     {
         if (! $class instanceof TargetClassInterface) {
             return [];

--- a/library/Mockery/LegacyMockInterface.php
+++ b/library/Mockery/LegacyMockInterface.php
@@ -107,7 +107,7 @@ interface LegacyMockInterface
      *
      * @return void
      */
-    public function mockery_init(Container $container = null, $partialObject = null);
+    public function mockery_init(?Container $container = null, $partialObject = null);
 
     /**
      * @return bool
@@ -220,7 +220,7 @@ interface LegacyMockInterface
      *
      * @return mixed
      */
-    public function shouldNotHaveBeenCalled(array $args = null);
+    public function shouldNotHaveBeenCalled(?array $args = null);
 
     /**
      * @param string $method

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -181,7 +181,7 @@ class Mock implements MockInterface
      * @param bool $instanceMock
      * @return void
      */
-    public function mockery_init(Container $container = null, $partialObject = null, $instanceMock = true)
+    public function mockery_init(?Container $container = null, $partialObject = null, $instanceMock = true)
     {
         if (is_null($container)) {
             $container = new Container();
@@ -839,7 +839,7 @@ class Mock implements MockInterface
         return null;
     }
 
-    public function shouldNotHaveBeenCalled(array $args = null)
+    public function shouldNotHaveBeenCalled(?array $args = null)
     {
         return $this->shouldNotHaveReceived('__invoke', $args);
     }

--- a/tests/Mockery/ContainerTest.php
+++ b/tests/Mockery/ContainerTest.php
@@ -1777,7 +1777,7 @@ class MockeryTest_MockCallableTypeHint
         $baz();
     }
 
-    public function bar(callable $callback = null)
+    public function bar(?callable $callback = null)
     {
         $callback();
     }
@@ -1864,7 +1864,7 @@ class MockeryTest_PartialStatic
 
 class MockeryTest_MethodWithRequiredParamWithDefaultValue
 {
-    public function foo(DateTime $bar = null, $baz)
+    public function foo(?DateTime $bar = null, $baz)
     {
     }
 }

--- a/tests/Mockery/Fixtures/MethodWithNullableTypedParameter.php
+++ b/tests/Mockery/Fixtures/MethodWithNullableTypedParameter.php
@@ -27,7 +27,7 @@ class MethodWithNullableTypedParameter
     {
     }
 
-    public function bar(string $bar = null)
+    public function bar(?string $bar = null)
     {
     }
 

--- a/tests/Mockery/Fixtures/MethodWithParametersWithDefaultValues.php
+++ b/tests/Mockery/Fixtures/MethodWithParametersWithDefaultValues.php
@@ -27,7 +27,7 @@ class MethodWithParametersWithDefaultValues
     {
     }
 
-    public function bar(string $bar = null)
+    public function bar(?string $bar = null)
     {
     }
 }


### PR DESCRIPTION
Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)