### PR TITLE
Fix mocking anonymous classes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,50 +12,47 @@
 >
     <coverage processUncoveredFiles="true">
         <include>
-            <directory suffix=".php">./library/</directory>
+            <directory suffix=".php">library/</directory>
         </include>
         <exclude>
-            <directory>./library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>./library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>./library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>./library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
+            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
         </exclude>
         <report>
-            <!-- <html outputDirectory=".cache/phpunit/coverage-html"/> -->
+            <html outputDirectory=".cache/phpunit/coverage-html"/>
             <clover outputFile=".cache/phpunit/clover.xml"/>
             <text outputFile=".cache/phpunit/coverage.txt"/>
         </report>
     </coverage>
     <testsuites>
-        <testsuite name="Mockery Test Suite PHP7">
-            <directory suffix="Test.php">./tests</directory>
-            <exclude>./tests/PHP80</exclude>
-            <exclude>./tests/PHP81</exclude>
-            <exclude>./tests/PHP82</exclude>
-            <exclude>./tests/Unit/PHP81</exclude>
-            <exclude>./tests/Unit/PHP82</exclude>
-            <exclude>./tests/Unit/PHP83</exclude>
+        <testsuite name="default">
+            <directory>tests</directory>
+            <exclude>fixtures</exclude>
+            <exclude>tests/Fixture</exclude>
+            <exclude>tests/PHP*</exclude>
+            <exclude>tests/Unit/PHP*</exclude>
+            <exclude>tests/Unit/Regression</exclude>
         </testsuite>
