### PR TITLE
Fix reserved words used to name a class, interface or trait

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -988,7 +988,7 @@ class Mockery
             $parRefMethodRetType = Reflector::getReturnType($parRefMethod, true);
 
             if ($parRefMethodRetType !== null) {
-                $returnTypes = \explode('|', $parRefMethodRetType) ?: [];
+                $returnTypes = \explode('|', $parRefMethodRetType);
 
                 $filteredReturnTypes = array_filter($returnTypes, static function (string $type): bool {
                     return ! Reflector::isReservedWord($type);

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -759,7 +759,7 @@ class Mockery
                 $mock = self::getNewDemeterMock($container, $parent, $method, $expectations);
             } else {
                 $demeterMockKey = $container->getKeyOfDemeterMockFor($method, $parent);
-                if ($demeterMockKey) {
+                if ($demeterMockKey !== null) {
                     $mock = self::getExistingDemeterMock($container, $demeterMockKey);
                 }
             }
@@ -987,13 +987,27 @@ class Mockery
             $parRefMethod = $parRef->getMethod($method);
             $parRefMethodRetType = Reflector::getReturnType($parRefMethod, true);
 
-            if ($parRefMethodRetType !== null && $parRefMethodRetType !== 'mixed') {
-                $nameBuilder = new MockNameBuilder();
-                $nameBuilder->addPart('\\' . $newMockName);
-                $mock = self::namedMock($nameBuilder->build(), $parRefMethodRetType);
-                $exp->andReturn($mock);
+            if ($parRefMethodRetType !== null) {
+                $returnTypes = \explode('|', $parRefMethodRetType) ?: [];
 
-                return $mock;
+                $filteredReturnTypes = array_filter($returnTypes, static function (string $type): bool {
+                    return ! Reflector::isReservedWord($type);
+                });
+
+                if ($filteredReturnTypes !== []) {
+                    $nameBuilder = new MockNameBuilder();
+
+                    $nameBuilder->addPart('\\' . $newMockName);
+
+                    $mock = self::namedMock(
+                        $nameBuilder->build(),
+                        ...$filteredReturnTypes
+                    );
+
+                    $exp->andReturn($mock);
+
+                    return $mock;
+                }
             }
         }
 

--- a/library/Mockery/Reflector.php
+++ b/library/Mockery/Reflector.php
@@ -45,6 +45,13 @@ class Reflector
     public const BUILTIN_TYPES = ['array', 'bool', 'int', 'float', 'null', 'object', 'string'];
 
     /**
+     * List of reserved words.
+     *
+     * @var list<string>
+     */
+    public const RESERVED_WORDS = ['bool', 'true', 'false', 'float', 'int', 'iterable', 'mixed', 'never', 'null', 'object', 'string', 'void'];
+
+    /**
      * Iterable.
      *
      * @var list<string>
@@ -146,6 +153,14 @@ class Reflector
         $type = $param->getType();
 
         return $type instanceof ReflectionNamedType && $type->getName();
+    }
+
+    /**
+     * Determine if the given type is a reserved word.
+     */
+    public static function isReservedWord(string $type): bool
+    {
+        return in_array(strtolower($type), self::RESERVED_WORDS, true);
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,6 +16,9 @@
       <code>self::$_generator === null</code>
       <code>self::$_loader === null</code>
     </DocblockTypeContradiction>
+    <InternalMethod>
+      <code>Reflector::isReservedWord($type)</code>
+    </InternalMethod>
     <InvalidReturnStatement>
       <code>$argument</code>
       <code><![CDATA[$container->getMocks()[$demeterMockKey] ?? null]]></code>
@@ -166,6 +169,7 @@
     </PossiblyUnusedReturnValue>
     <RedundantConditionGivenDocblockType>
       <code>$parentMock !== null</code>
+      <code><![CDATA[\explode('|', $parRefMethodRetType)]]></code>
     </RedundantConditionGivenDocblockType>
     <UnevaluatedCode>
       <code><![CDATA[$exp->andReturn($mock);]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -169,7 +169,6 @@
     </PossiblyUnusedReturnValue>
     <RedundantConditionGivenDocblockType>
       <code>$parentMock !== null</code>
-      <code><![CDATA[\explode('|', $parRefMethodRetType)]]></code>
     </RedundantConditionGivenDocblockType>
     <UnevaluatedCode>
       <code><![CDATA[$exp->andReturn($mock);]]></code>

--- a/tests/Mockery/ReflectorTest.php
+++ b/tests/Mockery/ReflectorTest.php
@@ -40,6 +40,33 @@ class ReflectorTest extends MockeryTestCase
         ];
     }
 
+    /**
+     * @dataProvider provideReservedWords
+     */
+    public function testIsReservedWord(string $type): void
+    {
+        self::assertTrue(Reflector::isReservedWord($type));
+    }
+
+    public static function provideReservedWords(): Generator
+    {
+        foreach ([
+                'bool',
+                'false',
+                'float',
+                'int',
+                'iterable',
+                'mixed',
+                'never',
+                'null',
+                'object',
+                'string',
+                'true',
+                'void'
+        ] as $type) {
+            yield $type => [$type];
+        }
+    }
 }
 
 class ParentClass

--- a/tests/Unit/Regression/Issue1404Test.php
+++ b/tests/Unit/Regression/Issue1404Test.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mockery\Tests\Unit\Regression;
+
+use Generator;
+use Mockery;
+use PDO;
+use PDOStatement;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Mockery
+ * @uses \Mockery\Reflector
+ */
+final class Issue1404Test extends TestCase
+{
+    /**
+     * @return Generator<string,list<string>>
+     */
+    public static function provideResult(): Generator
+    {
+        yield from [
+            'empty' => [[]],
+            'non-empty' => [['Black', 'Lives', 'Matter']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideResult
+     */
+    public function testDemeterChainsAllows(array $result): void
+    {
+        $dbConnection = Mockery::mock(PDO::class);
+
+        $dbConnection->allows('query->fetchAll')->andReturn($result);
+
+        self::assertSame($result, $dbConnection->query('sql')->fetchAll());
+    }
+    /**
+     * @dataProvider provideResult
+     */
+    public function testDemeterChainsExpects(array $result): void
+    {
+        $dbConnection = Mockery::mock(PDO::class);
+
+        $dbConnection->expects('query->fetchAll')->andReturn($result);
+
+        self::assertSame($result, $dbConnection->query('sql')->fetchAll());
+    }
+
+    /**
+     * @dataProvider provideResult
+     */
+    public function testDemeterChainsAlternativeSyntax(array $result): void
+    {
+        $dbConnection = Mockery::mock(PDO::class);
+
+        $dbConnection->shouldReceive('query->fetchAll')->andReturn($result);
+
+        self::assertSame($result, $dbConnection->query('sql')->fetchAll());
+    }
+
+    /**
+     * @dataProvider provideResult
+     */
+    public function testNonDemeterChainsSyntax(array $result): void
+    {
+        $dbStatement = Mockery::mock(PDOStatement::class);
+        $dbStatement->expects('fetchAll')
+                    ->andReturn($result);
+
+        $dbConnection = Mockery::mock(PDO::class);
+        $dbConnection->expects('query')
+                     ->with('sql')
+                     ->andReturn($dbStatement);
+
+        self::assertSame($result, $dbConnection->query('sql')->fetchAll());
+    }
+}


### PR DESCRIPTION
This patch resolves #1404 , via the following changes:

 - Filter reserved words from method return types.