### PR TITLE
Refactor `\Mockery\Container::mock`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -50,7 +50,7 @@ jobs:
           ${fullCommand}
 
       - name: Run PHPUnit to collect coverage
-        run: composer phpunit:coverage
+        run: composer phpunit
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,7 +23,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
           tools: composer:v2
-          extensions: mongodb, redis
+          extensions: mongodb, redis-phpredis/phpredis@develop
 
       - name: Get composer cache directory
         id: composer-cache
@@ -53,7 +53,7 @@ jobs:
         run: composer phpunit:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: ${{ github.workspace }}/.cache/phpunit/
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -55,9 +55,13 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          directory: ${{ github.workspace }}/.cache/phpunit/
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
       - name: Upload test results to Codecov
         uses: codecov/test-results-action@v1
         with:
+          directory: ${{ github.workspace }}/.cache/phpunit/
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -20,9 +20,10 @@ php_versions=(
 )
 
 projects=(
-    "laravel/framework"
-    "Brain-WP/BrainMonkey"
     "filp/whoops"
+    "thephpleague/glide"
+    "10up/wp_mock"
+    "laravel/framework"
 )
 
 mockery_path="$(pwd)"
@@ -44,7 +45,7 @@ echo "Mockery path: $mockery_path"
 echo "Resource path: $resources_path"
 echo " "
 
-
+rm -rf "$resources_path" || { echo "Failed to remove directory $resources_path"; exit 1; }
 mkdir -p "$resources_path" || { echo "Failed to create directory $resources_path"; exit 1; }
 cd "$resources_path" || { echo "Failed to change directory to $resources_path"; exit 1; }
 
@@ -53,7 +54,7 @@ do
     project_path="$resources_path/$project"
 
     if [ ! -d "$project_path" ]; then
-        echo "Cloning $project to $project_path"
+        echo "Cloning $project to $project_path\n\n"
 
         git clone "git@github.com:$project.git" "$project_path" --depth=1 || { echo "Failed to clone $project"; exit 1; }
     else
@@ -72,7 +73,7 @@ do
     do
         echo "Running PHPUnit for PHP version $php_version"
 
-        docker run -it --rm -v "$mockery_path":/opt/mockery -v "$project_path":/opt/workspace -w /opt/workspace ghcr.io/ghostwriter/php:"$php_version"-pcov sh -c "composer config repositories.local '{\"type\": \"path\", \"url\": \"/opt/mockery\"}' && composer require 'mockery/mockery:$mockery_version' --with-dependencies --ignore-platform-reqs --no-scripts --no-plugins --dev --no-interaction && php vendor/bin/phpunit" || { echo "Failed to run PHPUnit for $project PHP version $php_version"; exit 1; }
+        docker run -it --rm -v "$mockery_path":/opt/mockery -v "$project_path":/opt/workspace -w /opt/workspace ghcr.io/ghostwriter/php:"$php_version"-pcov sh -c "composer config repositories.local '{\"type\": \"path\", \"url\": \"/opt/mockery\"}' && composer require 'mockery/mockery:$mockery_version' --with-dependencies --ignore-platform-reqs --no-scripts --no-plugins --dev --no-interaction && php /opt/workspace/vendor/bin/phpunit" || { echo "Failed to run PHPUnit for $project PHP version $php_version"; exit 1; }
     done
 done
 

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -16,10 +16,11 @@ use Mockery;
 use Mockery\Exception\InvalidOrderException;
 use Mockery\Exception\RuntimeException;
 use Mockery\Generator\Generator;
+use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\MockConfigurationBuilder;
 use Mockery\Loader\Loader as LoaderInterface;
 use ReflectionClass;
-use ReflectionException;
+use stdClass;
 use Throwable;
 
 use function array_filter;
@@ -33,7 +34,7 @@ use function count;
 use function explode;
 use function get_class;
 use function interface_exists;
-use function is_callable;
+use function is_array;
 use function is_object;
 use function is_string;
 use function md5;
@@ -43,9 +44,10 @@ use function range;
 use function reset;
 use function rtrim;
 use function sprintf;
+use function str_contains;
 use function str_replace;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use function strtolower;
 use function substr;
 use function trait_exists;
@@ -93,7 +95,8 @@ class Container
     /**
      * Store of mock objects
      *
-     * @var array<class-string<LegacyMockInterface&MockInterface&TMockObject>|array-key,LegacyMockInterface&MockInterface&TMockObject>
+     * @template TMockObject of object
+     * @var array<class-string<(LegacyMockInterface&TMockObject)|(MockInterface&TMockObject)>,(LegacyMockInterface&TMockObject)|(MockInterface&TMockObject)>
      */
     protected $_mocks = [];
 
@@ -118,11 +121,11 @@ class Container
      * Return a specific remembered mock according to the array index it
      * was stored to in this container instance
      *
-     * @template TMock of object
+     * @template TFetchMock of object
      *
-     * @param class-string<TMock> $reference
+     * @param class-string<TFetchMock> $reference
      *
-     * @return null|(LegacyMockInterface&MockInterface&TMock)
+     * @return null|(LegacyMockInterface&TFetchMock)|(MockInterface&TFetchMock)
      */
     public function fetchMock($reference)
     {
@@ -168,8 +171,7 @@ class Container
     }
 
     /**
-     * @template TMock of object
-     * @return array<class-string<LegacyMockInterface&MockInterface&TMockObject>|array-key,LegacyMockInterface&MockInterface&TMockObject>
+     * @return array<class-string<(LegacyMockInterface&TMockObject)|(MockInterface&TMockObject)>,(LegacyMockInterface&TMockObject)|(MockInterface&TMockObject)>
      */
     public function getMocks()
     {
@@ -198,11 +200,11 @@ class Container
 
         // all the namespaces and class name should match the regex
         return array_filter(
-            explode('\\', $className),
-            static function ($name): bool {
-                return ! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name);
-            }
-        ) === [];
+                explode('\\', $className),
+                static function ($name): bool {
+                    return ! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name);
+                }
+            ) === [];
     }
 
     /**
@@ -215,171 +217,27 @@ class Container
      *
      * @template TMock of object
      *
-     * @param array<class-string<TMock>|TMock|Closure(LegacyMockInterface&MockInterface&TMock):LegacyMockInterface&MockInterface&TMock|array<TMock>> $args
+     * @param (TMock|class-string<TMock>|array<class-string<TMock>|TMock|MockConfigurationBuilder>|(Closure((LegacyMockInterface&TMock)|(MockInterface&TMock)):void)) ...$args
      *
-     * @throws ReflectionException|RuntimeException
+     * @throws Throwable
      *
-     * @return LegacyMockInterface&MockInterface&TMock
+     * @return (LegacyMockInterface&TMock)|(MockInterface&TMock)
      */
     public function mock(...$args)
     {
-        /** @var null|MockConfigurationBuilder $builder */
-        $builder = null;
-        /** @var null|callable $expectationClosure */
-        $expectationClosure = null;
-        $partialMethods = null;
-        $quickDefinitions = [];
-        $constructorArgs = null;
-        $blocks = [];
-
-        if (count($args) > 1) {
-            $finalArg = array_pop($args);
-
-            if (is_callable($finalArg) && is_object($finalArg)) {
-                $expectationClosure = $finalArg;
-            } else {
-                $args[] = $finalArg;
-            }
-        }
-
-        foreach ($args as $k => $arg) {
-            if ($arg instanceof MockConfigurationBuilder) {
-                $builder = $arg;
-
-                unset($args[$k]);
-            }
-        }
-
-        reset($args);
-
-        $builder = $builder ?? new MockConfigurationBuilder();
-        $mockeryConfiguration = Mockery::getConfiguration();
-        $builder->setParameterOverrides($mockeryConfiguration->getInternalClassMethodParamMaps());
-        $builder->setConstantsMap($mockeryConfiguration->getConstantsMap());
-
-        while ($args !== []) {
-            $arg = array_shift($args);
-
-            // check for multiple interfaces
-            if (is_string($arg)) {
-                foreach (explode('|', $arg) as $type) {
-                    if ($arg === 'null') {
-                        // skip PHP 8 'null's
-                        continue;
-                    }
-
-                    if (strpos($type, ',') && !strpos($type, ']')) {
-                        $interfaces = explode(',', str_replace(' ', '', $type));
-
-                        $builder->addTargets($interfaces);
-
-                        continue;
-                    }
-
-                    if (strpos($type, 'alias:') === 0) {
-                        $type = str_replace('alias:', '', $type);
-
-                        $builder->addTarget('stdClass');
-                        $builder->setName($type);
-
-                        continue;
-                    }
-
-                    if (strpos($type, 'overload:') === 0) {
-                        $type = str_replace('overload:', '', $type);
-
-                        $builder->setInstanceMock(true);
-                        $builder->addTarget('stdClass');
-                        $builder->setName($type);
-
-                        continue;
-                    }
-
-                    if ($type[strlen($type) - 1] === ']') {
-                        $parts = explode('[', $type);
-
-                        $class = $parts[0];
-
-                        if (! class_exists($class, true) && ! interface_exists($class, true)) {
-                            throw new Exception('Can only create a partial mock from an existing class or interface');
-                        }
-
-                        $builder->addTarget($class);
-
-                        $partialMethods = array_filter(
-                            explode(',', strtolower(rtrim(str_replace(' ', '', $parts[1]), ']')))
-                        );
-
-                        foreach ($partialMethods as $partialMethod) {
-                            if ($partialMethod[0] === '!') {
-                                $builder->addBlackListedMethod(substr($partialMethod, 1));
-
-                                continue;
-                            }
-
-                            $builder->addWhiteListedMethod($partialMethod);
-                        }
-
-                        continue;
-                    }
-
-                    if (class_exists($type, true) || interface_exists($type, true) || trait_exists($type, true)) {
-                        $builder->addTarget($type);
-
-                        continue;
-                    }
-
-                    if (! $mockeryConfiguration->mockingNonExistentMethodsAllowed()) {
-                        throw new Exception(sprintf("Mockery can't find '%s' so can't mock it", $type));
-                    }
-
-                    if (! $this->isValidClassName($type)) {
-                        throw new Exception('Class name contains invalid characters');
-                    }
-
-                    $builder->addTarget($type);
-
-                    // unions are "sum" types and not "intersections", and so we must only process the first part
-                    break;
-                }
-
-                continue;
-            }
-
-            if (is_object($arg)) {
-                $builder->addTarget($arg);
-
-                continue;
-            }
-
-            if (is_array($arg)) {
-                if ([] !== $arg && array_keys($arg) !== range(0, count($arg) - 1)) {
-                    // if associative array
-                    if (array_key_exists(self::BLOCKS, $arg)) {
-                        $blocks = $arg[self::BLOCKS];
-                    }
-
-                    unset($arg[self::BLOCKS]);
-
-                    $quickDefinitions = $arg;
-
-                    continue;
-                }
-
-                $constructorArgs = $arg;
-
-                continue;
-            }
-
-            throw new Exception(sprintf(
-                'Unable to parse arguments sent to %s::mock()', get_class($this)
-            ));
-        }
+        [
+            $expectationClosure,
+            $builder,
+            $partialMethods,
+            $quickDefinitions,
+            $constructorArgs,
+            $blocks
+        ] = $this->parseArguments($args);
 
         $builder->addBlackListedMethods($blocks);
 
         if ($constructorArgs !== null) {
-            $builder->addBlackListedMethod('__construct'); // we need to pass through
+            $builder->addBlackListedMethod('__construct');
         } else {
             $builder->setMockOriginalDestructor(true);
         }
@@ -388,36 +246,30 @@ class Container
             $constructorArgs = [];
         }
 
-        $config = $builder->getMockConfiguration();
+        $mockConfiguration = $builder->getMockConfiguration();
 
-        $this->checkForNamedMockClashes($config);
+        $this->checkForNamedMockClashes($mockConfiguration);
 
-        $def = $this->getGenerator()->generate($config);
+        $className = $this->generateMock($mockConfiguration);
 
