### PR TITLE
Bump `urllib3` from 2.2.1 to 2.2.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,5 +21,5 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
-urllib3==2.2.1
+urllib3==2.2.2
 wheel==0.43.0


### PR DESCRIPTION
Fix [CVE-2024-37891](https://github.com/advisories/GHSA-34jh-p97f-mpxf)