### PR TITLE
Bump `requests` from 2.31.0 to 2.32.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ Jinja2==3.1.4
 MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2
-requests==2.31.0
+requests==2.32.0
 setuptools==69.2.0
 snowballstemmer==2.2.0
 Sphinx==7.3.7


### PR DESCRIPTION
Fix [CVE-2024-35195](https://github.com/advisories/GHSA-9wx4-h78v-vm56), upgrading to patched version.