-        $className = $def->getClassName();
-        if (class_exists($className, $attemptAutoload = false)) {
-            $rfc = new ReflectionClass($className);
-            if (! $rfc->implementsInterface(LegacyMockInterface::class)) {
-                throw new RuntimeException(sprintf('Could not load mock %s, class already exists', $className));
-            }
-        }
-
-        $this->getLoader()->load($def);
-
-        $mock = $this->_getInstance($className, $constructorArgs);
-        $mock->mockery_init($this, $config->getTargetObject(), $config->isInstanceMock());
+        $mock = $this->initializeMock($className, $constructorArgs, $mockConfiguration);
 
         if ($quickDefinitions !== []) {
-            if ($mockeryConfiguration->getQuickDefinitions()->shouldBeCalledAtLeastOnce()) {
-                $mock->shouldReceive($quickDefinitions)->atLeast()->once();
+            if (
+                Mockery::getConfiguration()
+                       ->getQuickDefinitions()
+                       ->shouldBeCalledAtLeastOnce()
+            ) {
+                $mock->shouldReceive($quickDefinitions)
+                     ->atLeast()
+                     ->once();
             } else {
-                $mock->shouldReceive($quickDefinitions)->byDefault();
+                $mock->shouldReceive($quickDefinitions)
+                     ->byDefault();
             }
         }
 
-        // if the last parameter passed to mock() is a closure,
         if ($expectationClosure instanceof Closure) {
-            // call the closure with the mock object
             $expectationClosure($mock);
         }
 
@@ -512,6 +364,8 @@ class Container
      * Tear down tasks for this container
      *
      * @throws PHPException
+     *
+     * @return void
      */
     public function mockery_teardown()
     {
@@ -550,6 +404,8 @@ class Container
      * @param int    $order
      *
      * @throws Exception
+     *
+     * @return void
      */
     public function mockery_validateOrder($method, $order, LegacyMockInterface $mock)
     {
@@ -564,9 +420,9 @@ class Container
             );
 
             $exception->setMock($mock)
-                ->setMethodName($method)
-                ->setExpectedOrder($order)
-                ->setActualOrder($this->_currentOrder);
+                      ->setMethodName($method)
+                      ->setExpectedOrder($order)
+                      ->setActualOrder($this->_currentOrder);
 
             throw $exception;
         }
@@ -576,6 +432,8 @@ class Container
 
     /**
      * Verify the container mocks
+     *
+     * @return void
      */
     public function mockery_verify()
     {
@@ -587,11 +445,11 @@ class Container
     /**
      * Store a mock and set its container reference
      *
-     * @template TRememberMock of object
+     * @template TRememberMock
      *
-     * @param LegacyMockInterface&MockInterface&TRememberMock $mock
+     * @param (LegacyMockInterface&TRememberMock)|(MockInterface&TRememberMock) $mock
      *
-     * @return LegacyMockInterface&MockInterface&TRememberMock
+     * @return (LegacyMockInterface&TRememberMock)|(MockInterface&TRememberMock)
      */
     public function rememberMock(LegacyMockInterface $mock)
     {
@@ -602,8 +460,8 @@ class Container
         }
 
         /**
-         * This condition triggers for an instance mock where origin mock
-         * is already remembered
+         * This condition triggers for an instance mock
+         * where origin mock is already remembered
          */
         return $this->_mocks[] = $mock;
     }
@@ -613,7 +471,7 @@ class Container
      * which is the same as saying retrieve the current mock being programmed where you have yet to call mock()
      * to change it thus why the method name is "self" since it will be used during the programming of the same mock.
      *
-     * @return LegacyMockInterface|MockInterface
+     * @return (LegacyMockInterface&TMockObject)|(MockInterface&TMockObject)
      */
     public function self()
     {
@@ -628,6 +486,8 @@ class Container
      *
      * @param class-string<TMock> $mockName
      * @param null|array<TMixed>  $constructorArgs
+     *
+     * @throws Throwable
      *
      * @return TMock
      */
@@ -657,6 +517,13 @@ class Container
         return $instance;
     }
 
+    /**
+     * @param MockConfiguration $config
+     *
+     * @return void
+     *
+     * @throws Throwable
+     */
     protected function checkForNamedMockClashes($config)
     {
         $name = $config->getName();
@@ -674,5 +541,209 @@ class Container
         }
 
         $this->_namedMocks[$name] = $hash;
+    }
+
+    private function createBuilder(array &$arguments): MockConfigurationBuilder
+    {
+        foreach ($arguments as $key => $argument) {
+            if (! $argument instanceof MockConfigurationBuilder) {
+                continue;
+            }
+
+            unset($arguments[$key]);
+
+            return $argument;
+        }
+
+        return new MockConfigurationBuilder();
+    }
+
+    /**
+     * @template TMock of object
+     *
+     * @return class-string<TMock>
+     *
+     * @throws Throwable
+     */
+    private function generateMock(MockConfiguration $mockConfiguration): string
+    {
+        $mockDefinition = $this->getGenerator()->generate($mockConfiguration);
+
+        $className = $mockDefinition->getClassName();
+
+        if (class_exists($className, $attemptAutoload = false)) {
+            $rfc = new ReflectionClass($className);
+
+            if (! $rfc->implementsInterface(LegacyMockInterface::class)) {
+                throw new RuntimeException(sprintf('Could not load mock %s, class already exists', $className));
+            }
+        }
+
+        $this->getLoader()->load($mockDefinition);
+
+        return $className;
+    }
+
+    /** @return null|Closure(MockInterface):void */
+    private function handleClosure(array &$arguments): ?Closure
+    {
+        if (2 > count($arguments)) {
+            return null;
+        }
+
+        $argument = array_pop($arguments);
+
+        if ($argument instanceof Closure) {
+            /** @var Closure(MockInterface):void $argument */
+            return $argument;
+        }
+
+        $arguments[] = $argument;
+
+        return null;
+    }
+
+    private function initializeBuilder(array &$arguments): MockConfigurationBuilder
+    {
+        $configuration = Mockery::getConfiguration();
+        return $this->createBuilder($arguments)
+                    ->setParameterOverrides($configuration->getInternalClassMethodParamMaps())
+                    ->setConstantsMap($configuration->getConstantsMap());
+    }
+
+    /**
+     * @template TMock of object
+     *
+     * @param class-string<TMock> $className
+     * @param null|array $constructorArgs
+     * @param MockConfiguration $mockConfiguration
+     *
+     * @return (TMock&MockInterface)|(TMock&LegacyMockInterface)
+     */
+    private function initializeMock(string $className, ?array $constructorArgs, MockConfiguration $mockConfiguration): object
+    {
+        $mock = $this->_getInstance($className, $constructorArgs);
+        $mock->mockery_init($this, $mockConfiguration->getTargetObject(), $mockConfiguration->isInstanceMock());
+        return $mock;
+    }
+
+    private function parseArguments(array &$arguments): array
+    {
+        $blocks = [];
+        $constructorArgs = null;
+        $partialMethods = null;
+        $quickDefinitions = [];
+        $expectationClosure = $this->handleClosure($arguments);
+        $builder = $this->initializeBuilder($arguments);
+
+        while ($arguments !== []) {
+            $argument = array_shift($arguments);
+
+            if (is_string($argument)) {
+                $this->parseStringArgument($argument, $builder, $partialMethods);
+
+                continue;
+            }
+
+            if (is_object($argument)) {
+                $builder->addTarget($argument);
+
+                continue;
+            }
+
+            if (is_array($argument)) {
+                $this->parseArrayArgument($argument, $quickDefinitions, $constructorArgs, $blocks);
+
+                continue;
+            }
+
+            throw new Exception(sprintf('Unable to parse arguments sent to %s::mock()', get_class($this)));
+        }
+
+        return [$expectationClosure, $builder, $partialMethods, $quickDefinitions, $constructorArgs, $blocks];
+    }
+
+    private function parseArrayArgument(
+        array $argument,
+        array &$quickDefinitions,
+        ?array &$constructorArgs,
+        array &$blocks
+    ): void {
+        if ($argument !== [] && array_keys($argument) !== range(0, count($argument) - 1)) {
+            if (array_key_exists(self::BLOCKS, $argument)) {
+                $blocks = $argument[self::BLOCKS];
+            }
+            unset($argument[self::BLOCKS]);
+            $quickDefinitions = $argument;
+        } else {
+            $constructorArgs = $argument;
+        }
+    }
+
+    private function parseStringArgument(
+        string $arguments,
+        MockConfigurationBuilder $builder,
+        ?array &$partialMethods
+    ): void {
+        foreach (explode('|', $arguments) as $type) {
+            if ($arguments === 'null') {
+                continue;
+            }
+
+            if (str_contains($type, ',') && ! str_contains($type, ']')) {
+                $interfaces = explode(',', str_replace(' ', '', $type));
+                $builder->addTargets($interfaces);
+                continue;
+            }
+
+            if (str_starts_with($type, 'alias:')) {
+                $builder->addTarget(stdClass::class);
+                $builder->setName(substr($type, 6));
+                continue;
+            }
+
+            if (str_starts_with($type, 'overload:')) {
+                $builder->addTarget(stdClass::class);
+                $builder->setInstanceMock(true);
+                $builder->setName(substr($type,9));
+                continue;
+            }
+
+            if (str_ends_with($type, ']')){
+                $parts = explode('[', $type);
+                $class = $parts[0];
+
+                if (! class_exists($class, true) && ! interface_exists($class, true)) {
+                    throw new Exception('Can only create a partial mock from an existing class or interface');
+                }
+
+                $builder->addTarget($class);
+                $partialMethods = array_filter(explode(',', strtolower(rtrim(str_replace(' ', '', $parts[1]), ']'))));
+                foreach ($partialMethods as $partialMethod) {
+                    if ($partialMethod[0] === '!') {
+                        $builder->addBlackListedMethod(substr($partialMethod, 1));
+                    } else {
+                        $builder->addWhiteListedMethod($partialMethod);
+                    }
+                }
+                continue;
+            }
+
+            if (class_exists($type, true) || interface_exists($type, true) || trait_exists($type, true)) {
+                $builder->addTarget($type);
+                continue;
+            }
+
+            if (! Mockery::getConfiguration()->mockingNonExistentMethodsAllowed()) {
+                throw new Exception(sprintf("Mockery can't find '%s' so can't mock it", $type));
+            }
+
+            if (! $this->isValidClassName($type)) {
+                throw new Exception('Class name contains invalid characters');
+            }
+
+            $builder->addTarget($type);
+            break;
+        }
     }
 }

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -45,12 +45,14 @@ use function reset;
 use function rtrim;
 use function sprintf;
 use function str_contains;
+use function str_ends_with;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
 use function substr;
 use function trait_exists;
+use function trim;
 
 /**
  * Container for mock objects
@@ -194,6 +196,10 @@ class Container
      */
     public function isValidClassName($className)
     {
+        if (trim($className) === '') {
+            return false;
+        }
+
         if ($className[0] === '\\') {
             $className = substr($className, 1); // remove the first backslash
         }
@@ -217,7 +223,7 @@ class Container
      *
      * @template TMock of object
      *
-     * @param (TMock|class-string<TMock>|array<class-string<TMock>|TMock|MockConfigurationBuilder>|(Closure((LegacyMockInterface&TMock)|(MockInterface&TMock)):void)) ...$args
+     * @param (array<class-string<TMock>|MockConfigurationBuilder|TMock>|class-string<TMock>|(Closure((LegacyMockInterface&TMock)|(MockInterface&TMock)):void)|TMock) ...$args
      *
      * @throws Throwable
      *
@@ -257,15 +263,15 @@ class Container
         if ($quickDefinitions !== []) {
             if (
                 Mockery::getConfiguration()
-                       ->getQuickDefinitions()
-                       ->shouldBeCalledAtLeastOnce()
+                    ->getQuickDefinitions()
+                    ->shouldBeCalledAtLeastOnce()
             ) {
                 $mock->shouldReceive($quickDefinitions)
-                     ->atLeast()
-                     ->once();
+                    ->atLeast()
+                    ->once();
             } else {
                 $mock->shouldReceive($quickDefinitions)
-                     ->byDefault();
+                    ->byDefault();
             }
         }
 
@@ -420,9 +426,9 @@ class Container
             );
 
             $exception->setMock($mock)
-                      ->setMethodName($method)
-                      ->setExpectedOrder($order)
-                      ->setActualOrder($this->_currentOrder);
+                ->setMethodName($method)
+                ->setExpectedOrder($order)
+                ->setActualOrder($this->_currentOrder);
 
             throw $exception;
         }
@@ -561,13 +567,14 @@ class Container
     /**
      * @template TMock of object
      *
+     * @throws Throwable
      * @return class-string<TMock>
      *
-     * @throws Throwable
      */
     private function generateMock(MockConfiguration $mockConfiguration): string
     {
-        $mockDefinition = $this->getGenerator()->generate($mockConfiguration);
+        $mockDefinition = $this->getGenerator()
+            ->generate($mockConfiguration);
 
         $className = $mockDefinition->getClassName();
 
@@ -579,7 +586,8 @@ class Container
             }
         }
 