-        <testsuite name="Mockery Test Suite PHP80">
-            <directory phpVersion="8.0.0-dev" phpVersionOperator="&gt;=">./tests</directory>
-            <exclude>./tests/PHP81</exclude>
-            <exclude>./tests/PHP82</exclude>
-            <exclude>./tests/Unit/PHP81</exclude>
-            <exclude>./tests/Unit/PHP82</exclude>
-            <exclude>./tests/Unit/PHP83</exclude>
-        </testsuite>
-        <testsuite name="Mockery Test Suite PHP81">
-            <directory phpVersion="8.1.0-dev" phpVersionOperator="&gt;=">./tests</directory>
-            <exclude>./tests/PHP82</exclude>
-            <exclude>./tests/Unit/PHP82</exclude>
-            <exclude>./tests/Unit/PHP83</exclude>
-        </testsuite>
-        <testsuite name="Mockery Test Suite PHP82">
-            <directory phpVersion="8.2.0-dev" phpVersionOperator="&gt;=">./tests</directory>
-            <exclude>./tests/Unit/PHP83</exclude>
-        </testsuite>
-        <testsuite name="Mockery Test Suite PHP83">
-            <directory phpVersion="8.3.0-dev" phpVersionOperator="&gt;=">./tests</directory>
+        <testsuite name="versioned">
+            <!--<directory phpVersion="7.3.0-dev">tests/Unit/*</directory> -->
+            <!--<directory phpVersion="7.3.0-dev">tests</directory> -->
+            <!--<directory phpVersion="7.4.0-dev">tests/PHP74</directory>-->
+            <!--<directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>-->
+            <!--<directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>-->
+            <!--<directory phpVersion="8.3.0-dev">tests/PHP83</directory>-->
+            <!--<directory phpVersion="8.4.0-dev">tests/PHP84</directory>-->
+            <!--<directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>-->
+            <directory phpVersion="8.0.0-dev">tests/PHP80</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/Regression</directory>
+            <directory phpVersion="8.1.0-dev">tests/PHP81</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/PHP82</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <exclude>fixtures</exclude>
+            <exclude>tests/Fixture</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -19,6 +19,9 @@
     <InternalMethod>
       <code><![CDATA[Reflector::isReservedWord($type)]]></code>
     </InternalMethod>
+    <InvalidArgument>
+      <code><![CDATA[$newMockName]]></code>
+    </InvalidArgument>
     <InvalidReturnStatement>
       <code><![CDATA[$argument]]></code>
       <code><![CDATA[$container->getMocks()[$demeterMockKey] ?? null]]></code>
@@ -74,8 +77,6 @@
       <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
       <code><![CDATA[$formattedArguments]]></code>
       <code><![CDATA[$k]]></code>
     </MixedArgumentTypeCoercion>
@@ -126,6 +127,8 @@
       <code><![CDATA[$expectations]]></code>
     </NullableReturnStatement>
     <PossiblyInvalidArgument>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
       <code><![CDATA[$args]]></code>
       <code><![CDATA[$args]]></code>
     </PossiblyInvalidArgument>
@@ -373,7 +376,7 @@
     <DocblockTypeContradiction>
       <code><![CDATA[$arg instanceof MockConfigurationBuilder]]></code>
       <code><![CDATA[$match === false]]></code>
-      <code><![CDATA[is_object($arg)]]></code>
+      <code><![CDATA[is_string($arg)]]></code>
     </DocblockTypeContradiction>
     <InvalidArgument>
       <code><![CDATA[$keys]]></code>
@@ -473,7 +476,7 @@
       <code><![CDATA[LegacyMockInterface&MockInterface&TMock]]></code>
     </MoreSpecificReturnType>
     <NoValue>
-      <code><![CDATA[$expectationClosure]]></code>
+      <code><![CDATA[$arg]]></code>
     </NoValue>
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$parts[1]]]></code>
@@ -488,15 +491,18 @@
     <PossiblyUnusedReturnValue>
       <code><![CDATA[int]]></code>
     </PossiblyUnusedReturnValue>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[is_array($arg)]]></code>
+    </RedundantConditionGivenDocblockType>
     <RiskyTruthyFalsyComparison>
+      <code><![CDATA[!strpos($type, ']')]]></code>
       <code><![CDATA[strpos($type, ',')]]></code>
     </RiskyTruthyFalsyComparison>
     <TooManyArguments>
       <code><![CDATA[mockery_init]]></code>
     </TooManyArguments>
     <TypeDoesNotContainType>
-      <code><![CDATA[is_callable($finalArg) && is_object($finalArg)]]></code>
-      <code><![CDATA[is_object($finalArg)]]></code>
+      <code><![CDATA[$arg === 'null']]></code>
     </TypeDoesNotContainType>
     <UndefinedInterfaceMethod>
       <code><![CDATA[atLeast]]></code>
@@ -507,9 +513,6 @@
       <code><![CDATA[atLeast]]></code>
       <code><![CDATA[byDefault]]></code>
     </UndefinedMagicMethod>
-    <UnusedVariable>
-      <code><![CDATA[$expectationClosure]]></code>
-    </UnusedVariable>
   </file>
   <file src="library/Mockery/CountValidator/AtLeast.php">
     <InvalidOperand>

--- a/tests/Unit/Regression/Issue1414Test.php
+++ b/tests/Unit/Regression/Issue1414Test.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \Mockery
  * @see https://github.com/mockery/mockery/issues/1414
+ * @requires PHP 8.0
  */
 final class Issue1414Test extends TestCase
 {

--- a/tests/Unit/Regression/Issue1414Test.php
+++ b/tests/Unit/Regression/Issue1414Test.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mockery\Tests\Unit\Regression;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Mockery
+ * @see https://github.com/mockery/mockery/issues/1414
+ */
+final class Issue1414Test extends TestCase
+{
+    public function testMockAnonymousClass(): void
+    {
+        $class = new class() extends \stdClass {};
+
+        $mock = Mockery::mock($class::class);
+
+        self::assertInstanceOf($class::class, $mock);
+    }
+}


### PR DESCRIPTION
This patch resolves #1414, via the following changes:

 - Add `tests/Unit/Regression/Issue1414Test.php`
 - Fix `library/Mockery/Container.php`

checks for the presence of the issue and verifies that the fix works correctly to prevent regression in the future.