### PR TITLE
Bump setuptools from 69.2.0 to 70.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2
 requests==2.32.0
-setuptools==69.2.0
+setuptools==70.0.0
 snowballstemmer==2.2.0
 Sphinx==7.3.7
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
Fixes [CVE-2024-6345](https://github.com/advisories/GHSA-cx63-2mw6-8hw5)