-        $this->getLoader()->load($mockDefinition);
+        $this->getLoader()
+            ->load($mockDefinition);
 
         return $className;
     }
@@ -587,7 +595,7 @@ class Container
     /** @return null|Closure(MockInterface):void */
     private function handleClosure(array &$arguments): ?Closure
     {
-        if (2 > count($arguments)) {
+        if (count($arguments) < 2) {
             return null;
         }
 
@@ -607,8 +615,8 @@ class Container
     {
         $configuration = Mockery::getConfiguration();
         return $this->createBuilder($arguments)
-                    ->setParameterOverrides($configuration->getInternalClassMethodParamMaps())
-                    ->setConstantsMap($configuration->getConstantsMap());
+            ->setParameterOverrides($configuration->getInternalClassMethodParamMaps())
+            ->setConstantsMap($configuration->getConstantsMap());
     }
 
     /**
@@ -620,8 +628,11 @@ class Container
      *
      * @return (TMock&MockInterface)|(TMock&LegacyMockInterface)
      */
-    private function initializeMock(string $className, ?array $constructorArgs, MockConfiguration $mockConfiguration): object
-    {
+    private function initializeMock(
+        string $className,
+        ?array $constructorArgs,
+        MockConfiguration $mockConfiguration
+    ): object {
         $mock = $this->_getInstance($className, $constructorArgs);
         $mock->mockery_init($this, $mockConfiguration->getTargetObject(), $mockConfiguration->isInstanceMock());
         return $mock;
@@ -705,11 +716,11 @@ class Container
             if (str_starts_with($type, 'overload:')) {
                 $builder->addTarget(stdClass::class);
                 $builder->setInstanceMock(true);
-                $builder->setName(substr($type,9));
+                $builder->setName(substr($type, 9));
                 continue;
             }
 
-            if (str_ends_with($type, ']')){
+            if (str_ends_with($type, ']')) {
                 $parts = explode('[', $type);
                 $class = $parts[0];
 

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -38,6 +38,11 @@ if (! \function_exists('anyArgs')) {
 
 if (! \function_exists('get_debug_type')) {
     /**
+     * Copied from symfony/polyfill (https://github.com/symfony/polyfill/blob/1.x/src/Php80/Php80.php)
+     *
+     * @copyright Fabien Potencier
+     * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
+     *
      * @param mixed $value
      */
     function get_debug_type($value): string

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -15,55 +15,6 @@ use Mockery\Matcher\AndAnyOtherArgs;
 use Mockery\Matcher\AnyArgs;
 use Mockery\MockInterface;
 
-if (! \function_exists('mock')) {
-    /**
-     * @template TMock of object
-     *
-     * @param TMock|array<class-string<TMock>|TMock|Closure(LegacyMockInterface&MockInterface&TMock):LegacyMockInterface&MockInterface&TMock|array<TMock>> ...$args
-     *
-     * @return (LegacyMockInterface|MockInterface)&TMock
-     */
-    function mock(...$args)
-    {
-        return Mockery::mock(...$args);
-    }
-}
-
-if (! \function_exists('spy')) {
-    /**
-     * @template TSpy of object
-     *
-     * @param TSpy|array<class-string<TSpy>|TSpy|Closure(LegacyMockInterface&MockInterface&TSpy):LegacyMockInterface&MockInterface&TSpy|array<TSpy>> ...$args
-     *
-     * @return (LegacyMockInterface|MockInterface)&TSpy
-     */
-    function spy(...$args)
-    {
-        return Mockery::spy(...$args);
-    }
-}
-
-if (! \function_exists('namedMock')) {
-    /**
-     * @template TNamedMock of object
-     *
-     * @param TNamedMock|array<class-string<TNamedMock>|TNamedMock|array<TNamedMock>> ...$args
-     *
-     * @return (LegacyMockInterface|MockInterface)&TNamedMock
-     */
-    function namedMock(...$args)
-    {
-        return Mockery::namedMock(...$args);
-    }
-}
-
-if (! \function_exists('anyArgs')) {
-    function anyArgs(): AnyArgs
-    {
-        return new AnyArgs();
-    }
-}
-
 if (! \function_exists('andAnyOtherArgs')) {
     function andAnyOtherArgs(): AndAnyOtherArgs
     {
@@ -75,5 +26,171 @@ if (! \function_exists('andAnyOthers')) {
     function andAnyOthers(): AndAnyOtherArgs
     {
         return new AndAnyOtherArgs();
+    }
+}
+
+if (! \function_exists('anyArgs')) {
+    function anyArgs(): AnyArgs
+    {
+        return new AnyArgs();
+    }
+}
+
+if (! \function_exists('get_debug_type')) {
+    /**
+     * @param mixed $value
+     */
+    function get_debug_type($value): string
+    {
+        switch (true) {
+            case $value === null: return 'null';
+            case \is_bool($value): return 'bool';
+            case \is_string($value): return 'string';
+            case \is_array($value): return 'array';
+            case \is_int($value): return 'int';
+            case \is_float($value): return 'float';
+            case \is_object($value): break;
+            case $value instanceof \__PHP_Incomplete_Class: return '__PHP_Incomplete_Class';
+            default:
+                if (null === $type = @\get_resource_type($value)) {
+                    return 'unknown';
+                }
+
+                if ($type === 'Unknown') {
+                    $type = 'closed';
+                }
+
+                return "resource ({$type})";
+        }
+
+        $class = \get_class($value);
+
+        if (! \str_contains($class, '@')) {
+            return $class;
+        }
+
+        $parent = \get_parent_class($class);
+        if ($parent !== false) {
+            return $parent . '@anonymous';
+        }
+
+        $interfaces = \class_implements($class);
+        if ($interfaces === false) {
+            return 'class@anonymous';
+        }
+
+        $parent = \key($interfaces);
+        if ($parent === null) {
+            return 'class@anonymous';
+        }
+
+        return $parent . '@anonymous';
+    }
+}
+
+if (! \function_exists('mock')) {
+    /**
+     * @template TMixed
+     *
+     * @param TMixed ...$args
+     *
+     * @throws Throwable
+     *
+     * @return LegacyMockInterface|MockInterface
+     */
+    function mock(...$args)
+    {
+        return Mockery::mock(...$args);
+    }
+}
+
+if (! \function_exists('namedMock')) {
+    /**
+     * @template TMixed
+     *
+     * @param TMixed ...$args
+     *
+     * @return ((LegacyMockInterface&TMixed)|(TMixed&MockInterface))
+     *
+     * @throws Throwable
+     *
+     */
+    function namedMock(...$args)
+    {
+        return Mockery::namedMock(...$args);
+    }
+}
+
+if (! \function_exists('spy')) {
+    /**
+     * @template TMixed
+     *
+     * @param TMixed ...$args
+     *
+     * @return ((LegacyMockInterface&TMixed)|(TMixed&MockInterface))
+     *
+     * @throws Throwable
+     */
+    function spy(...$args)
+    {
+        return Mockery::spy(...$args);
+    }
+}
+
+if (! \function_exists('str_contains')) {
+    /**
+     * Copied from symfony/polyfill (https://github.com/symfony/polyfill/blob/1.x/src/Php80/Php80.php)
+     *
+     * @copyright Fabien Potencier
+     * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
+     *
+     * @param non-empty-string $haystack
+     * @param non-empty-string $needle
+     */
+    function str_contains(string $haystack, string $needle): bool
+    {
+        return '' === $needle || false !== strpos($haystack, $needle);
+    }
+}
+
+if (! \function_exists('str_ends_with')) {
+    /**
+     * Copied from symfony/polyfill (https://github.com/symfony/polyfill/blob/1.x/src/Php80/Php80.php)
+     *
+     * @copyright Fabien Potencier
+     * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
+     *
+     * @param non-empty-string $haystack
+     * @param non-empty-string $needle
+     */
+    function str_ends_with(string $haystack, string $needle): bool
+    {
+        if ('' === $needle || $needle === $haystack) {
+            return true;
+        }
+
+        if ('' === $haystack) {
+            return false;
+        }
+
+        $needleLength = \strlen($needle);
+
+        return $needleLength <= \strlen($haystack) && 0 === substr_compare($haystack, $needle, -$needleLength);
+    }
+}
+
+if (! \function_exists('str_starts_with')) {
+    /**
+     * Copied from symfony/polyfill (https://github.com/symfony/polyfill/blob/1.x/src/Php80/Php80.php)
+     *
+     * @copyright Fabien Potencier
+     * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
+     *
+     * @param non-empty-string $haystack
+     * @param non-empty-string $needle
+     */
+    function str_starts_with(string $haystack, string $needle): bool
+    {
+        return 0 === strncmp($haystack, $needle, \strlen($needle));
     }
 }

--- a/library/helpers.php
+++ b/library/helpers.php
@@ -115,10 +115,9 @@ if (! \function_exists('namedMock')) {
      *
      * @param TMixed ...$args
      *
-     * @return ((LegacyMockInterface&TMixed)|(TMixed&MockInterface))
-     *
      * @throws Throwable
      *
+     * @return ((LegacyMockInterface&TMixed)|(MockInterface&TMixed))
      */
     function namedMock(...$args)
     {
@@ -132,9 +131,9 @@ if (! \function_exists('spy')) {
      *
      * @param TMixed ...$args
      *
-     * @return ((LegacyMockInterface&TMixed)|(TMixed&MockInterface))
-     *
      * @throws Throwable
+     * @return ((LegacyMockInterface&TMixed)|(MockInterface&TMixed))
+     *
      */
     function spy(...$args)
     {
@@ -154,7 +153,7 @@ if (! \function_exists('str_contains')) {
      */
     function str_contains(string $haystack, string $needle): bool
     {
-        return '' === $needle || false !== strpos($haystack, $needle);
+        return $needle === '' || \strpos($haystack, $needle) !== false;
     }
 }
 
@@ -170,17 +169,17 @@ if (! \function_exists('str_ends_with')) {
      */
     function str_ends_with(string $haystack, string $needle): bool
     {
-        if ('' === $needle || $needle === $haystack) {
+        if ($needle === '' || $needle === $haystack) {
             return true;
         }
 
-        if ('' === $haystack) {
+        if ($haystack === '') {
             return false;
         }
 
         $needleLength = \strlen($needle);
 
-        return $needleLength <= \strlen($haystack) && 0 === substr_compare($haystack, $needle, -$needleLength);
+        return $needleLength <= \strlen($haystack) && \substr_compare($haystack, $needle, -$needleLength) === 0;
     }
 }
 
@@ -196,6 +195,6 @@ if (! \function_exists('str_starts_with')) {
      */
     function str_starts_with(string $haystack, string $needle): bool
     {
-        return 0 === strncmp($haystack, $needle, \strlen($needle));
+        return \strncmp($haystack, $needle, \strlen($needle)) === 0;
     }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="library/Mockery.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$demeterMockKey]]></code>
@@ -22,15 +22,19 @@
     </InternalMethod>
     <InvalidReturnStatement>
       <code><![CDATA[$argument]]></code>
-      <code><![CDATA[$container->getMocks()[$demeterMockKey] ?? null]]></code>
       <code><![CDATA['...']]></code>
       <code><![CDATA[self::getContainer()->mock(...$args)->shouldIgnoreMissing()]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[LegacyMockInterface&MockInterface&TSpy]]></code>
       <code><![CDATA[TArray]]></code>
-      <code><![CDATA[null|(LegacyMockInterface&MockInterface&TMock)]]></code>
     </InvalidReturnType>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$container->getMocks()[$demeterMockKey] ?? null]]></code>
+      <code><![CDATA[$mock]]></code>
+      <code><![CDATA[self::getContainer()->fetchMock($name)]]></code>
+      <code><![CDATA[self::getContainer()->mock(...$args)]]></code>
+    </LessSpecificReturnStatement>
     <LessSpecificReturnType>
       <code><![CDATA[array<string, mixed>]]></code>
     </LessSpecificReturnType>
@@ -59,11 +63,6 @@
       <code><![CDATA[mock]]></code>
       <code><![CDATA[mock]]></code>
       <code><![CDATA[mock]]></code>
-      <code><![CDATA[mock]]></code>
-      <code><![CDATA[mock]]></code>
-      <code><![CDATA[mock]]></code>
-      <code><![CDATA[mock]]></code>
-      <code><![CDATA[mock]]></code>
       <code><![CDATA[mockery_teardown]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
@@ -74,6 +73,8 @@
       <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
       <code><![CDATA[$args]]></code>
       <code><![CDATA[$formattedArguments]]></code>
       <code><![CDATA[$k]]></code>
@@ -109,12 +110,22 @@
       <code><![CDATA[$expectations]]></code>
       <code><![CDATA[$expectations]]></code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[LegacyMockInterface&MockInterface&TInstanceMock]]></code>
+      <code><![CDATA[LegacyMockInterface&MockInterface&TNamedMock]]></code>
+      <code><![CDATA[self::getContainer()->mock(...$args)]]></code>
+      <code><![CDATA[self::getContainer()->mock(...$args)]]></code>
+    </MixedReturnTypeCoercion>
+    <MoreSpecificReturnType>
+      <code><![CDATA[LegacyMockInterface&MockInterface]]></code>
+      <code><![CDATA[LegacyMockInterface&MockInterface&TMock]]></code>
+      <code><![CDATA[null|(LegacyMockInterface&MockInterface&TFetchMock)]]></code>
+      <code><![CDATA[null|(LegacyMockInterface&MockInterface&TMock)]]></code>
+    </MoreSpecificReturnType>
     <NullableReturnStatement>
       <code><![CDATA[$expectations]]></code>
     </NullableReturnStatement>
     <PossiblyInvalidArgument>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
       <code><![CDATA[$name]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
@@ -323,91 +334,78 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$constructorArgs]]></code>
       <code><![CDATA[$interfaces]]></code>
-      <code><![CDATA[$mock]]></code>
       <code><![CDATA[$type]]></code>
-      <code><![CDATA['stdClass']]></code>
-      <code><![CDATA['stdClass']]></code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code><![CDATA[$match === false]]></code>
-      <code><![CDATA[array_keys($arg) !== range(0, count($arg) - 1)]]></code>
     </DocblockTypeContradiction>
     <InvalidArgument>
-      <code><![CDATA[$arg]]></code>
+      <code><![CDATA[$argument]]></code>
     </InvalidArgument>
     <InvalidArrayOffset>
       <code><![CDATA[$mocks[$index]]]></code>
     </InvalidArrayOffset>
     <InvalidCast>
-      <code><![CDATA[$arg]]></code>
+      <code><![CDATA[$argument]]></code>
     </InvalidCast>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->_mocks]]></code>
+      <code><![CDATA[$this->_mocks]]></code>
+    </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
-      <code><![CDATA[$this->rememberMock($mock)]]></code>
+      <code><![CDATA[$this->_mocks[$reference] ?? null]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code><![CDATA[LegacyMockInterface&MockInterface&TMock]]></code>
+      <code><![CDATA[null|(LegacyMockInterface&TFetchMock)|(MockInterface&TFetchMock)]]></code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
-      <code><![CDATA[$this->_mocks[$reference] ?? null]]></code>
+      <code><![CDATA[$mock]]></code>
     </LessSpecificReturnStatement>
-    <MissingParamType>
-      <code><![CDATA[$config]]></code>
-    </MissingParamType>
-    <MissingReturnType>
-      <code><![CDATA[checkForNamedMockClashes]]></code>
-      <code><![CDATA[mockery_teardown]]></code>
-      <code><![CDATA[mockery_validateOrder]]></code>
-      <code><![CDATA[mockery_verify]]></code>
-    </MissingReturnType>
+    <LessSpecificReturnType>
+      <code><![CDATA[array]]></code>
+    </LessSpecificReturnType>
     <MissingThrowsDocblock>
-      <code><![CDATA[throw new Exception(
-                sprintf("The mock named '%s' has been already defined with a different mock configuration", $name)
-            );]]></code>
+      <code><![CDATA[_getInstance]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
       <code><![CDATA[$className]]></code>
-      <code><![CDATA[$className]]></code>
-      <code><![CDATA[$def]]></code>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$constructorArgs]]></code>
+      <code><![CDATA[$mockConfiguration]]></code>
+      <code><![CDATA[$mockConfiguration]]></code>
+      <code><![CDATA[$mockDefinition]]></code>
+      <code><![CDATA[$quickDefinitions]]></code>
+      <code><![CDATA[$quickDefinitions]]></code>
+      <code><![CDATA[$quickDefinitions]]></code>
+      <code><![CDATA[$quickDefinitions]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$keys]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$arg[self::BLOCKS]]]></code>
-    </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->_namedMocks[$name]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
+      <code><![CDATA[$argument]]></code>
+      <code><![CDATA[$argument]]></code>
+      <code><![CDATA[$arguments[]]]></code>
       <code><![CDATA[$blocks]]></code>
       <code><![CDATA[$className]]></code>
-      <code><![CDATA[$def]]></code>
       <code><![CDATA[$exception]]></code>
       <code><![CDATA[$exceptions[]]]></code>
-      <code><![CDATA[$hash]]></code>
-      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$mockConfiguration]]></code>
+      <code><![CDATA[$mockDefinition]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code><![CDATA[LegacyMockInterface|MockInterface]]></code>
+      <code><![CDATA[(LegacyMockInterface&TMockObject)|(MockInterface&TMockObject)]]></code>
+      <code><![CDATA[class-string<TMock>]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
-      <code><![CDATA[atLeast]]></code>
-      <code><![CDATA[byDefault]]></code>
+      <code><![CDATA[addBlackListedMethod]]></code>
+      <code><![CDATA[addBlackListedMethods]]></code>
       <code><![CDATA[getClassName]]></code>
-      <code><![CDATA[getHash]]></code>
-      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getMockConfiguration]]></code>
       <code><![CDATA[mockery_init]]></code>
       <code><![CDATA[new $internalMockName()]]></code>
       <code><![CDATA[once]]></code>
-      <code><![CDATA[shouldReceive]]></code>
-      <code><![CDATA[shouldReceive]]></code>
+      <code><![CDATA[setMockOriginalDestructor]]></code>
     </MixedMethodCall>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$this->_namedMocks]]></code>
-    </MixedPropertyTypeCoercion>
     <MixedReturnStatement>
+      <code><![CDATA[$className]]></code>
+      <code><![CDATA[$className]]></code>
       <code><![CDATA[$mocks[$index]]]></code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
@@ -415,15 +413,8 @@
       <code><![CDATA[array<Throwable>]]></code>
     </MixedReturnTypeCoercion>
     <MoreSpecificReturnType>
-      <code><![CDATA[null|(LegacyMockInterface&MockInterface&TMock)]]></code>
+      <code><![CDATA[(TMock&MockInterface)|(TMock&LegacyMockInterface)]]></code>
     </MoreSpecificReturnType>
-    <NoValue>
-      <code><![CDATA[$arg]]></code>
-      <code><![CDATA[$arg]]></code>
-      <code><![CDATA[$arg]]></code>
-      <code><![CDATA[$constructorArgs]]></code>
-      <code><![CDATA[$quickDefinitions]]></code>
-    </NoValue>
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$parts[1]]]></code>
     </PossiblyUndefinedIntArrayOffset>
@@ -440,21 +431,14 @@
     <PossiblyUnusedReturnValue>
       <code><![CDATA[int]]></code>
     </PossiblyUnusedReturnValue>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->_mocks]]></code>
-      <code><![CDATA[$this->_mocks]]></code>
-    </PropertyTypeCoercion>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_object($arg)]]></code>
-    </RedundantConditionGivenDocblockType>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[!strpos($type, ']')]]></code>
-      <code><![CDATA[strpos($type, ',')]]></code>
-    </RiskyTruthyFalsyComparison>
-    <TypeDoesNotContainType>
-      <code><![CDATA[$constructorArgs !== null]]></code>
-      <code><![CDATA[is_array($arg)]]></code>
-    </TypeDoesNotContainType>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[atLeast]]></code>
+      <code><![CDATA[byDefault]]></code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMagicMethod>
+      <code><![CDATA[atLeast]]></code>
+      <code><![CDATA[byDefault]]></code>
+    </UndefinedMagicMethod>
   </file>
   <file src="library/Mockery/CountValidator/AtLeast.php">
     <InvalidOperand>
