### PR TITLE
Bump `certifi` from 2024.2.2 to 2024.07.04

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.16
 Babel==2.14.0
-certifi==2024.2.2
+certifi==2024.07.04
 charset-normalizer==3.3.2
 docutils==0.20.1
 idna==3.7


### PR DESCRIPTION
Fix [CVE-2024-39689](https://github.com/advisories/GHSA-248v-346w-9cwc)