### PR TITLE
Fix Undefined Array Key in Mockery `withArgs` for PHP 8.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,31 +20,35 @@ phpDocumentor.phar:
 
 library_files=$(shell find library -name '*.php')
 docs/api/index.html: vendor/composer/installed.json $(library_files) phpDocumentor.phar
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1-pcov php phpDocumentor.phar run -d library -t docs/api
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1 php phpDocumentor.phar run -d library -t docs/api
 
 .PHONY: test-all
-test-all: test-83 test-82 test-81 test-80 test-74 test-73
+test-all: test-84 test-83 test-82 test-81 test-80 test-74 test-73
 
 .PHONY: test-73
 test-73: deps
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:7.3-pcov php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:7.3 php vendor/bin/phpunit
 
 .PHONY: test-74
 test-74: deps
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:7.4-pcov php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:7.4 php vendor/bin/phpunit
 
 .PHONY: test-80
 test-80: deps
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.0-pcov php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.0 php vendor/bin/phpunit
 
 .PHONY: test-81
 test-81: deps
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1-pcov php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.1 php vendor/bin/phpunit
 
 .PHONY: test-82
 test-82: deps
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.2-pcov php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.2 php vendor/bin/phpunit
 
 .PHONY: test-83
 test-83: deps
-	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.3-pcov php vendor/bin/phpunit
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.3 php vendor/bin/phpunit
+
+.PHONY: test-84
+test-84: deps
+	docker run -it --rm -v $$PWD:/opt/mockery -w /opt/mockery ghcr.io/ghostwriter/php:8.4-rc php vendor/bin/phpunit

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -559,8 +559,14 @@ class Expectation implements ExpectationInterface
      */
     public function matchArgs(array $args)
     {
-        if ($this->isArgumentListMatcher()) {
-            return $this->_matchArg($this->_expectedArgs[0], $args);
+        if ($this->_expectedArgs !== []) {
+            foreach ($this->_expectedArgs as $expectedArg) {
+                if (!$expectedArg instanceof ArgumentListMatcher) {
+                    continue;
+                }
+
+                return $this->_matchArg($expectedArg, $args);
+            }
         }
 
         $argCount = count($args);
@@ -964,10 +970,10 @@ class Expectation implements ExpectationInterface
      */
     protected function _matchArgs($args)
     {
-        for ($index = 0, $argCount = count($args); $index < $argCount; ++$index) {
+        foreach ($this->_expectedArgs as $index => $expectedArg) {
             $param = &$args[$index];
 
-            if (! $this->_matchArg($this->_expectedArgs[$index], $param)) {
+            if (! $this->_matchArg($expectedArg, $param)) {
                 return false;
             }
         }
@@ -1021,16 +1027,6 @@ class Expectation implements ExpectationInterface
     private function isAndAnyOtherArgumentsMatcher($expectedArg)
     {
         return $expectedArg instanceof AndAnyOtherArgs;
-    }
-
-    /**
-     * Check if the registered expectation is an ArgumentListMatcher
-     *
-     * @return bool
-     */
-    private function isArgumentListMatcher()
-    {
-        return $this->_expectedArgs !== [] && $this->_expectedArgs[0] instanceof ArgumentListMatcher;
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -591,6 +591,9 @@
       <code><![CDATA[times]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
       <code><![CDATA[$code]]></code>
       <code><![CDATA[$exception]]></code>
       <code><![CDATA[$groups]]></code>
@@ -608,6 +611,7 @@
     </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$arg]]></code>
+      <code><![CDATA[$expectedArg]]></code>
       <code><![CDATA[$expectedArg]]></code>
       <code><![CDATA[$groups]]></code>
       <code><![CDATA[$lastExpectedArgument]]></code>
@@ -663,10 +667,6 @@
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUndefinedIntArrayOffset>
-      <code><![CDATA[$this->_expectedArgs[0]]]></code>
-      <code><![CDATA[$this->_expectedArgs[0]]]></code>
-    </PossiblyUndefinedIntArrayOffset>
     <PossiblyUndefinedMethod>
       <code><![CDATA[mockery_isInstance]]></code>
     </PossiblyUndefinedMethod>
@@ -5361,6 +5361,18 @@
     </UndefinedMethod>
     <UnusedClass>
       <code><![CDATA[Php82LanguageFeaturesTest]]></code>
+    </UnusedClass>
+  </file>
+  <file src="tests/Unit/PHP82/TestCase1439Test.php">
+    <MixedMethodCall>
+      <code><![CDATA[andReturn]]></code>
+      <code><![CDATA[withArgs]]></code>
+    </MixedMethodCall>
+    <UndefinedMagicMethod>
+      <code><![CDATA[expects]]></code>
+    </UndefinedMagicMethod>
+    <UnusedClass>
+      <code><![CDATA[TestCase1439Test]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP84/Php84LanguageFeaturesTest.php">

--- a/tests/Unit/PHP82/TestCase1439Test.php
+++ b/tests/Unit/PHP82/TestCase1439Test.php
@@ -14,6 +14,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 final class TestCase1439Test extends MockeryTestCase
 {
+    /** @throws \Throwable */
     public function testDescription(): void
     {
         // Mock the SOAP client

--- a/tests/Unit/PHP82/TestCase1439Test.php
+++ b/tests/Unit/PHP82/TestCase1439Test.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PHP82;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @coversDefaultClass \Mockery\Expectation
+ * @requires PHP 8.2
+ * @see https://github.com/mockery/mockery/issues/1439
+ */
+final class TestCase1439Test extends MockeryTestCase
+{
+    public function testDescription(): void
+    {
+        // Mock the SOAP client
+        $soapClientMock = Mockery::mock(\SoapClient::class);
+
+        // Method we will be calling
+        $methodName = 'testMethod';
+
+        // Expect result
+        $expectedResult = 'result';
+
+        // Expected parameters
+        $params = [
+            'param1' => 'value1',
+            'param2' => 'value2',
+        ];
+
+        // Expect the method to be called with specific arguments using withArgs
+        $soapClientMock
+            ->expects($methodName)
+            ->withArgs($params)
+            ->andReturn($expectedResult);
+
+        // Simulate the call
+        $response = call_user_func_array([$soapClientMock, $methodName], $params);
+
+        self::assertSame($expectedResult, $response);
+    }
+}


### PR DESCRIPTION
This patch fixes #1439, an Undefined array key: 0 error in Mockery's withArgs function on PHP 8.2. 

 - [Update Expectation.php](https://github.com/mockery/mockery/commit/e1eed3bba8bbad52b7c32bc4100a34caddee0da2)