@@ -683,6 +667,9 @@
       <code><![CDATA[$this->_expectedArgs[0]]]></code>
       <code><![CDATA[$this->_expectedArgs[0]]]></code>
     </PossiblyUndefinedIntArrayOffset>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[mockery_isInstance]]></code>
+    </PossiblyUndefinedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
       <code><![CDATA[andReturnArg]]></code>
@@ -727,7 +714,6 @@
     </UndefinedClass>
     <UndefinedInterfaceMethod>
       <code><![CDATA[mockery_callSubjectMethod]]></code>
-      <code><![CDATA[mockery_isInstance]]></code>
       <code><![CDATA[mockery_returnValueForMethod]]></code>
     </UndefinedInterfaceMethod>
     <UnusedMethod>
@@ -952,8 +938,10 @@
       <code><![CDATA[$method]]></code>
     </MixedAssignment>
     <PossiblyUnusedMethod>
+      <code><![CDATA[addBlackListedMethods]]></code>
       <code><![CDATA[addWhiteListedMethods]]></code>
       <code><![CDATA[setBlackListedMethods]]></code>
+      <code><![CDATA[setMockOriginalDestructor]]></code>
       <code><![CDATA[setWhiteListedMethods]]></code>
     </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
@@ -1349,9 +1337,10 @@
       <code><![CDATA[shouldAllowMockingMethod]]></code>
       <code><![CDATA[shouldAllowMockingProtectedMethods]]></code>
       <code><![CDATA[shouldDeferMissing]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldNotHaveBeenCalled]]></code>
     </PossiblyUnusedMethod>
+    <PossiblyUnusedReturnValue>
+      <code><![CDATA[self]]></code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="library/Mockery/Loader/RequireLoader.php">
     <RiskyTruthyFalsyComparison>
@@ -1652,19 +1641,14 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/helpers.php">
-    <InvalidDocblock>
-      <code><![CDATA[function mock(...$args)]]></code>
-      <code><![CDATA[function namedMock(...$args)]]></code>
-      <code><![CDATA[function spy(...$args)]]></code>
-    </InvalidDocblock>
-    <MissingReturnType>
-      <code><![CDATA[mock]]></code>
-      <code><![CDATA[namedMock]]></code>
-      <code><![CDATA[spy]]></code>
-    </MissingReturnType>
-    <PossiblyInvalidArgument>
+    <LessSpecificReturnType>
+      <code><![CDATA[((LegacyMockInterface&TMixed)|(TMixed&MockInterface))]]></code>
+      <code><![CDATA[((LegacyMockInterface&TMixed)|(TMixed&MockInterface))]]></code>
+      <code><![CDATA[LegacyMockInterface|MockInterface]]></code>
+    </LessSpecificReturnType>
+    <MixedArgumentTypeCoercion>
       <code><![CDATA[$args]]></code>
-    </PossiblyInvalidArgument>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="tests/Bootstrap.php">
     <ForbiddenCode>
@@ -1710,10 +1694,6 @@
       <code><![CDATA[$class]]></code>
       <code><![CDATA[$exception]]></code>
     </ArgumentTypeCoercion>
-    <InvalidArgument>
-      <code><![CDATA[$class]]></code>
-      <code><![CDATA[$class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf($class, mock($class))]]></code>
       <code><![CDATA[self::assertInstanceOf($class, mock($class))]]></code>
@@ -1725,26 +1705,22 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/Unit/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php">
-    <InvalidArgument>
-      <code><![CDATA[BaseClassStub::class]]></code>
-      <code><![CDATA[BaseClassStub::class]]></code>
-    </InvalidArgument>
     <MixedAssignment>
-      <code><![CDATA[$mock]]></code>
-      <code><![CDATA[$mock]]></code>
       <code><![CDATA[$test]]></code>
       <code><![CDATA[$test]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[finish]]></code>
       <code><![CDATA[finish]]></code>
-      <code><![CDATA[foobar]]></code>
-      <code><![CDATA[foobar]]></code>
       <code><![CDATA[markAsRisky]]></code>
       <code><![CDATA[markAsRisky]]></code>
       <code><![CDATA[shouldHaveReceived]]></code>
       <code><![CDATA[shouldNotHaveReceived]]></code>
     </MixedMethodCall>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[foobar]]></code>
+      <code><![CDATA[foobar]]></code>
+    </UndefinedInterfaceMethod>
     <UndefinedMethod>
       <code><![CDATA[makePartial]]></code>
       <code><![CDATA[makePartial]]></code>
