### PR TITLE
Update CI workflows to test on PHP 8.4

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2']
+        php: ['8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -24,7 +24,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: none
-          php-version: 8.2
+          php-version: 8.3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         dependencies: ['lowest','highest','locked']
-        dev: ['8.3']
+        dev: ['8.4']
+        stable: ['8.3']
 
     continue-on-error: ${{ matrix.php == matrix.dev || matrix.dependencies == 'lowest' }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ jobs:
         dev: ['8.4']
         stable: ['8.3']
 
-    continue-on-error: ${{ matrix.php == matrix.dev || matrix.dependencies == 'lowest' }}
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -74,3 +72,4 @@ jobs:
 
       - name: Execute PHPUnit
         run: composer phpunit
+        continue-on-error: ${{ matrix.php == matrix.dev || matrix.dependencies == 'lowest' }}


### PR DESCRIPTION
This patch updates CI workflow files:

- `.github/workflows/codecov.yml`
- `.github/workflows/psalm.yml`
- `.github/workflows/tests.yml`