### PR TITLE
Properly Handle Initialization Errors and Ensure Accurate 'Failed Expectation' Messages

### DIFF
--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -885,8 +885,8 @@ class Mockery
                 $name = $publicProperty->getName();
                 try {
                     $cleanedProperties[$name] = self::cleanupNesting($object->{$name}, $nesting);
-                } catch (Exception $exception) {
-                    $cleanedProperties[$name] = $exception->getMessage();
+                } catch (Throwable $throwable) {
+                    $cleanedProperties[$name] = $throwable->getMessage();
                 }
             }
         }


### PR DESCRIPTION
This patch resolves #1132, via the following changes:

 - Switching from `Exception` to `Throwable` in Mockery's TryCatch Block