@@ -1754,12 +1730,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Adapter/Phpunit/PhpUnitConstraintExpectationTest.php">
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-      <code><![CDATA['foo']]></code>
-      <code><![CDATA['foo']]></code>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::markTestSkipped('TODO: Constraint exception message')]]></code>
       <code><![CDATA[self::markTestSkipped('TODO: Constraint exception message')]]></code>
@@ -1997,24 +1967,6 @@
       <code><![CDATA[self::assertEquals(124, $spy(123))]]></code>
       <code><![CDATA[self::assertEquals(124, $spy(123))]]></code>
     </MissingThrowsDocblock>
-    <MixedAssignment>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-      <code><![CDATA[$spy]]></code>
-    </MixedAssignment>
     <MixedFunctionCall>
       <code><![CDATA[$spy()]]></code>
       <code><![CDATA[$spy()]]></code>
@@ -2070,14 +2022,44 @@
     <MixedOperand>
       <code><![CDATA[$number]]></code>
     </MixedOperand>
+    <PossiblyInvalidFunctionCall>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(456)]]></code>
+    </PossiblyInvalidFunctionCall>
+    <PossiblyUndefinedMethod>
+      <code><![CDATA[twice]]></code>
+      <code><![CDATA[twice]]></code>
+      <code><![CDATA[twice]]></code>
+      <code><![CDATA[with]]></code>
+      <code><![CDATA[with]]></code>
+      <code><![CDATA[with]]></code>
+      <code><![CDATA[with]]></code>
+      <code><![CDATA[with]]></code>
+    </PossiblyUndefinedMethod>
     <UnusedClass>
       <code><![CDATA[CallableSpyTest]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/DefaultMatchersTest.php">
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
     <MissingPropertyType>
       <code><![CDATA[$mock]]></code>
     </MissingPropertyType>
@@ -2263,51 +2245,16 @@
       <code><![CDATA['InvalidArgumentException']]></code>
       <code><![CDATA['OutOfBoundsException']]></code>
       <code><![CDATA['f']]></code>
-    </ArgumentTypeCoercion>
-    <DocblockTypeContradiction>
-      <code><![CDATA[assertSame]]></code>
-      <code><![CDATA[assertSame]]></code>
-    </DocblockTypeContradiction>
-    <InvalidArgument>
-      <code><![CDATA['Foo']]></code>
-      <code><![CDATA['Foo']]></code>
-      <code><![CDATA['MyService']]></code>
-      <code><![CDATA['MyService']]></code>
-      <code><![CDATA['SomeMadeUpClass']]></code>
-      <code><![CDATA['bar']]></code>
-      <code><![CDATA['bar']]></code>
-      <code><![CDATA['f']]></code>
-      <code><![CDATA['f']]></code>
-      <code><![CDATA[IWater::class]]></code>
-      <code><![CDATA[MockeryTest_Foo::class]]></code>
-      <code><![CDATA[MockeryTest_Foo::class]]></code>
-      <code><![CDATA[MockeryTest_Foo::class]]></code>
-      <code><![CDATA[MockeryTest_Foo::class]]></code>
-      <code><![CDATA[MockeryTest_InterMethod1::class . '[doThird]']]></code>
-      <code><![CDATA[MockeryTest_SubjectCall1::class]]></code>
-      <code><![CDATA[MockeryTest_SubjectCall1::class]]></code>
-      <code><![CDATA[Mockery_Demeterowski::class]]></code>
-      <code><![CDATA[Mockery_Demeterowski::class]]></code>
-      <code><![CDATA[Mockery_Duck::class]]></code>
-      <code><![CDATA[Mockery_Duck::class]]></code>
-      <code><![CDATA[Mockery_Magic::class]]></code>
-      <code><![CDATA[MyService2::class]]></code>
-      <code><![CDATA[MyService2::class]]></code>
       <code><![CDATA[[
             'foo' => 'rfoo',
             'bar' => 'rbar',
             'baz' => 'rbaz',
         ]]]></code>
-      <code><![CDATA[stdClass::class]]></code>
-    </InvalidArgument>
-    <InvalidScalarArgument>
-      <code><![CDATA[[
-            'foo' => 1,
-        ]]]></code>
-      <code><![CDATA[[
-            'foo' => 1,
-        ]]]></code>
-    </InvalidScalarArgument>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+    </DocblockTypeContradiction>
     <MissingClosureParamType>
       <code><![CDATA[$arg]]></code>
       <code><![CDATA[$arg]]></code>
@@ -2344,7 +2291,6 @@
     </MissingPropertyType>
     <MissingThrowsDocblock>
       <code><![CDATA[Mockery::self()]]></code>
-      <code><![CDATA[mock]]></code>
       <code><![CDATA[mock]]></code>
       <code><![CDATA[self::assertEmpty($this->mock->bar)]]></code>
       <code><![CDATA[self::assertEmpty($this->mock->bar)]]></code>
@@ -2642,7 +2588,6 @@
       <code><![CDATA[$exp]]></code>
       <code><![CDATA[$exp]]></code>
       <code><![CDATA[$m]]></code>
-      <code><![CDATA[$mock]]></code>
       <code><![CDATA[$mock]]></code>
       <code><![CDATA[$mock]]></code>
       <code><![CDATA[$s]]></code>
@@ -3601,7 +3546,6 @@
       <code><![CDATA[shouldReceive]]></code>
       <code><![CDATA[shouldReceive]]></code>
       <code><![CDATA[shouldReceive]]></code>
-      <code><![CDATA[shouldReceive]]></code>
       <code><![CDATA[start]]></code>
       <code><![CDATA[start]]></code>
       <code><![CDATA[times]]></code>
@@ -3907,6 +3851,11 @@
       <code><![CDATA[$service]]></code>
       <code><![CDATA[$service]]></code>
       <code><![CDATA[$service]]></code>
+      <code><![CDATA[[
+            'foo' => 'rfoo',
+            'bar' => 'rbar',
+            'baz' => 'rbaz',
+        ]]]></code>
       <code><![CDATA[mock('f')]]></code>
       <code><![CDATA[mock('f')]]></code>
     </UndefinedClass>
@@ -4035,10 +3984,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php">
-    <InvalidArgument>
-      <code><![CDATA[MockConfiguration::class]]></code>
-      <code><![CDATA[UndefinedTargetClass::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertStringContainsString($expected, $code)]]></code>
       <code><![CDATA[self::assertStringContainsString($expected, $code)]]></code>
@@ -4181,9 +4126,6 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$className]]></code>
     </ArgumentTypeCoercion>
-    <InvalidArgument>
-      <code><![CDATA[$className]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf($className, $double)]]></code>
       <code><![CDATA[self::assertInstanceOf($className, $double)]]></code>
@@ -4198,8 +4140,10 @@
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $double)]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $double)]]></code>
     </MissingThrowsDocblock>
-    <UndefinedInterfaceMethod>
+    <PossiblyUndefinedMethod>
       <code><![CDATA[foo]]></code>
+    </PossiblyUndefinedMethod>
+    <UndefinedInterfaceMethod>
       <code><![CDATA[foo]]></code>
     </UndefinedInterfaceMethod>
     <UnusedClass>
@@ -4207,9 +4151,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/HamcrestExpectationTest.php">
-    <InvalidArgument>
-      <code><![CDATA['foo']]></code>
-    </InvalidArgument>
     <MissingPropertyType>
       <code><![CDATA[$mock]]></code>
     </MissingPropertyType>
@@ -4354,9 +4295,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockClassWithIterableReturnTypeTest.php">
-    <InvalidArgument>
-      <code><![CDATA[ReturnTypeIterableTypeHint::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertSame([], $mock->returnIterable())]]></code>
       <code><![CDATA[self::assertSame([], $mock->returnIterable())]]></code>
@@ -4369,11 +4307,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockClassWithMethodOverloadingTest.php">
-    <InvalidArgument>
-      <code><![CDATA[TestWithMethodOverloading::class]]></code>
-      <code><![CDATA[TestWithMethodOverloading::class]]></code>
-      <code><![CDATA[TestWithMethodOverloadingWithoutCall::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(TestWithMethodOverloading::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(TestWithMethodOverloading::class, $mock)]]></code>
@@ -4403,9 +4336,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockClassWithUnknownTypeHintTest.php">
-    <InvalidArgument>
-      <code><![CDATA[HasUnknownClassAsTypeHintOnMethod::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $mock)]]></code>
@@ -4508,19 +4438,6 @@
     <InaccessibleMethod>
       <code><![CDATA[foo]]></code>
     </InaccessibleMethod>
-    <InvalidArgument>
-      <code><![CDATA['ClassName.CannotContainDot']]></code>
-      <code><![CDATA[ClassWithMethods::class]]></code>
-      <code><![CDATA[ClassWithMethods::class]]></code>
-      <code><![CDATA[ClassWithMethods::class]]></code>
-      <code><![CDATA[ClassWithMethods::class]]></code>
-      <code><![CDATA[ClassWithNoToString::class]]></code>
-      <code><![CDATA[ClassWithNoToString::class]]></code>
-      <code><![CDATA[ClassWithNoToString::class]]></code>
-      <code><![CDATA[ClassWithProtectedMethod::class]]></code>
-      <code><![CDATA[ClassWithToString::class]]></code>
-      <code><![CDATA[ExampleClassForTestingNonExistentMethod::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertEquals('foo', (string) $mock)]]></code>
       <code><![CDATA[self::assertEquals('foo', (string) $mock)]]></code>
@@ -4577,7 +4494,6 @@
       <code><![CDATA[self::assertTrue(method_exists($mock, '__toString'))]]></code>
     </MissingThrowsDocblock>
     <MixedAssignment>
-      <code><![CDATA[$m]]></code>
       <code><![CDATA[$mock]]></code>
       <code><![CDATA[$mock]]></code>
       <code><![CDATA[$mock]]></code>
