### PR TITLE
Changelog v1.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.11] - 2024-03-21
+
+### Fixed
+
+- [1407: Fix constants map generics doc comments](https://github.com/mockery/mockery/pull/1407)
+- [1406: Fix reserved words used to name a class, interface or trait](https://github.com/mockery/mockery/pull/1406)
+- [1403: Fix regression - partial construction with trait methods](https://github.com/mockery/mockery/pull/1403)
+- [1401: Improve `Mockery::mock()` parameter type compatibility with array typehints](https://github.com/mockery/mockery/pull/1401)
+
 ## [1.6.10] - 2024-03-19
 
 ### Added


### PR DESCRIPTION
## What's Changed

 - [1407: Fix constants map generics doc comments](https://github.com/mockery/mockery/pull/1407)
 - [1406: Fix reserved words used to name a class, interface or trait](https://github.com/mockery/mockery/pull/1406)
 - [1403: Fix regression - partial construction with trait methods](https://github.com/mockery/mockery/pull/1403)
 - [1401: Improve `Mockery::mock()` parameter type compatibility with array typehints](https://github.com/mockery/mockery/pull/1401)


**Full Changelog**: https://github.com/mockery/mockery/compare/1.6.10...1.6.11