### PR TITLE
Bump `Jinja2` from `3.1.3` to `3.1.4` fix CVE-2024-34064

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.3.2
 docutils==0.20.1
 idna==3.7
 imagesize==1.4.1
-Jinja2==3.1.3
+Jinja2==3.1.4
 MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2


### PR DESCRIPTION
Fix CVE-2024-34064