@@ -4587,7 +4503,6 @@
       <code><![CDATA[$mock]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code><![CDATA[andReturn]]></code>
       <code><![CDATA[andReturn]]></code>
       <code><![CDATA[andReturn]]></code>
       <code><![CDATA[asUndefined]]></code>
@@ -4611,8 +4526,6 @@
       <code><![CDATA[shouldReceive]]></code>
       <code><![CDATA[shouldReceive]]></code>
       <code><![CDATA[shouldReceive]]></code>
-      <code><![CDATA[shouldReceive]]></code>
-      <code><![CDATA[test123]]></code>
     </MixedMethodCall>
     <TooManyArguments>
       <code><![CDATA[expectException]]></code>
@@ -4627,10 +4540,12 @@
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
+      <code><![CDATA[test123]]></code>
       <code><![CDATA[twice]]></code>
       <code><![CDATA[twice]]></code>
     </UndefinedInterfaceMethod>
     <UndefinedMagicMethod>
+      <code><![CDATA[andReturn]]></code>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
@@ -4680,7 +4595,6 @@
   <file src="tests/Unit/Mockery/MockeryCanMockMultipleInterfacesWhichOverlapTest.php">
     <MissingThrowsDocblock>
       <code><![CDATA[mock]]></code>
-      <code><![CDATA[mock]]></code>
       <code><![CDATA[self::assertInstanceOf(Evenement_EventEmitter::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(Evenement_EventEmitter::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(Evenement_EventEmitter::class, $mock)]]></code>
@@ -4690,9 +4604,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockingAllLowerCasedMethodsTest.php">
-    <InvalidArgument>
-      <code><![CDATA[ClassWithAllLowerCaseMethod::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertSame($expected, $mock->userExpectsCamelCaseMethod())]]></code>
       <code><![CDATA[self::assertSame($expected, $mock->userExpectsCamelCaseMethod())]]></code>
@@ -4728,9 +4639,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockingMethodsWithIterableTypeHintsTest.php">
-    <InvalidArgument>
-      <code><![CDATA[MethodWithIterableTypeHints::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(MethodWithIterableTypeHints::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(MethodWithIterableTypeHints::class, $mock)]]></code>
@@ -4758,10 +4666,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockingMethodsWithNullableParametersTest.php">
-    <InvalidArgument>
-      <code><![CDATA[MethodWithNullableTypedParameter::class]]></code>
-      <code><![CDATA[MethodWithParametersWithDefaultValues::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(MethodWithNullableTypedParameter::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(MethodWithNullableTypedParameter::class, $mock)]]></code>
@@ -4781,20 +4685,6 @@
       <code><![CDATA[new MethodWithNullableReturnType()]]></code>
       <code><![CDATA[new MethodWithNullableReturnType()]]></code>
     </InternalMethod>
-    <InvalidArgument>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-      <code><![CDATA[MethodWithNullableReturnType::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertNull($double->nullableClass())]]></code>
       <code><![CDATA[self::assertNull($double->nullableClass())]]></code>
@@ -4856,15 +4746,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockingProtectedMethodsTest.php">
-    <InvalidArgument>
-      <code><![CDATA[TestIncreasedVisibilityChild::class]]></code>
-      <code><![CDATA[TestWithProtectedMethods::class]]></code>
-      <code><![CDATA[TestWithProtectedMethods::class]]></code>
-      <code><![CDATA[TestWithProtectedMethods::class]]></code>
-      <code><![CDATA[TestWithProtectedMethods::class]]></code>
-      <code><![CDATA[TestWithProtectedMethods::class . '[foo]']]></code>
-      <code><![CDATA[TestWithProtectedMethods::class . '[protectedBar]']]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertEquals('abstractProtected', $mock->foo())]]></code>
       <code><![CDATA[self::assertEquals('abstractProtected', $mock->foo())]]></code>
@@ -4923,11 +4804,6 @@
     <InaccessibleMethod>
       <code><![CDATA[protectedBar]]></code>
     </InaccessibleMethod>
-    <InvalidArgument>
-      <code><![CDATA[ClassWithStaticMethods::class]]></code>
-      <code><![CDATA[ClassWithStaticMethods::class]]></code>
-      <code><![CDATA[ClassWithStaticMethods::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertTrue($mock->foo())]]></code>
       <code><![CDATA[self::assertTrue($mock->foo())]]></code>
@@ -4952,9 +4828,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockingVariadicArgumentsTest.php">
-    <InvalidArgument>
-      <code><![CDATA[TestWithVariadicArguments::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertEquals('notbar', $mock->foo())]]></code>
       <code><![CDATA[self::assertEquals('notbar', $mock->foo())]]></code>
@@ -5010,23 +4883,16 @@
     </UnusedVariable>
   </file>
   <file src="tests/Unit/Mockery/ProxyMockingTest.php">
-    <InvalidArgument>
-      <code><![CDATA[UnmockableClass::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertSame(1, $mock->anyMethod())]]></code>
       <code><![CDATA[self::assertSame(1, $mock->anyMethod())]]></code>
       <code><![CDATA[self::assertSame(42, $mock->theAnswer())]]></code>
       <code><![CDATA[self::assertSame(42, $mock->theAnswer())]]></code>
     </MissingThrowsDocblock>
-    <MixedAssignment>
-      <code><![CDATA[$mock]]></code>
-      <code><![CDATA[$mock]]></code>
-    </MixedAssignment>
-    <MixedMethodCall>
+    <UndefinedInterfaceMethod>
       <code><![CDATA[anyMethod]]></code>
       <code><![CDATA[theAnswer]]></code>
-    </MixedMethodCall>
+    </UndefinedInterfaceMethod>
     <UnusedClass>
       <code><![CDATA[ProxyMockingTest]]></code>
     </UnusedClass>
@@ -5111,22 +4977,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/TraitsTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[[
-            'doBaz' => 'baz',
-        ]]]></code>
-    </ArgumentTypeCoercion>
-    <InvalidArgument>
-      <code><![CDATA[SimpleTrait::class]]></code>
-      <code><![CDATA[SimpleTrait::class]]></code>
-      <code><![CDATA[TraitWithAbstractMethod::class]]></code>
-      <code><![CDATA[TraitWithAbstractMethod::class]]></code>
-    </InvalidArgument>
-    <InvalidScalarArgument>
-      <code><![CDATA[[
-            'doBaz' => 123,
-        ]]]></code>
-    </InvalidScalarArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertEquals('bar', $trait->foo())]]></code>
       <code><![CDATA[self::assertEquals('bar', $trait->foo())]]></code>
@@ -5142,9 +4992,6 @@
       <code><![CDATA[$trait]]></code>
       <code><![CDATA[$trait]]></code>
       <code><![CDATA[$trait]]></code>
-      <code><![CDATA[[
-            'doBaz' => 'baz',
-        ]]]></code>
     </UndefinedClass>
     <UnusedClass>
       <code><![CDATA[TraitsTest]]></code>
@@ -5185,9 +5032,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP73/MockingOldStyleConstructorTest.php">
-    <InvalidArgument>
-      <code><![CDATA[OldStyleConstructor::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $double)]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $double)]]></code>
@@ -5201,10 +5045,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP73/MockingVoidMethodsTest.php">
-    <InvalidArgument>
-      <code><![CDATA[MethodWithVoidReturnType::class]]></code>
-      <code><![CDATA[MethodWithVoidReturnType::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, mock(MethodWithVoidReturnType::class))]]></code>
       <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, mock(MethodWithVoidReturnType::class))]]></code>
@@ -5410,9 +5250,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP80/MockingMethodsWithStaticReturnTypeTest.php">
-    <InvalidArgument>
-      <code><![CDATA[MethodWithStaticReturnType::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertSame($mock, $mock->returnType())]]></code>
       <code><![CDATA[self::assertSame($mock, $mock->returnType())]]></code>
@@ -5425,17 +5262,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP80/Php80LanguageFeaturesTest.php">
-    <InvalidArgument>
-      <code><![CDATA[ArgumentMixedTypeHint::class]]></code>
-      <code><![CDATA[ArgumentParentTypeHint::class]]></code>
-      <code><![CDATA[ArgumentUnionTypeHint::class]]></code>
-      <code><![CDATA[ArgumentUnionTypeHintWithNull::class]]></code>
-      <code><![CDATA[ImplementsIterator::class]]></code>
-      <code><![CDATA[ImplementsIteratorAggregate::class]]></code>
-      <code><![CDATA[ReturnTypeMixedTypeHint::class]]></code>
-      <code><![CDATA[ReturnTypeParentTypeHint::class]]></code>
-      <code><![CDATA[ReturnTypeUnionTypeHint::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertInstanceOf(Iterator::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(Iterator::class, $mock)]]></code>
@@ -5507,13 +5333,6 @@
       <code><![CDATA[Reflector::getTypeHint($refParam)]]></code>
       <code><![CDATA[Reflector::getTypeHint($refParam)]]></code>
     </InternalMethod>
-    <InvalidArgument>
-      <code><![CDATA[$fullyQualifiedClassName]]></code>
-      <code><![CDATA[$fullyQualifiedClassName]]></code>
-      <code><![CDATA['MockUnDefinedClass']]></code>
-      <code><![CDATA[HasReservedWordFalse::class]]></code>
-      <code><![CDATA[HasReservedWordTrue::class]]></code>
-    </InvalidArgument>
     <MissingThrowsDocblock>
       <code><![CDATA[getMethod]]></code>
       <code><![CDATA[getMethod]]></code>
@@ -5549,14 +5368,6 @@
       <code><![CDATA[self::assertTrue($mock->testTrueMethod())]]></code>
       <code><![CDATA[self::assertTrue($mock->testTrueMethod())]]></code>
     </MissingThrowsDocblock>
-    <MixedArgument>
-      <code><![CDATA[$mock]]></code>
-      <code><![CDATA[$mock]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$mock]]></code>
-      <code><![CDATA[$mock]]></code>
-    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1642,8 +1642,8 @@
   </file>
   <file src="library/helpers.php">
     <LessSpecificReturnType>
-      <code><![CDATA[((LegacyMockInterface&TMixed)|(TMixed&MockInterface))]]></code>
-      <code><![CDATA[((LegacyMockInterface&TMixed)|(TMixed&MockInterface))]]></code>
+      <code><![CDATA[((LegacyMockInterface&TMixed)|(MockInterface&TMixed))]]></code>
+      <code><![CDATA[((LegacyMockInterface&TMixed)|(MockInterface&TMixed))]]></code>
       <code><![CDATA[LegacyMockInterface|MockInterface]]></code>
     </LessSpecificReturnType>
     <MixedArgumentTypeCoercion>
@@ -1957,6 +1957,29 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/CallableSpyTest.php">
+    <InvalidFunctionCall>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy()]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(123)]]></code>
+      <code><![CDATA[$spy(456)]]></code>
+    </InvalidFunctionCall>
     <MissingClosureParamType>
       <code><![CDATA[$number]]></code>
     </MissingClosureParamType>
@@ -1967,85 +1990,15 @@
       <code><![CDATA[self::assertEquals(124, $spy(123))]]></code>
       <code><![CDATA[self::assertEquals(124, $spy(123))]]></code>
     </MissingThrowsDocblock>
-    <MixedFunctionCall>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(456)]]></code>
-    </MixedFunctionCall>
     <MixedMethodCall>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldHaveBeenCalled]]></code>
-      <code><![CDATA[shouldNotHaveBeenCalled]]></code>
-      <code><![CDATA[shouldNotHaveBeenCalled]]></code>
-      <code><![CDATA[shouldNotHaveBeenCalled]]></code>
-      <code><![CDATA[shouldNotHaveBeenCalled]]></code>
-      <code><![CDATA[shouldNotHaveBeenCalled]]></code>
       <code><![CDATA[twice]]></code>
       <code><![CDATA[twice]]></code>
       <code><![CDATA[twice]]></code>
-      <code><![CDATA[twice]]></code>
-      <code><![CDATA[twice]]></code>
-      <code><![CDATA[twice]]></code>
-      <code><![CDATA[with]]></code>
-      <code><![CDATA[with]]></code>
-      <code><![CDATA[with]]></code>
-      <code><![CDATA[with]]></code>
-      <code><![CDATA[with]]></code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$number]]></code>
     </MixedOperand>
-    <PossiblyInvalidFunctionCall>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy()]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(123)]]></code>
-      <code><![CDATA[$spy(456)]]></code>
-    </PossiblyInvalidFunctionCall>
-    <PossiblyUndefinedMethod>
+    <UndefinedInterfaceMethod>
       <code><![CDATA[twice]]></code>
       <code><![CDATA[twice]]></code>
       <code><![CDATA[twice]]></code>
@@ -2054,7 +2007,7 @@
       <code><![CDATA[with]]></code>
       <code><![CDATA[with]]></code>
       <code><![CDATA[with]]></code>
-    </PossiblyUndefinedMethod>
+    </UndefinedInterfaceMethod>
     <UnusedClass>
       <code><![CDATA[CallableSpyTest]]></code>
     </UnusedClass>

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -241,7 +241,7 @@ final class ContainerTest extends MockeryTestCase
             self::markTestSkipped('phpredis not installed');
         }
 
-        mock(Redis::class);
+        self::assertInstanceOf(Redis::class, mock(Redis::class));
     }
 
     public function testCanMockClassesThatDescendFromInternalClasses(): void
@@ -1187,7 +1187,7 @@ final class ContainerTest extends MockeryTestCase
         if (! class_exists('Redis')) {
             self::markTestSkipped('PHPRedis extension required for this test');
         }
-        $m = mock(Redis::class);
+        self::assertInstanceOf(Redis::class, mock(Redis::class));
     }
 
     public function testNamedMockMultipleInterfaces(): void

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -10,6 +10,7 @@ use Countable;
 use DateTime;
 use Exception;
 use Foo\Bar;
+use Generator;
 use InvalidArgumentException;
 use Iterator;
 use IteratorAggregate;
@@ -94,34 +95,23 @@ use SplFixedArray;
 use stdClass;
 use Traversable;
 
+use const PHP_MAJOR_VERSION;
+
 use function class_exists;
 use function extension_loaded;
 use function fopen;
 use function get_class;
 use function mock;
 use function preg_match;
+use function random_int;
 use function time;
 use function uniqid;
-use function random_int;
-
-use const PHP_MAJOR_VERSION;
 
 /**
  * @coversDefaultClass \Mockery
  */
 final class ContainerTest extends MockeryTestCase
 {
-    public static function classNameProvider(): array
-    {
-        return [
-            [false, ' '], // just a space
-            [false, 'ClassName.WithDot'],
-            [false, '\\\\TooManyBackSlashes'],
-            [true, 'Foo'],
-            [true, Bar::class],
-        ];
-    }
-
     public function testBlockForwardingToPartialObject(): void
     {
         $m = mock(new MockeryTestBar1(), [
@@ -271,7 +261,7 @@ final class ContainerTest extends MockeryTestCase
         self::assertInstanceOf(MockeryTest_InterfaceWithAbstractMethod::class, $m);
         $m->shouldReceive('foo')
             ->andReturn(1);
-        self::assertEquals(1, $m->foo());
+        self::assertSame(1, $m->foo());
     }
 
     public function testCanMockInterfaceWithPublicStaticMethod(): void
@@ -339,7 +329,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock('alias:MyNamespace\MyClass2');
         $m->shouldReceive('staticFoo')
             ->andReturn('bar');
-        self::assertEquals('bar', MyClass2::staticFoo());
+        self::assertSame('bar', MyClass2::staticFoo());
     }
 
     /**
@@ -363,7 +353,7 @@ final class ContainerTest extends MockeryTestCase
         @$m = mock(MongoCollection::class);
         self::assertInstanceOf(MockInterface::class, $m, 'Mocking failed, remove @ error suppresion to debug');
         $m->shouldReceive('insert')
-            ->with(Mockery::on(function (&$data) {
+            ->with(Mockery::on(static function (&$data) {
                 $data['_id'] = 123;
                 return true;
             }), Mockery::type('array'));
@@ -373,7 +363,7 @@ final class ContainerTest extends MockeryTestCase
         ];
         $m->insert($data, []);
         self::assertArrayHasKey('_id', $data);
-        self::assertEquals(123, $data['_id']);
+        self::assertSame(123, $data['_id']);
         Mockery::getConfiguration()->resetInternalClassMethodParamMaps();
     }
 
@@ -395,13 +385,13 @@ final class ContainerTest extends MockeryTestCase
         @$m = mock(DateTime::class);
         self::assertInstanceOf(MockInterface::class, $m, 'Mocking failed, remove @ error suppresion to debug');
         $m->shouldReceive('modify')
-            ->with(Mockery::on(function (&$string) {
+            ->with(Mockery::on(static function (&$string) {
                 $string = 'foo';
                 return true;
             }));
         $data = 'bar';
         $m->modify($data);
-        self::assertEquals('foo', $data);
+        self::assertSame('foo', $data);
         Mockery::getConfiguration()->resetInternalClassMethodParamMaps();
     }
 
@@ -419,8 +409,8 @@ final class ContainerTest extends MockeryTestCase
         self::assertInstanceOf(MockeryTest_PartialNormalClass::class, $m);
         $m->shouldReceive('foo')
             ->andReturn('cba');
-        self::assertEquals('abc', $m->bar());
-        self::assertEquals('cba', $m->foo());
+        self::assertSame('abc', $m->bar());
+        self::assertSame('cba', $m->foo());
     }
 
     public function testCanPartiallyMockANormalClassWith2Methods(): void
@@ -431,9 +421,9 @@ final class ContainerTest extends MockeryTestCase
             ->andReturn('cba');
         $m->shouldReceive('baz')
             ->andReturn('cba');
-        self::assertEquals('abc', $m->bar());
-        self::assertEquals('cba', $m->foo());
-        self::assertEquals('cba', $m->baz());
+        self::assertSame('abc', $m->bar());
+        self::assertSame('cba', $m->foo());
+        self::assertSame('cba', $m->baz());
     }
 
     public function testCanPartiallyMockAnAbstractClass(): void
@@ -442,8 +432,8 @@ final class ContainerTest extends MockeryTestCase
         self::assertInstanceOf(MockeryTest_PartialAbstractClass::class, $m);
         $m->shouldReceive('foo')
             ->andReturn('cba');
-        self::assertEquals('abc', $m->bar());
-        self::assertEquals('cba', $m->foo());
+        self::assertSame('abc', $m->bar());
+        self::assertSame('cba', $m->foo());
     }
 
     public function testCanPartiallyMockAnAbstractClassWith2Methods(): void
@@ -454,9 +444,9 @@ final class ContainerTest extends MockeryTestCase
             ->andReturn('cba');
         $m->shouldReceive('baz')
             ->andReturn('cba');
-        self::assertEquals('abc', $m->bar());
-        self::assertEquals('cba', $m->foo());
-        self::assertEquals('cba', $m->baz());
+        self::assertSame('abc', $m->bar());
+        self::assertSame('cba', $m->foo());
+        self::assertSame('cba', $m->baz());
     }
 
     public function testCanPartiallyMockObjectWhereMethodHasReferencedParameter(): void
@@ -514,8 +504,8 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(MockeryFoo4::class . '[bar]');
         $m->shouldReceive('bar')
             ->andReturn('baz');
-        self::assertEquals('baz', $m->foo());
-        self::assertEquals('baz', $m->bar());
+        self::assertSame('baz', $m->foo());
+        self::assertSame('baz', $m->bar());
         self::assertInstanceOf(MockeryFoo4::class, $m);
     }
 
@@ -524,7 +514,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(MockeryFoo4::class . '[foo]');
         $m->shouldReceive('foo')
             ->andReturn('foo');
-        self::assertEquals('baz', $m->foo()); // partial expectation ignored - will fail callcount assertion
+        self::assertSame('baz', $m->foo()); // partial expectation ignored - will fail callcount assertion
         self::assertInstanceOf(MockeryFoo4::class, $m);
     }
 
@@ -533,8 +523,8 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(new MockeryFoo4());
         $m->shouldReceive('foo')
             ->andReturn('baz');
-        self::assertEquals('baz', $m->foo());
-        self::assertEquals('bar', $m->bar());
+        self::assertSame('baz', $m->foo());
+        self::assertSame('bar', $m->bar());
         self::assertInstanceOf(MockeryFoo4::class, $m);
     }
 
@@ -543,8 +533,8 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(new MockeryTestFoo());
         $m->shouldReceive('bar')
             ->andReturn('bar');
-        self::assertEquals('bar', $m->bar());
-        self::assertEquals('foo', $m->foo());
+        self::assertSame('bar', $m->bar());
+        self::assertSame('foo', $m->foo());
         self::assertInstanceOf(MockeryTestFoo::class, $m);
     }
 
@@ -553,8 +543,8 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(new MockeryTestFoo2());
         $m->shouldReceive('bar')
             ->andReturn('baz');
-        self::assertEquals('baz', $m->bar());
-        self::assertEquals('foo', $m->foo());
+        self::assertSame('baz', $m->bar());
+        self::assertSame('foo', $m->foo());
         self::assertInstanceOf(MockeryTestFoo2::class, $m);
     }
 
@@ -566,7 +556,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(MockeryTest_WithToString::class); // this would fatal
         $m->shouldReceive('__toString')
             ->andReturn('dave');
-        self::assertEquals('dave', "{$m}");
+        self::assertSame('dave', "{$m}");
     }
 
     public function testCreationOfInstanceMock(): void
@@ -601,8 +591,8 @@ final class ContainerTest extends MockeryTestCase
             ->with(5)
             ->andReturn(10);
 
-        self::assertEquals(10, $mock::mockMe(5));
-        self::assertEquals(3, $mock::keepMe(3));
+        self::assertSame(10, $mock::mockMe(5));
+        self::assertSame(3, $mock::keepMe(3));
     }
 
     public function testFinalClassesCanBePartialMocks(): void
@@ -610,13 +600,13 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(new MockeryFoo3());
         $m->shouldReceive('foo')
             ->andReturn('baz');
-        self::assertEquals('baz', $m->foo());
+        self::assertSame('baz', $m->foo());
         self::assertNotInstanceOf(MockeryFoo3::class, $m);
     }
 
     public function testGetExpectationCountFreshContainer(): void
     {
-        self::assertEquals(0, Mockery::getContainer()->mockery_getExpectationCount());
+        self::assertSame(0, Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     public function testGetExpectationCountMockWithAtLeast(): void
@@ -625,7 +615,7 @@ final class ContainerTest extends MockeryTestCase
         $m->shouldReceive('foo')
             ->atLeast()
             ->once();
-        self::assertEquals(1, Mockery::getContainer()->mockery_getExpectationCount());
+        self::assertSame(1, Mockery::getContainer()->mockery_getExpectationCount());
         $m->foo();
         $m->foo();
     }
@@ -635,7 +625,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock();
         $m->shouldReceive('foo')
             ->never();
-        self::assertEquals(1, Mockery::getContainer()->mockery_getExpectationCount());
+        self::assertSame(1, Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     public function testGetExpectationCountMockWithOnce(): void
@@ -643,7 +633,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock();
         $m->shouldReceive('foo')
             ->once();
-        self::assertEquals(1, Mockery::getContainer()->mockery_getExpectationCount());
+        self::assertSame(1, Mockery::getContainer()->mockery_getExpectationCount());
         $m->foo();
     }
 
@@ -651,7 +641,7 @@ final class ContainerTest extends MockeryTestCase
     {
         $m = mock();
         $m->shouldReceive('foo');
-        self::assertEquals(0, Mockery::getContainer()->mockery_getExpectationCount());
+        self::assertSame(0, Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     public function testGetKeyOfDemeterMockShouldReturnKeyWhenMatchingMock(): void
@@ -714,7 +704,7 @@ final class ContainerTest extends MockeryTestCase
     {
         $testArray = [];
         $testArray['a_scalar'] = 2;
-        $testArray['a_closure'] = function (): void {};
+        $testArray['a_closure'] = static function (): void {};
 
         $mock = mock('MyTestClass');
         $mock->shouldReceive('foo')
@@ -798,7 +788,7 @@ final class ContainerTest extends MockeryTestCase
             ->byDefault();
         $instance = new MyClass6();
 
-        self::assertEquals('bar', $instance->foo());
+        self::assertSame('bar', $instance->foo());
     }
 
     public function testInstantiationOfInstanceMockImportsDefaultExpectationsInTheCorrectOrder(): void
@@ -815,7 +805,7 @@ final class ContainerTest extends MockeryTestCase
             ->byDefault();
         $instance = new MyClass6();
 
-        self::assertEquals(3, $instance->foo());
+        self::assertSame(3, $instance->foo());
     }
 
     public function testInstantiationOfInstanceMockImportsExpectations(): void
@@ -824,7 +814,7 @@ final class ContainerTest extends MockeryTestCase
         $m->shouldReceive('foo')
             ->andReturn('bar');
         $instance = new MyClass6();
-        self::assertEquals('bar', $instance->foo());
+        self::assertSame('bar', $instance->foo());
     }
 
     public function testInstantiationOfInstanceMockWithConstructorParameterValidation(): void
@@ -918,8 +908,7 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testIsValidClassName($expected, $className): void
     {
-        $container = new Container();
-        self::assertSame($expected, $container->isValidClassName($className));
+        self::assertSame($expected, (new Container())->isValidClassName($className));
     }
 
     public function testIssetMappingUsingProxiedPartialsCheckNoExceptionThrown(): void
@@ -938,22 +927,22 @@ final class ContainerTest extends MockeryTestCase
     {
         $m = mock(MockeryTestRef1::class);
         $m->shouldReceive('foo')
-            ->with(Mockery::on(function (&$a) {
+            ->with(Mockery::on(static function (&$a) {
                 ++$a;
                 return true;
             }), Mockery::any());
         $a = 1;
         $b = 1;
         $m->foo($a, $b);
-        self::assertEquals(2, $a);
-        self::assertEquals(1, $b);
+        self::assertSame(2, $a);
+        self::assertSame(1, $b);
     }
 
     public function testMethodParamsPassedByReferenceThroughWithArgsHaveReferencePreserved(): void
     {
         $m = mock(MockeryTestRef1::class);
         $m->shouldReceive('foo')
-            ->withArgs(function (&$a, $b) {
+            ->withArgs(static function (&$a, $b) {
                 ++$a;
                 ++$b;
                 return true;
@@ -961,8 +950,8 @@ final class ContainerTest extends MockeryTestCase
         $a = 1;
         $b = 1;
         $m->foo($a, $b);
-        self::assertEquals(2, $a);
-        self::assertEquals(1, $b);
+        self::assertSame(2, $a);
+        self::assertSame(1, $b);
     }
 
     public function testMethodsReturningParamsByReferenceDoesNotErrorOut(): void
@@ -1060,7 +1049,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(new stdClass());
         $m->shouldReceive('foo')
             ->andReturn('bar');
-        self::assertEquals('bar', $m->foo());
+        self::assertSame('bar', $m->foo());
         self::assertInstanceOf(stdClass::class, $m);
     }
 
@@ -1070,7 +1059,7 @@ final class ContainerTest extends MockeryTestCase
         $m->shouldReceive('foo')
             ->andReturn('bar');
 
-        self::assertEquals('bar', $m->foo());
+        self::assertSame('bar', $m->foo());
         self::assertInstanceOf(MyClass::class, $m);
     }
 
@@ -1079,7 +1068,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(stdClass::class);
         $m->shouldReceive('foo')
             ->andReturn('bar');
-        self::assertEquals('bar', $m->foo());
+        self::assertSame('bar', $m->foo());
         self::assertInstanceOf(stdClass::class, $m);
     }
 
@@ -1104,7 +1093,7 @@ final class ContainerTest extends MockeryTestCase
     {
         $m = mock('Foo');
         $m->foo = 'bar';
-        self::assertEquals('bar', $m->foo);
+        self::assertSame('bar', $m->foo);
         //self::assertArrayHasKey('foo', $m->mockery_getMockableProperties());
     }
 
@@ -1112,7 +1101,7 @@ final class ContainerTest extends MockeryTestCase
     {
         $m = mock(new stdClass());
         $m->foo = 'bar';
-        self::assertEquals('bar', $m->foo);
+        self::assertSame('bar', $m->foo);
         //self::assertArrayHasKey('foo', $m->mockery_getMockableProperties());
     }
 
@@ -1120,14 +1109,14 @@ final class ContainerTest extends MockeryTestCase
     {
         $m = mock(MockeryTestFoo::class);
         $m->foo = 'bar';
-        self::assertEquals('bar', $m->foo);
+        self::assertSame('bar', $m->foo);
         //self::assertArrayHasKey('foo', $m->mockery_getMockableProperties());
     }
 
     public function testMockingDoesNotStubNonStubbedPropertiesOnPartials(): void
     {
         $m = mock(new MockeryTest_ExistingProperty());
-        self::assertEquals('bar', $m->foo);
+        self::assertSame('bar', $m->foo);
         self::assertArrayNotHasKey('foo', $m->mockery_getMockableProperties());
     }
 
@@ -1196,8 +1185,8 @@ final class ContainerTest extends MockeryTestCase
             'foo' => 1,
             'bar' => 2,
         ]);
-        self::assertEquals(1, $m->foo());
-        self::assertEquals(2, $m->bar());
+        self::assertSame(1, $m->foo());
+        self::assertSame(2, $m->bar());
         try {
             $m->f();
         } catch (BadMethodCallException $e) {
@@ -1213,8 +1202,8 @@ final class ContainerTest extends MockeryTestCase
             'foo' => 1,
             'bar' => 2,
         ]);
-        self::assertEquals(1, $m->foo());
-        self::assertEquals(2, $m->bar());
+        self::assertSame(1, $m->foo());
+        self::assertSame(2, $m->bar());
         try {
             $m->f();
         } catch (BadMethodCallException $e) {
@@ -1235,7 +1224,7 @@ final class ContainerTest extends MockeryTestCase
             ->once()
             ->andReturn(2);
 
-        self::assertEquals(2, $m->foo('bar'));
+        self::assertSame(2, $m->foo('bar'));
 
         try {
             $m->f();
@@ -1249,8 +1238,8 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()]);
         $m->shouldReceive('foo')
             ->andReturn(123);
-        self::assertEquals(123, $m->foo());
-        self::assertEquals($param1, $m->getParam1());
+        self::assertSame(123, $m->foo());
+        self::assertSame($param1, $m->getParam1());
     }
 
     public function testNamedMockWithConstructorArgsAndArrayDefs(): void
@@ -1258,15 +1247,15 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()], [
             'foo' => 123,
         ]);
-        self::assertEquals(123, $m->foo());
-        self::assertEquals($param1, $m->getParam1());
+        self::assertSame(123, $m->foo());
+        self::assertSame($param1, $m->getParam1());
     }
 
     public function testNamedMockWithConstructorArgsButNoQuickDefsShouldLeaveConstructorIntact(): void
     {
         $m = mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
         $m->makePartial();
-        self::assertEquals($param1, $m->getParam1());
+        self::assertSame($param1, $m->getParam1());
     }
 
     public function testNamedMockWithConstructorArgsWithInternalCallToMockedMethod(): void
@@ -1274,17 +1263,17 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()]);
         $m->shouldReceive('foo')
             ->andReturn(123);
-        self::assertEquals(123, $m->bar());
+        self::assertSame(123, $m->bar());
     }
 
     public function testNamedMockWithMakePartial(): void
     {
         $m = mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
         $m->makePartial();
-        self::assertEquals('foo', $m->bar());
+        self::assertSame('foo', $m->bar());
         $m->shouldReceive('bar')
             ->andReturn(123);
-        self::assertEquals(123, $m->bar());
+        self::assertSame(123, $m->bar());
     }
 
     public function testNamedMockWithMakePartialThrowsIfNotAvailable(): void
@@ -1315,17 +1304,17 @@ final class ContainerTest extends MockeryTestCase
             'foo' => 1,
             Container::BLOCKS => ['method1'],
         ]);
-        self::assertEquals(1, $m->foo());
+        self::assertSame(1, $m->foo());
     }
 
     public function testPassingClosureAsFinalParameterUsedToDefineExpectations(): void
     {
-        $m = mock('foo', function ($m): void {
+        $m = mock('foo', static function ($m): void {
             $m->shouldReceive('foo')
                 ->once()
                 ->andReturn('bar');
         });
-        self::assertEquals('bar', $m->foo());
+        self::assertSame('bar', $m->foo());
     }
 
     public function testSettingPropertyOnInstanceMockWillSetItOnActualInstance(): void
@@ -1335,8 +1324,8 @@ final class ContainerTest extends MockeryTestCase
             ->andSet('bar', 'baz');
         $instance = new MyClass13();
         $instance->foo();
-        self::assertEquals('baz', $m->bar);
-        self::assertEquals('baz', $instance->bar);
+        self::assertSame('baz', $m->bar);
+        self::assertSame('baz', $instance->bar);
     }
 
     public function testShouldThrowIfAttemptingToStubPrivateMethod(): void
@@ -1364,8 +1353,8 @@ final class ContainerTest extends MockeryTestCase
             'foo' => 1,
             'bar' => 2,
         ]);
-        self::assertEquals(1, $m->foo());
-        self::assertEquals(2, $m->bar());
+        self::assertSame(1, $m->foo());
+        self::assertSame(2, $m->bar());
     }
 
     public function testSimpleMockWithArrayDefsCanBeOverridden(): void
@@ -1386,8 +1375,8 @@ final class ContainerTest extends MockeryTestCase
             ->once()
             ->andReturn(42);
 
-        self::assertEquals(2, $m->foo('baz'));
-        self::assertEquals(42, $m->bar('baz'));
+        self::assertSame(2, $m->foo('baz'));
+        self::assertSame(42, $m->bar('baz'));
     }
 
     public function testSimplestMockCreation(): void
@@ -1395,7 +1384,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock();
         $m->shouldReceive('foo')
             ->andReturn('bar');
-        self::assertEquals('bar', $m->foo());
+        self::assertSame('bar', $m->foo());
     }
 
     public function testSplClassWithFinalMethodsCanBeMocked(): void
@@ -1403,7 +1392,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(SplFileInfo::class);
         $m->shouldReceive('foo')
             ->andReturn('baz');
-        self::assertEquals('baz', $m->foo());
+        self::assertSame('baz', $m->foo());
         self::assertInstanceOf(SplFileInfo::class, $m);
     }
 
@@ -1413,7 +1402,7 @@ final class ContainerTest extends MockeryTestCase
         $m = mock(SplFileInfo::class);
         $m->shouldReceive('foo')
             ->andReturn('baz');
-        self::assertEquals('baz', $m->foo());
+        self::assertSame('baz', $m->foo());
         self::assertInstanceOf(SplFileInfo::class, $m);
     }
 
@@ -1435,10 +1424,20 @@ final class ContainerTest extends MockeryTestCase
 
         // not sure what this test is for, maybe something special about
         // SplFileInfo
-        self::assertEquals('foo', $file->getFilename());
-        self::assertEquals('path/to/foo', $file->getPathname());
-        self::assertEquals('css', $file->getExtension());
+        self::assertSame('foo', $file->getFilename());
+        self::assertSame('path/to/foo', $file->getPathname());
+        self::assertSame('css', $file->getExtension());
         self::assertIsInt($file->getMTime());
+    }
+
+    public function testThrowsExceptionIfClassNamesContainInvalidCharacters(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Class name contains invalid characters');
+
+        $container = new Container();
+
+        self::assertInstanceOf(MockInterface::class, $container->mock('ClassName.WithDot'));
     }
 
     public function testThrowsExceptionIfClassOrInterfaceForPartialMockDoesNotExist(): void
@@ -1491,5 +1490,20 @@ final class ContainerTest extends MockeryTestCase
     public function testWakeupMagicIsNotMockedToAllowSerialisationInstanceHack(): void
     {
         self::assertInstanceOf(DateTime::class, mock(DateTime::class));
+    }
+
+    /**
+     * @return Generator<string,array{0: bool, 1: string}>
+     */
+    public static function classNameProvider(): Generator
+    {
+        yield from [
+            'empty string' => [false, ''],
+            'just a space' => [false, ' '],
+            'class name with dot' => [false, 'ClassName.WithDot'],
+            'too many backslashes' => [false, '\\\\TooManyBackSlashes'],
+            'global class name' => [true, 'Foo'],
+            'namespaced class name' => [true, Bar::class],
+        ];
     }
 }

--- a/tests/Unit/Mockery/GlobalHelpersTest.php
+++ b/tests/Unit/Mockery/GlobalHelpersTest.php
@@ -10,12 +10,6 @@ use Mockery\Matcher\AnyArgs;
 use Mockery\MockInterface;
 use Throwable;
 
-use function andAnyOtherArgs;
-use function andAnyOthers;
-use function anyArgs;
-use function mock;
-use function namedMock;
-use function spy;
 use function uniqid;
 
 /**
@@ -28,7 +22,7 @@ final class GlobalHelpersTest extends MockeryTestCase
      */
     public function testAndAnyOtherArgs(): void
     {
-        self::assertInstanceOf(AndAnyOtherArgs::class, andAnyOtherArgs());
+        self::assertInstanceOf(AndAnyOtherArgs::class, \andAnyOtherArgs());
     }
 
     /**
@@ -36,7 +30,7 @@ final class GlobalHelpersTest extends MockeryTestCase
      */
     public function testAndAnyOthers(): void
     {
-        self::assertInstanceOf(AndAnyOtherArgs::class, andAnyOthers());
+        self::assertInstanceOf(AndAnyOtherArgs::class, \andAnyOthers());
     }
 
     /**
@@ -44,12 +38,12 @@ final class GlobalHelpersTest extends MockeryTestCase
      */
     public function testAnyArgs(): void
     {
-        self::assertInstanceOf(AnyArgs::class, AnyArgs());
+        self::assertInstanceOf(AnyArgs::class, \anyArgs());
     }
 
     public function testMockCreatesAMock(): void
     {
-        $double = mock();
+        $double = \mock();
 
         self::assertInstanceOf(MockInterface::class, $double);
 
@@ -62,7 +56,7 @@ final class GlobalHelpersTest extends MockeryTestCase
     {
         $className = uniqid('Class');
 
-        $double = namedMock($className);
+        $double = \namedMock($className);
 
         self::assertInstanceOf(MockInterface::class, $double);
         self::assertInstanceOf($className, $double);
@@ -70,7 +64,7 @@ final class GlobalHelpersTest extends MockeryTestCase
 
     public function testSpyCreatesASpy(): void
     {
-        $double = spy();
+        $double = \spy();
 
         self::assertInstanceOf(MockInterface::class, $double);
         $double->foo();

--- a/tests/Unit/Mockery/GlobalHelpersTest.php
+++ b/tests/Unit/Mockery/GlobalHelpersTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Tests\Unit\Mockery;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Matcher\AndAnyOtherArgs;
+use Mockery\Matcher\AnyArgs;
 use Mockery\MockInterface;
 use Throwable;
 
+use function andAnyOtherArgs;
+use function andAnyOthers;
+use function anyArgs;
 use function mock;
 use function namedMock;
 use function spy;
@@ -18,6 +23,30 @@ use function uniqid;
  */
 final class GlobalHelpersTest extends MockeryTestCase
 {
+    /**
+     * @throws Throwable
+     */
+    public function testAndAnyOtherArgs(): void
+    {
+        self::assertInstanceOf(AndAnyOtherArgs::class, andAnyOtherArgs());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testAndAnyOthers(): void
+    {
+        self::assertInstanceOf(AndAnyOtherArgs::class, andAnyOthers());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testAnyArgs(): void
+    {
+        self::assertInstanceOf(AnyArgs::class, AnyArgs());
+    }
+
     public function testMockCreatesAMock(): void
     {
         $double = mock();


### PR DESCRIPTION
Refactors `\Mockery\Container::mock` method using new private methods for argument parsing and mock creation.