### PR TITLE
Bump symplify/easy-coding-standard from 12.1.14 to 12.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.38 || ^9.6.19",
-        "symplify/easy-coding-standard": "^12.1.14"
+        "symplify/easy-coding-standard": "^12.3.5"
     },
     "conflict": {
         "phpunit/phpunit": "<8.0"
@@ -59,6 +59,9 @@
         "psr-4": {
             "Mockery\\": "library/Mockery"
         },
+        "exclude-from-classmap": [
+            "tests/Fixture"
+        ],
         "files": [
             "library/helpers.php",
             "library/Mockery.php"
@@ -66,7 +69,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests"
+            "Tests\\Unit\\": "tests/Unit"
         },
         "files": [
             "tests/Fixture/autoload.php",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "hamcrest/hamcrest-php": "^2.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.38 || ^9.6.19",
+        "phpunit/phpunit": "^8.5.38 || ^9.6.21",
         "symplify/easy-coding-standard": "^12.3.5"
     },
     "conflict": {
@@ -108,7 +108,7 @@
         "psalm:alter": "tools/psalm --no-cache --alter --allow-backwards-incompatible-changes=false --safe-types",
         "psalm:baseline": "@psalm --no-diff --set-baseline=psalm-baseline.xml",
         "psalm:dry-run": "@psalm:alter --issues=all --dry-run",
-        "psalm:fix": "@psalm:alter --issues=UnnecessaryVarAnnotation,MissingPureAnnotation,MissingImmutableAnnotation",
+        "psalm:fix": "@psalm:alter --issues=UnnecessaryVarAnnotation",
         "psalm:security": "@psalm --no-diff --taint-analysis",
         "psalm:shepherd": "@psalm --no-diff --shepherd --stats --output-format=github",
         "psalm:update": "@psalm --no-diff --update-baseline=psalm-baseline.xml",

--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,6 @@
         "psr-4": {
             "Mockery\\": "library/Mockery"
         },
-        "exclude-from-classmap": [
-            "tests/Fixture"
-        ],
         "files": [
             "library/helpers.php",
             "library/Mockery.php"
@@ -69,8 +66,11 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Unit\\": "tests/Unit"
+            "Tests\\": "tests"
         },
+        "exclude-from-classmap": [
+            "tests/Fixture"
+        ],
         "files": [
             "tests/Fixture/autoload.php",
             "vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c5c993d140448164b4b1c75d48b6327",
+    "content-hash": "7392a12aabf5960041b03abdc0b6c087",
     "packages": [
         {
             "name": "hamcrest/hamcrest-php",
@@ -131,16 +131,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -148,11 +148,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -178,7 +179,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -186,20 +187,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.1",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
                 "shasum": ""
             },
             "require": {
@@ -208,7 +209,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -240,9 +241,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
             },
-            "time": "2024-03-17T08:10:35+00:00"
+            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -364,35 +365,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -401,7 +402,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -430,7 +431,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -438,7 +439,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -683,45 +684,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -766,7 +767,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
             },
             "funding": [
                 {
@@ -782,7 +783,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-09-19T10:50:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1749,16 +1750,16 @@
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "12.1.14",
+            "version": "12.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/easy-coding-standard/easy-coding-standard.git",
-                "reference": "e3c4a241ee36704f7cf920d5931f39693e64afd5"
+                "reference": "0d7c2cfee3debdf11c12135e90d69d1d9f4eef03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/e3c4a241ee36704f7cf920d5931f39693e64afd5",
-                "reference": "e3c4a241ee36704f7cf920d5931f39693e64afd5",
+                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/0d7c2cfee3debdf11c12135e90d69d1d9f4eef03",
+                "reference": "0d7c2cfee3debdf11c12135e90d69d1d9f4eef03",
                 "shasum": ""
             },
             "require": {
@@ -1768,6 +1769,9 @@
                 "friendsofphp/php-cs-fixer": "<3.46",
                 "phpcsstandards/php_codesniffer": "<3.8",
                 "symplify/coding-standard": "<12.1"
+            },
+            "suggest": {
+                "ext-dom": "Needed to support checkstyle output format in class CheckstyleOutputFormatter"
             },
             "bin": [
                 "bin/ecs"
@@ -1791,7 +1795,7 @@
             ],
             "support": {
                 "issues": "https://github.com/easy-coding-standard/easy-coding-standard/issues",
-                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.1.14"
+                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.3.5"
             },
             "funding": [
                 {
@@ -1803,7 +1807,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-23T13:10:40+00:00"
+            "time": "2024-08-08T08:43:50+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7392a12aabf5960041b03abdc0b6c087",
+    "content-hash": "ce6e3fb9680692a29a2d6d118099b15c",
     "packages": [
         {
             "name": "hamcrest/hamcrest-php",

--- a/ecs.php
+++ b/ecs.php
@@ -4,145 +4,226 @@ declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\Casing\ConstantCaseFixer;
+use PhpCsFixer\Fixer\ClassNotation\FinalClassFixer;
 use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\GetClassToClassKeywordFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitAssertNewNamesFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitAttributesFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderNameFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderReturnTypeFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderStaticFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitFqcnAnnotationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitInternalClassFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitNamespacedFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer;
+use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
+use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
+use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+use Symplify\CodingStandard\Fixer\Spacing\MethodChainingNewlineFixer;
+use Symplify\CodingStandard\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
+use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Option;
 
 $cacheDirectory = __DIR__ . '/.cache/ecs';
 $cacheNamespace = \str_replace(search: \DIRECTORY_SEPARATOR, replace: '_', subject: $cacheDirectory);
 
 return ECSConfig::configure()
-    ->withCache(directory: $cacheDirectory, namespace: $cacheNamespace)
-    ->withPhpCsFixerSets(
-        doctrineAnnotation: true,
-        per: true,
-        perCS: true,
-        perCS10: true,
-        perCS10Risky: true,
-        perCS20: true,
-        perCS20Risky: true,
-        perCSRisky: true,
-        perRisky: true,
-        php54Migration: true,
-        php56MigrationRisky: true,
-        php70Migration: true,
-        php70MigrationRisky: true,
-        php71Migration: true,
-        php71MigrationRisky: true,
-        php73Migration: true,
-        php74Migration: false,
-        php74MigrationRisky: false,
-        php80Migration: false,
-        php80MigrationRisky: false,
-        php81Migration: false,
-        php82Migration: false,
-        php83Migration: false,
-        phpunit30MigrationRisky: true,
-        phpunit32MigrationRisky: true,
-        phpunit35MigrationRisky: true,
-        phpunit43MigrationRisky: true,
-        phpunit48MigrationRisky: true,
-        phpunit50MigrationRisky: true,
-        phpunit52MigrationRisky: true,
-        phpunit54MigrationRisky: true,
-        phpunit55MigrationRisky: true,
-        phpunit56MigrationRisky: true,
-        phpunit57MigrationRisky: true,
-        phpunit60MigrationRisky: true,
-        phpunit75MigrationRisky: true,
-        phpunit84MigrationRisky: true,
-        phpunit100MigrationRisky: true,
-        psr1: true,
-        psr2: true,
-        psr12: true,
-        psr12Risky: true,
-        phpCsFixer: false,
-        phpCsFixerRisky: false,
-        symfony: false,
-        symfonyRisky: false,
-    )
-    ->withPreparedSets(
-        psr12: true,
-        common: false,
-        symplify: true,
-        arrays: true,
-        comments: true,
-        docblocks: true,
-        spaces: true,
-        namespaces: true,
-        controlStructures: true,
-        phpunit: true,
-        strict: true,
-        cleanCode: true,
-    )
-    ->withConfiguredRule(NativeFunctionInvocationFixer::class, [
-        'include' => ['@all'],
-        'scope' => 'all',
-    ])
-    ->withConfiguredRule(
-        checkerClass: GlobalNamespaceImportFixer::class,
-        configuration: [
-            'import_classes' => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ]
-    )
-    ->withConfiguredRule(checkerClass: OrderedImportsFixer::class, configuration: [
-        'imports_order' => ['class', 'const', 'function'],
-    ])
+                ->withCache(directory: $cacheDirectory, namespace: $cacheNamespace)
+                ->withPhpCsFixerSets(
+                    doctrineAnnotation: true,
+                    per: true,
+                    perCS: true,
+                    perCS10: true,
+                    perCS10Risky: true,
+                    perCS20: true,
+                    perCS20Risky: true,
+                    perCSRisky: true,
+                    perRisky: true,
+                    php54Migration: true,
+                    php56MigrationRisky: true,
+                    php70Migration: true,
+                    php70MigrationRisky: true,
+                    php71Migration: true,
+                    php71MigrationRisky: true,
+                    php73Migration: true,
+                    php74Migration: false,
+                    php74MigrationRisky: false,
+                    php80Migration: false,
+                    php80MigrationRisky: false,
+                    php81Migration: false,
+                    php82Migration: false,
+                    php83Migration: false,
+                    phpunit30MigrationRisky: true,
+                    phpunit32MigrationRisky: true,
+                    phpunit35MigrationRisky: true,
+                    phpunit43MigrationRisky: true,
+                    phpunit48MigrationRisky: true,
+                    phpunit50MigrationRisky: true,
+                    phpunit52MigrationRisky: true,
+                    phpunit54MigrationRisky: true,
+                    phpunit55MigrationRisky: true,
+                    phpunit56MigrationRisky: true,
+                    phpunit57MigrationRisky: true,
+                    phpunit60MigrationRisky: true,
+                    phpunit75MigrationRisky: true,
+                    phpunit84MigrationRisky: true,
+                    phpunit100MigrationRisky: true,
+                    psr1: true,
+                    psr2: true,
+                    psr12: true,
+                    psr12Risky: true,
+                    phpCsFixer: false,
+                    phpCsFixerRisky: false,
+                    symfony: false,
+                    symfonyRisky: false,
+                )
+                ->withPreparedSets(
+                    psr12: true,
+                    common: false,
+                    symplify: true,
+                    arrays: true,
+                    comments: true,
+                    docblocks: true,
+                    spaces: true,
+                    namespaces: true,
+                    controlStructures: true,
+                    phpunit: true,
+                    strict: true,
+                    cleanCode: true,
+                )
+                ->withConfiguredRule(NativeFunctionInvocationFixer::class, [
+                    'include' => ['@all'],
+                    'scope' => 'all',
+                ])
+                ->withConfiguredRule(
+                    checkerClass: GlobalNamespaceImportFixer::class,
+                    configuration: [
+                        'import_classes' => true,
+                        'import_constants' => true,
+                        'import_functions' => false,
+                    ]
+                )
+                ->withConfiguredRule(checkerClass: OrderedImportsFixer::class, configuration: [
+                    'imports_order' => ['class', 'const', 'function'],
+                ])
 
-    ->withConfiguredRule(checkerClass: PhpdocAlignFixer::class, configuration: [
-        'tags' => ['method', 'param', 'property', 'return', 'throws', 'type', 'var'],
-    ])
+                ->withConfiguredRule(checkerClass: PhpdocAlignFixer::class, configuration: [
+                    'tags' => ['method', 'param', 'property', 'return', 'throws', 'type', 'var'],
+                ])
 
-    ->withConfiguredRule(checkerClass: PhpUnitTestCaseStaticMethodCallsFixer::class, configuration: [
-        'call_type' => 'self',
-    ])
+                ->withConfiguredRule(checkerClass: PhpUnitTestCaseStaticMethodCallsFixer::class, configuration: [
+                    'call_type' => 'self',
+                ])
 
-    ->withConfiguredRule(checkerClass: ArraySyntaxFixer::class, configuration: [
-        'syntax' => 'short',
-    ])
+                ->withConfiguredRule(checkerClass: ArraySyntaxFixer::class, configuration: [
+                    'syntax' => 'short',
+                ])
 
-    ->withConfiguredRule(checkerClass: ConstantCaseFixer::class, configuration: [
-        'case' => 'lower',
-    ])
+                ->withConfiguredRule(checkerClass: ConstantCaseFixer::class, configuration: [
+                    'case' => 'lower',
+                ])
 
-    ->withConfiguredRule(checkerClass: OrderedClassElementsFixer::class, configuration: [
-        'case_sensitive' => true,
-        'sort_algorithm' => 'alpha',
-        'order' => [
-            'use_trait',
-            'case',
-            'constant_public',
-            'constant_protected',
-            'constant_private',
-            'property_public',
-            'property_protected',
-            'property_private',
-            'construct',
-            'destruct',
-            'magic',
-            'method:mockeryTestSetUp',
-            'method:mockeryTestTearDown',
-            'phpunit',
-            'method_public',
-            'method_protected',
-            'method_private',
-        ],
-    ])
-    ->withParallel()
-    ->withPaths(paths: [__DIR__ . '/tests'])
-    ->withSkip(skip: [
-        __DIR__ . '/library/Mockery/Mock.php',
-        __DIR__ . '/tests/Fixture/*',
-        GetClassToClassKeywordFixer::class,
-    ])
-    ->withRootFiles()
-    ->withRules([PhpUnitTestClassRequiresCoversFixer::class])
-;
+                ->withConfiguredRule(checkerClass: OrderedClassElementsFixer::class, configuration: [
+                    'case_sensitive' => true,
+                    'sort_algorithm' => 'alpha',
+                    'order' => [
+                        'use_trait',
+                        'case',
+                        'constant_public',
+                        'constant_protected',
+                        'constant_private',
+                        'property_public',
+                        'property_protected',
+                        'property_private',
+                        'construct',
+                        'destruct',
+                        'magic',
+                        'method:mockeryTestSetUp',
+                        'method:mockeryTestTearDown',
+                        'phpunit',
+                        'method_public',
+                        'method_protected',
+                        'method_private',
+                    ],
+                ])
+                ->withParallel()
+                ->withRootFiles()
+                ->withRules([
+                    PhpUnitAssertNewNamesFixer::class,
+                    PhpUnitConstructFixer::class,
+                    PhpUnitDataProviderNameFixer::class,
+                    PhpUnitDataProviderReturnTypeFixer::class,
+                    PhpUnitDataProviderStaticFixer::class,
+                    PhpUnitDedicateAssertFixer::class,
+                    PhpUnitDedicateAssertInternalTypeFixer::class,
+                    PhpUnitExpectationFixer::class,
+                    PhpUnitFqcnAnnotationFixer::class,
+                    //        PhpUnitInternalClassFixer::class,
+                    PhpUnitMethodCasingFixer::class,
+                    PhpUnitMockFixer::class,
+                    PhpUnitMockShortWillReturnFixer::class,
+                    PhpUnitNamespacedFixer::class,
+                    PhpUnitNoExpectationAnnotationFixer::class,
+                    PhpUnitSetUpTearDownVisibilityFixer::class,
+                    PhpUnitStrictFixer::class,
+                    FinalClassFixer::class,
+                    PhpUnitTestAnnotationFixer::class,
+
+                    //        PhpUnitTestClassRequiresCoversFixer::class,
+                    ParamReturnAndVarTagMalformsFixer::class,
+                    // arrays
+                    ArrayListItemNewlineFixer::class,
+                    ArrayOpenerAndCloserNewlineFixer::class,
+                    StandaloneLinePromotedPropertyFixer::class,
+                    // newlines
+                    SpaceAfterCommaHereNowDocFixer::class,
+                    BlankLineAfterStrictTypesFixer::class,
+                    LineLengthFixer::class,
+                ])
+                ->withConfiguredRule(
+                    \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer::class,
+                    [
+                        'annotations' => ['small', 'internal', 'coversDefaultClass1', 'coversNothing'],
+                    ]
+                )
+                ->withSkip(skip: [
+                    __DIR__ . '/library/Mockery/Mock.php',
+                    __DIR__ . '/tests/Fixture/*',
+                    MethodChainingNewlineFixer::class,
+                    GetClassToClassKeywordFixer::class,
+                    //        \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer::class,
+                    PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class => [
+                        __DIR__ . '/library/Mockery/Matcher/IsEqual.php',
+                        __DIR__ . '/library/Mockery/Matcher/MustBe.php',
+                        __DIR__ . '/library/Mockery/Matcher/Subset.php',
+                        __DIR__ . '/library/Mockery/Generator/StringManipulation',
+                    ],
+                    // Enable later
+                    FinalClassFixer::class,
+                    PhpUnitAttributesFixer::class,
+                ])
+                ->withSpacing(indentation: Option::INDENTATION_SPACES, lineEnding: PHP_EOL)
+                ->withPaths(paths: [
+                    __DIR__ . '/tests',
+                    // __DIR__ . '/library',
+                ])
+    ;

--- a/ecs.php
+++ b/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
+use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\Casing\ConstantCaseFixer;
 use PhpCsFixer\Fixer\ClassNotation\FinalClassFixer;
@@ -200,7 +202,7 @@ return ECSConfig::configure()
                     LineLengthFixer::class,
                 ])
                 ->withConfiguredRule(
-                    \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer::class,
+                    GeneralPhpdocAnnotationRemoveFixer::class,
                     [
                         'annotations' => ['small', 'internal', 'coversDefaultClass1', 'coversNothing'],
                     ]
@@ -208,10 +210,12 @@ return ECSConfig::configure()
                 ->withSkip(skip: [
                     __DIR__ . '/library/Mockery/Mock.php',
                     __DIR__ . '/tests/Fixture/*',
+                    PhpUnitTestClassRequiresCoversFixer::class,
+                    PhpUnitInternalClassFixer::class,
                     MethodChainingNewlineFixer::class,
                     GetClassToClassKeywordFixer::class,
                     //        \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer::class,
-                    PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class => [
+                    StrictComparisonFixer::class => [
                         __DIR__ . '/library/Mockery/Matcher/IsEqual.php',
                         __DIR__ . '/library/Mockery/Matcher/MustBe.php',
                         __DIR__ . '/library/Mockery/Matcher/Subset.php',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,20 +36,13 @@
             <exclude>tests/Fixture</exclude>
         </testsuite>
         <testsuite name="php">
-            <directory phpVersion="7.3.0-dev">tests/**/**/PHP73</directory>
-            <directory phpVersion="7.3.0-dev">tests/**/PHP73</directory>
-            <directory phpVersion="7.4.0-dev">tests/**/**/PHP74</directory>
-            <directory phpVersion="7.4.0-dev">tests/**/PHP74</directory>
-            <directory phpVersion="8.0.0-dev">tests/**/**/PHP80</directory>
-            <directory phpVersion="8.0.0-dev">tests/**/PHP80</directory>
-            <directory phpVersion="8.1.0-dev">tests/**/**/PHP81</directory>
-            <directory phpVersion="8.1.0-dev">tests/**/PHP81</directory>
-            <directory phpVersion="8.2.0-dev">tests/**/**/PHP82</directory>
-            <directory phpVersion="8.2.0-dev">tests/**/PHP82</directory>
-            <directory phpVersion="8.3.0-dev">tests/**/**/PHP83</directory>
-            <directory phpVersion="8.3.0-dev">tests/**/PHP83</directory>
-            <directory phpVersion="8.4.0-dev">tests/**/**/PHP84</directory>
-            <directory phpVersion="8.4.0-dev">tests/**/PHP84</directory>
+            <directory phpVersion="7.3.0-dev">tests/Unit/PHP73</directory>
+            <directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>
             <exclude>tests/Fixture</exclude>
         </testsuite>
     </testsuites>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="library/Mockery.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$demeterMockKey]]></code>
@@ -38,6 +38,9 @@
     <LessSpecificReturnType>
       <code><![CDATA[array<string, mixed>]]></code>
     </LessSpecificReturnType>
+    <MissingClassConstType>
+      <code><![CDATA[BLOCKS = 'Mockery_Forward_Blocks']]></code>
+    </MissingClassConstType>
     <MissingClosureParamType>
       <code><![CDATA[$argument]]></code>
       <code><![CDATA[$method]]></code>
@@ -146,10 +149,8 @@
     </PossiblyUndefinedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[andAnyOtherArgs]]></code>
-      <code><![CDATA[fetchMock]]></code>
       <code><![CDATA[instanceMock]]></code>
       <code><![CDATA[isBuiltInType]]></code>
-      <code><![CDATA[parseShouldReturnArgs]]></code>
       <code><![CDATA[resetContainer]]></code>
       <code><![CDATA[setContainer]]></code>
       <code><![CDATA[setGenerator]]></code>
@@ -191,6 +192,17 @@
       <code><![CDATA[dismissed]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function assertPostConditions(): void]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function setUp(): void]]></code>
+      <code><![CDATA[protected function tearDown(): void]]></code>
+    </MissingOverrideAttribute>
+  </file>
   <file src="library/Mockery/Adapter/Phpunit/TestListener.php">
     <DeprecatedInterface>
       <code><![CDATA[TestListener]]></code>
@@ -198,6 +210,10 @@
     <DeprecatedTrait>
       <code><![CDATA[TestListenerDefaultImplementation]]></code>
     </DeprecatedTrait>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function endTest(Test $test, float $time): void]]></code>
+      <code><![CDATA[public function startTestSuite(TestSuite $suite): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$trait]]></code>
     </MissingPropertyType>
@@ -272,6 +288,12 @@
       <code><![CDATA[$first->getMock()->shouldReceive(...$args)]]></code>
       <code><![CDATA[$this->andReturn(...$args)]]></code>
     </LessSpecificReturnStatement>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function andReturn(...$args)]]></code>
+      <code><![CDATA[public function andReturns(...$args)]]></code>
+      <code><![CDATA[public function getMock()]]></code>
+      <code><![CDATA[public function getOrderNumber()]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$args]]></code>
       <code><![CDATA[$args]]></code>
@@ -314,7 +336,6 @@
       <code><![CDATA[getDefaultMatcher]]></code>
       <code><![CDATA[getInternalClassMethodParamMap]]></code>
       <code><![CDATA[mockingMethodsUnnecessarilyAllowed]]></code>
-      <code><![CDATA[reflectionCacheEnabled]]></code>
       <code><![CDATA[resetInternalClassMethodParamMaps]]></code>
       <code><![CDATA[setInternalClassMethodParamMap]]></code>
     </PossiblyUnusedMethod>
@@ -332,7 +353,6 @@
   </file>
   <file src="library/Mockery/Container.php">
     <ArgumentTypeCoercion>
-      <code><![CDATA[$constructorArgs]]></code>
       <code><![CDATA[$interfaces]]></code>
       <code><![CDATA[$type]]></code>
     </ArgumentTypeCoercion>
@@ -364,6 +384,9 @@
     <LessSpecificReturnType>
       <code><![CDATA[array]]></code>
     </LessSpecificReturnType>
+    <MissingClassConstType>
+      <code><![CDATA[BLOCKS = Mockery::BLOCKS]]></code>
+    </MissingClassConstType>
     <MissingThrowsDocblock>
       <code><![CDATA[_getInstance]]></code>
     </MissingThrowsDocblock>
@@ -448,6 +471,10 @@
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function isEligible($n)]]></code>
+      <code><![CDATA[public function validate($n)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/CountValidator/AtMost.php">
     <InvalidOperand>
@@ -457,8 +484,15 @@
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function validate($n)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/CountValidator/CountValidatorAbstract.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[abstract public function validate($n);]]></code>
+      <code><![CDATA[public function isEligible($n)]]></code>
+    </MissingOverrideAttribute>
     <PossiblyNullPropertyAssignmentValue>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
@@ -481,6 +515,9 @@
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function validate($n)]]></code>
+    </MissingOverrideAttribute>
     <PossiblyNullOperand>
       <code><![CDATA[$this->_expectation->getExceptionMessage()]]></code>
     </PossiblyNullOperand>
@@ -549,6 +586,9 @@
       <code><![CDATA[self]]></code>
       <code><![CDATA[self]]></code>
     </LessSpecificReturnType>
+    <MissingClassConstType>
+      <code><![CDATA[ERROR_ZERO_INVOCATION = 'shouldNotReceive(), never(), times(0) chaining additional invocation count methods has been deprecated and will throw an exception in a future version of Mockery']]></code>
+    </MissingClassConstType>
     <MissingClosureParamType>
       <code><![CDATA[$args]]></code>
       <code><![CDATA[$args]]></code>
@@ -557,6 +597,12 @@
       <code><![CDATA[static function () use ($args) {]]></code>
       <code><![CDATA[static function (...$args) use ($index) {]]></code>
     </MissingClosureReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function andReturn(...$args)]]></code>
+      <code><![CDATA[public function andReturns(...$args)]]></code>
+      <code><![CDATA[public function getMock()]]></code>
+      <code><![CDATA[public function getOrderNumber()]]></code>
+    </MissingOverrideAttribute>
     <MissingParamType>
       <code><![CDATA[$code]]></code>
       <code><![CDATA[$exception]]></code>
@@ -671,7 +717,6 @@
       <code><![CDATA[mockery_isInstance]]></code>
     </PossiblyUndefinedMethod>
     <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
       <code><![CDATA[andReturnArg]]></code>
       <code><![CDATA[andReturnFalse]]></code>
       <code><![CDATA[andReturnNull]]></code>
@@ -688,7 +733,6 @@
       <code><![CDATA[globally]]></code>
       <code><![CDATA[isCallCountConstrained]]></code>
       <code><![CDATA[isEligible]]></code>
-      <code><![CDATA[once]]></code>
       <code><![CDATA[ordered]]></code>
       <code><![CDATA[passthru]]></code>
       <code><![CDATA[set]]></code>
@@ -702,6 +746,7 @@
     </PossiblyUnusedProperty>
     <PossiblyUnusedReturnValue>
       <code><![CDATA[mixed]]></code>
+      <code><![CDATA[self]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[$argsOrClosure instanceof Closure]]></code>
@@ -736,8 +781,6 @@
       <code><![CDATA[null]]></code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-      <code><![CDATA[addExpectation]]></code>
       <code><![CDATA[call]]></code>
       <code><![CDATA[getExpectationCount]]></code>
       <code><![CDATA[verify]]></code>
@@ -760,15 +803,15 @@
     </PossiblyUnusedReturnValue>
   </file>
   <file src="library/Mockery/ExpectsHigherOrderMessage.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function __call($method, $args)]]></code>
+    </MissingOverrideAttribute>
     <MixedInferredReturnType>
       <code><![CDATA[Expectation|ExpectationInterface|HigherOrderMessage]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$expectation->once()]]></code>
     </MixedReturnStatement>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
-    </PossiblyUnusedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[once]]></code>
     </UndefinedInterfaceMethod>
@@ -777,6 +820,9 @@
     </UndefinedMagicMethod>
   </file>
   <file src="library/Mockery/Generator/CachingGenerator.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function generate(MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MixedInferredReturnType>
       <code><![CDATA[string]]></code>
     </MixedInferredReturnType>
@@ -801,12 +847,23 @@
             )
         )]]></code>
     </LessSpecificReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$this->rfc->getAttributes()]]></code>
-    </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[$attribute->getName()]]></code>
-    </MixedOperand>
+    <LessSpecificReturnType>
+      <code><![CDATA[string]]></code>
+    </LessSpecificReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getAttributes()]]></code>
+      <code><![CDATA[public function getInterfaces()]]></code>
+      <code><![CDATA[public function getMethods()]]></code>
+      <code><![CDATA[public function getName()]]></code>
+      <code><![CDATA[public function getNamespaceName()]]></code>
+      <code><![CDATA[public function getShortName()]]></code>
+      <code><![CDATA[public function hasInternalAncestor()]]></code>
+      <code><![CDATA[public function implementsInterface($interface)]]></code>
+      <code><![CDATA[public function inNamespace()]]></code>
+      <code><![CDATA[public function isAbstract()]]></code>
+      <code><![CDATA[public function isFinal()]]></code>
+      <code><![CDATA[public static function factory($name, $alias = null)]]></code>
+    </MissingOverrideAttribute>
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$interface]]></code>
     </MoreSpecificImplementedParamType>
@@ -996,12 +1053,38 @@
       <code><![CDATA[getTypeHintAsString]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="library/Mockery/Generator/StringManipulation/Pass/AvoidMethodClashPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="library/Mockery/Generator/StringManipulation/Pass/CallTypeHintPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="library/Mockery/Generator/StringManipulation/Pass/ClassAttributesPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
+  </file>
+  <file src="library/Mockery/Generator/StringManipulation/Pass/ClassNamePass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
+  </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/ClassPass.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$className]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/ConstantsPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
@@ -1013,6 +1096,51 @@
     </PossiblyNullArgument>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/InstanceMockPass.php">
+    <MissingClassConstType>
+      <code><![CDATA[INSTANCE_MOCK_CODE = <<<MOCK
+
+    protected \$_mockery_ignoreVerification = true;
+
+    public function __construct()
+    {
+        \$this->_mockery_ignoreVerification = false;
+        \$associatedRealObject = \Mockery::fetchMock(__CLASS__);
+
+        foreach (get_object_vars(\$this) as \$attr => \$val) {
+            if (\$attr !== "_mockery_ignoreVerification" && \$attr !== "_mockery_expectations") {
+                \$this->\$attr = \$associatedRealObject->\$attr;
+            }
+        }
+
+        \$directors = \$associatedRealObject->mockery_getExpectations();
+        foreach (\$directors as \$method=>\$director) {
+            // get the director method needed
+            \$existingDirector = \$this->mockery_getExpectationsFor(\$method);
+            if (!\$existingDirector) {
+                \$existingDirector = new \Mockery\ExpectationDirector(\$method, \$this);
+                \$this->mockery_setExpectationsFor(\$method, \$existingDirector);
+            }
+            \$expectations = \$director->getExpectations();
+            foreach (\$expectations as \$expectation) {
+                \$clonedExpectation = clone \$expectation;
+                \$existingDirector->addExpectation(\$clonedExpectation);
+            }
+            \$defaultExpectations = \$director->getDefaultExpectations();
+            foreach (array_reverse(\$defaultExpectations) as \$expectation) {
+                \$clonedExpectation = clone \$expectation;
+                \$existingDirector->addExpectation(\$clonedExpectation);
+                \$existingDirector->makeExpectationDefault(\$clonedExpectation);
+            }
+        }
+        \Mockery::getContainer()->rememberMock(\$this);
+
+        \$this->_mockery_constructorCalled(func_get_args());
+    }
+MOCK]]></code>
+    </MissingClassConstType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MissingParamType>
       <code><![CDATA[$class]]></code>
       <code><![CDATA[$code]]></code>
@@ -1041,6 +1169,9 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$name]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$i->getName()]]></code>
     </MixedArgument>
@@ -1074,6 +1205,9 @@
       <code><![CDATA[string]]></code>
       <code><![CDATA[string]]></code>
     </LessSpecificReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MissingReturnType>
       <code><![CDATA[renderTypeHint]]></code>
     </MissingReturnType>
@@ -1100,6 +1234,9 @@
       <code><![CDATA[getName]]></code>
       <code><![CDATA[isPassedByReference]]></code>
     </InvalidMethodCall>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MissingParamType>
       <code><![CDATA[$class]]></code>
       <code><![CDATA[$code]]></code>
@@ -1184,6 +1321,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/RemoveBuiltinMethodsThatAreFinalPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$methods]]></code>
     </MissingPropertyType>
@@ -1194,7 +1334,19 @@
       <code><![CDATA[$this->methods[$method->getName()]]]></code>
     </MixedArrayAccess>
   </file>
+  <file src="library/Mockery/Generator/StringManipulation/Pass/RemoveDestructorPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
+  </file>
   <file src="library/Mockery/Generator/StringManipulation/Pass/RemoveUnserializeForInternalSerializableClassesPass.php">
+    <MissingClassConstType>
+      <code><![CDATA[DUMMY_METHOD_DEFINITION = 'public function unserialize(string $data): void {} ']]></code>
+      <code><![CDATA[DUMMY_METHOD_DEFINITION_LEGACY = 'public function unserialize($string) {} ']]></code>
+    </MissingClassConstType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MissingParamType>
       <code><![CDATA[$class]]></code>
       <code><![CDATA[$code]]></code>
@@ -1222,10 +1374,18 @@
       <code><![CDATA[$lastBrace]]></code>
     </PossiblyFalseArgument>
   </file>
+  <file src="library/Mockery/Generator/StringManipulation/Pass/TraitPass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
+  </file>
   <file src="library/Mockery/Generator/StringManipulationGenerator.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$className]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function generate(MockConfiguration $config)]]></code>
+    </MissingOverrideAttribute>
     <MissingThrowsDocblock>
       <code><![CDATA[new MockDefinition($namedConfig, $code)]]></code>
     </MissingThrowsDocblock>
@@ -1262,6 +1422,20 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="library/Mockery/Generator/UndefinedTargetClass.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getAttributes()]]></code>
+      <code><![CDATA[public function getInterfaces()]]></code>
+      <code><![CDATA[public function getMethods()]]></code>
+      <code><![CDATA[public function getName()]]></code>
+      <code><![CDATA[public function getNamespaceName()]]></code>
+      <code><![CDATA[public function getShortName()]]></code>
+      <code><![CDATA[public function hasInternalAncestor()]]></code>
+      <code><![CDATA[public function implementsInterface($interface)]]></code>
+      <code><![CDATA[public function inNamespace()]]></code>
+      <code><![CDATA[public function isAbstract()]]></code>
+      <code><![CDATA[public function isFinal()]]></code>
+      <code><![CDATA[public static function factory($name)]]></code>
+    </MissingOverrideAttribute>
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$interface]]></code>
     </MoreSpecificImplementedParamType>
@@ -1323,26 +1497,37 @@
     </UnusedMethod>
   </file>
   <file src="library/Mockery/LegacyMockInterface.php">
+    <InvalidParamDefault>
+      <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
+    </InvalidParamDefault>
     <PossiblyUnusedMethod>
-      <code><![CDATA[makePartial]]></code>
       <code><![CDATA[mockery_allocateOrder]]></code>
       <code><![CDATA[mockery_findExpectation]]></code>
       <code><![CDATA[mockery_getCurrentOrder]]></code>
       <code><![CDATA[mockery_getGroups]]></code>
       <code><![CDATA[mockery_getMockableProperties]]></code>
       <code><![CDATA[mockery_init]]></code>
-      <code><![CDATA[mockery_setCurrentOrder]]></code>
-      <code><![CDATA[mockery_setExpectationsFor]]></code>
       <code><![CDATA[mockery_setGroup]]></code>
       <code><![CDATA[shouldAllowMockingMethod]]></code>
       <code><![CDATA[shouldAllowMockingProtectedMethods]]></code>
       <code><![CDATA[shouldDeferMissing]]></code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedReturnValue>
+      <code><![CDATA[int]]></code>
+      <code><![CDATA[null|ExpectationDirector]]></code>
       <code><![CDATA[self]]></code>
     </PossiblyUnusedReturnValue>
   </file>
+  <file src="library/Mockery/Loader/EvalLoader.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function load(MockDefinition $definition)]]></code>
+    </MissingOverrideAttribute>
+  </file>
   <file src="library/Mockery/Loader/RequireLoader.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function load(MockDefinition $definition)]]></code>
+    </MissingOverrideAttribute>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[glob($this->path . DIRECTORY_SEPARATOR . 'Mockery_*.php')]]></code>
     </RiskyTruthyFalsyComparison>
@@ -1351,16 +1536,25 @@
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/Any.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/AnyArgs.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/AnyOf.php">
     <DeprecatedClass>
@@ -1369,6 +1563,9 @@
     <InvalidArgument>
       <code><![CDATA[$this->_expected]]></code>
     </InvalidArgument>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/Closure.php">
     <DeprecatedClass>
@@ -1377,11 +1574,17 @@
     <InvalidFunctionCall>
       <code><![CDATA[($this->_expected)($actual)]]></code>
     </InvalidFunctionCall>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/Contains.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$actual]]></code>
     </MixedArgumentTypeCoercion>
@@ -1397,6 +1600,9 @@
     <InvalidArgument>
       <code><![CDATA[$this->_expected]]></code>
     </InvalidArgument>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
     <UndefinedClass>
       <code><![CDATA[$this->_expected]]></code>
     </UndefinedClass>
@@ -1409,6 +1615,9 @@
       <code><![CDATA[$this->_expected]]></code>
       <code><![CDATA[$this->_expected]]></code>
     </InvalidArgument>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/HasValue.php">
     <DeprecatedClass>
@@ -1417,16 +1626,25 @@
     <InvalidCast>
       <code><![CDATA[$this->_expected]]></code>
     </InvalidCast>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/IsEqual.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/IsSame.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/MatcherAbstract.php">
     <MixedPropertyTypeCoercion>
@@ -1447,16 +1665,25 @@
     <InvalidFunctionCall>
       <code><![CDATA[($this->_expected)(...$actual)]]></code>
     </InvalidFunctionCall>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/MustBe.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/NoArgs.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$actual]]></code>
     </MixedArgumentTypeCoercion>
@@ -1465,11 +1692,17 @@
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/NotAnyOf.php">
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
     <UndefinedClass>
       <code><![CDATA[$this->_expected]]></code>
     </UndefinedClass>
@@ -1484,6 +1717,9 @@
     <InvalidCast>
       <code><![CDATA[$this->_expected]]></code>
     </InvalidCast>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/Mockery/Matcher/Subset.php">
     <DeprecatedClass>
@@ -1492,6 +1728,9 @@
     <InvalidOperand>
       <code><![CDATA[$k]]></code>
     </InvalidOperand>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$strict]]></code>
     </MissingPropertyType>
@@ -1518,6 +1757,9 @@
     <InvalidCast>
       <code><![CDATA[$this->_expected]]></code>
     </InvalidCast>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function match(&$actual)]]></code>
+    </MissingOverrideAttribute>
     <MixedInferredReturnType>
       <code><![CDATA[bool]]></code>
     </MixedInferredReturnType>
@@ -1540,10 +1782,286 @@
   </file>
   <file src="library/Mockery/MethodCall.php">
     <PossiblyUnusedMethod>
-      <code><![CDATA[__construct]]></code>
       <code><![CDATA[getArgs]]></code>
       <code><![CDATA[getMethod]]></code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="library/Mockery/Mock.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$returnType]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$method === null]]></code>
+      <code><![CDATA[$method === null]]></code>
+    </DocblockTypeContradiction>
+    <InvalidOperand>
+      <code><![CDATA[$order]]></code>
+      <code><![CDATA[$this->_mockery_currentOrder]]></code>
+    </InvalidOperand>
+    <InvalidReturnStatement>
+      <code><![CDATA[$director]]></code>
+      <code><![CDATA[new HigherOrderMessage($this, 'shouldHaveReceived')]]></code>
+      <code><![CDATA[new HigherOrderMessage($this, 'shouldNotHaveReceived')]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldNotHaveReceived]]></code>
+    </InvalidReturnType>
+    <LessSpecificImplementedReturnType>
+      <code><![CDATA[array]]></code>
+    </LessSpecificImplementedReturnType>
+    <MissingClosureParamType>
+      <code><![CDATA[$method]]></code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType>
+      <code><![CDATA[static function ($method) {]]></code>
+      <code><![CDATA[static function () {]]></code>
+    </MissingClosureReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function allows($something = [])]]></code>
+      <code><![CDATA[public function byDefault()]]></code>
+      <code><![CDATA[public function expects($something = null)]]></code>
+      <code><![CDATA[public function makePartial()]]></code>
+      <code><![CDATA[public function mockery_allocateOrder()]]></code>
+      <code><![CDATA[public function mockery_findExpectation($method, array $args)]]></code>
+      <code><![CDATA[public function mockery_getContainer()]]></code>
+      <code><![CDATA[public function mockery_getCurrentOrder()]]></code>
+      <code><![CDATA[public function mockery_getExpectationCount()]]></code>
+      <code><![CDATA[public function mockery_getExpectationsFor($method)]]></code>
+      <code><![CDATA[public function mockery_getGroups()]]></code>
+      <code><![CDATA[public function mockery_getMockableMethods()]]></code>
+      <code><![CDATA[public function mockery_getMockableProperties()]]></code>
+      <code><![CDATA[public function mockery_getName()]]></code>
+      <code><![CDATA[public function mockery_init(?Container $container = null, $partialObject = null, $instanceMock = true)]]></code>
+      <code><![CDATA[public function mockery_isAnonymous()]]></code>
+      <code><![CDATA[public function mockery_setCurrentOrder($order)]]></code>
+      <code><![CDATA[public function mockery_setExpectationsFor($method, ExpectationDirector $director)]]></code>
+      <code><![CDATA[public function mockery_setGroup($group, $order)]]></code>
+      <code><![CDATA[public function mockery_teardown()]]></code>
+      <code><![CDATA[public function mockery_validateOrder($method, $order)]]></code>
+      <code><![CDATA[public function mockery_verify()]]></code>
+      <code><![CDATA[public function shouldAllowMockingMethod($method)]]></code>
+      <code><![CDATA[public function shouldAllowMockingProtectedMethods()]]></code>
+      <code><![CDATA[public function shouldDeferMissing()]]></code>
+      <code><![CDATA[public function shouldHaveBeenCalled()]]></code>
+      <code><![CDATA[public function shouldHaveReceived($method = null, $args = null)]]></code>
+      <code><![CDATA[public function shouldIgnoreMissing($returnValue = null, $recursive = false)]]></code>
+      <code><![CDATA[public function shouldNotHaveBeenCalled(?array $args = null)]]></code>
+      <code><![CDATA[public function shouldNotHaveReceived($method = null, $args = null)]]></code>
+      <code><![CDATA[public function shouldNotReceive(...$methodNames)]]></code>
+      <code><![CDATA[public function shouldReceive(...$methodNames)]]></code>
+    </MissingOverrideAttribute>
+    <MissingParamType>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$name]]></code>
+    </MissingParamType>
+    <MissingPropertyType>
+      <code><![CDATA[$_mockery_allowMockingProtectedMethods]]></code>
+      <code><![CDATA[$_mockery_instanceMock]]></code>
+      <code><![CDATA[$_mockery_receivedMethodCalls]]></code>
+    </MissingPropertyType>
+    <MissingReturnType>
+      <code><![CDATA[_mockery_constructorCalled]]></code>
+      <code><![CDATA[_mockery_findExpectedMethodHandler]]></code>
+      <code><![CDATA[_mockery_getReceivedMethodCalls]]></code>
+      <code><![CDATA[_mockery_handleMethodCall]]></code>
+      <code><![CDATA[_mockery_handleStaticMethodCall]]></code>
+      <code><![CDATA[asUndefined]]></code>
+      <code><![CDATA[hasMethodOverloadingInParentClass]]></code>
+      <code><![CDATA[mockery_getExpectations]]></code>
+      <code><![CDATA[mockery_getMethod]]></code>
+      <code><![CDATA[mockery_isInstance]]></code>
+    </MissingReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw $bmce;]]></code>
+      <code><![CDATA[throw $e;]]></code>
+      <code><![CDATA[throw new BadMethodCallException(
+                'Static method ' . $associatedRealObject->mockery_getName() . '::' . $method
+                . '() does not exist on this mock object',
+                0,
+                $badMethodCallException
+            );]]></code>
+    </MissingThrowsDocblock>
+    <MixedArgument>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$rm]]></code>
+      <code><![CDATA[$this->_mockery_getReceivedMethodCalls()]]></code>
+      <code><![CDATA[$this->_mockery_getReceivedMethodCalls()]]></code>
+    </MixedArgument>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
+      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
+      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
+      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
+      <code><![CDATA[$this->_mockery_groups[$group]]]></code>
+    </MixedArrayOffset>
+    <MixedAssignment>
+      <code><![CDATA[$allowMockingProtectedMethods]]></code>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$director]]></code>
+      <code><![CDATA[$director]]></code>
+      <code><![CDATA[$director]]></code>
+      <code><![CDATA[$director]]></code>
+      <code><![CDATA[$exp]]></code>
+      <code><![CDATA[$exps]]></code>
+      <code><![CDATA[$handler]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$prototype]]></code>
+      <code><![CDATA[$returnValue]]></code>
+      <code><![CDATA[$rm]]></code>
+      <code><![CDATA[$rm]]></code>
+      <code><![CDATA[$rm]]></code>
+    </MixedAssignment>
+    <MixedInferredReturnType>
+      <code><![CDATA[ExpectationDirector|null]]></code>
+      <code><![CDATA[ExpectationInterface|Expectation|ExpectsHigherOrderMessage]]></code>
+      <code><![CDATA[Expectation|null]]></code>
+      <code><![CDATA[int]]></code>
+    </MixedInferredReturnType>
+    <MixedMethodCall>
+      <code><![CDATA[byDefault]]></code>
+      <code><![CDATA[call]]></code>
+      <code><![CDATA[findExpectation]]></code>
+      <code><![CDATA[getExpectationCount]]></code>
+      <code><![CDATA[getExpectations]]></code>
+      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getPrototype]]></code>
+      <code><![CDATA[isAbstract]]></code>
+      <code><![CDATA[isAbstract]]></code>
+      <code><![CDATA[isPrivate]]></code>
+      <code><![CDATA[isProtected]]></code>
+      <code><![CDATA[isProtected]]></code>
+      <code><![CDATA[isProtected]]></code>
+      <code><![CDATA[isPublic]]></code>
+      <code><![CDATA[isPublic]]></code>
+      <code><![CDATA[push]]></code>
+      <code><![CDATA[verify]]></code>
+    </MixedMethodCall>
+    <MixedOperand>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
+    </MixedOperand>
+    <MixedReturnStatement>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$director->findExpectation($args)]]></code>
+      <code><![CDATA[$this->__call('__toString', [])]]></code>
+      <code><![CDATA[$this->_mockery_expectations[$method]]]></code>
+      <code><![CDATA[$this->shouldReceive($something)->once()]]></code>
+    </MixedReturnStatement>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->_mockery_mockableMethods]]></code>
+      <code><![CDATA[string[]]]></code>
+    </MixedReturnTypeCoercion>
+    <NullableReturnStatement>
+      <code><![CDATA[null]]></code>
+    </NullableReturnStatement>
+    <PossiblyInvalidDocblockTag>
+      <code><![CDATA[@var array $args]]></code>
+      <code><![CDATA[@var string $method]]></code>
+      <code><![CDATA[@var string $method]]></code>
+      <code><![CDATA[@var string $method]]></code>
+    </PossiblyInvalidDocblockTag>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+    </PossiblyNullOperand>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference>
+      <code><![CDATA[__call]]></code>
+      <code><![CDATA[mockery_getName]]></code>
+    </PossiblyNullReference>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__callStatic]]></code>
+      <code><![CDATA[_mockery_constructorCalled]]></code>
+      <code><![CDATA[asUndefined]]></code>
+      <code><![CDATA[mockery_callSubjectMethod]]></code>
+      <code><![CDATA[mockery_getExpectations]]></code>
+      <code><![CDATA[mockery_isInstance]]></code>
+      <code><![CDATA[mockery_thrownExceptions]]></code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$_mockery_name]]></code>
+    </PossiblyUnusedProperty>
+    <PossiblyUnusedReturnValue>
+      <code><![CDATA[ExpectationDirector|null]]></code>
+    </PossiblyUnusedReturnValue>
+    <RedundantCondition>
+      <code><![CDATA[$i->getName() !== 'Stringable']]></code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[!is_null($this->_mockery_partial)]]></code>
+      <code><![CDATA[$this->_mockery_partial !== null]]></code>
+    </RedundantConditionGivenDocblockType>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[!$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+      <code><![CDATA[$this->_mockery_parentClass]]></code>
+    </RiskyTruthyFalsyComparison>
+    <TooManyArguments>
+      <code><![CDATA[shouldIgnoreMissing]]></code>
+      <code><![CDATA[shouldIgnoreMissing]]></code>
+    </TooManyArguments>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[never]]></code>
+      <code><![CDATA[once]]></code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMagicMethod>
+      <code><![CDATA[andReturn]]></code>
+      <code><![CDATA[never]]></code>
+      <code><![CDATA[once]]></code>
+    </UndefinedMagicMethod>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->_mockery_ignoreVerification]]></code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="library/Mockery/QuickDefinitionsConfiguration.php">
+    <MissingClassConstType>
+      <code><![CDATA[QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION = 'QUICK_DEFINITIONS_MODE_DEFAULT_EXPECTATION']]></code>
+      <code><![CDATA[QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE = 'QUICK_DEFINITIONS_MODE_MOCK_AT_LEAST_ONCE']]></code>
+    </MissingClassConstType>
   </file>
   <file src="library/Mockery/ReceivedMethodCalls.php">
     <MissingPropertyType>
@@ -1575,20 +2093,21 @@
   <file src="library/Mockery/Reflector.php">
     <LessSpecificReturnType>
       <code><![CDATA[string]]></code>
+      <code><![CDATA[string]]></code>
     </LessSpecificReturnType>
+    <MissingClassConstType>
+      <code><![CDATA[BUILTIN_TYPES = ['array', 'bool', 'int', 'float', 'null', 'object', 'string']]]></code>
+      <code><![CDATA[ITERABLE = ['iterable']]]></code>
+      <code><![CDATA[RESERVED_WORDS = ['bool', 'true', 'false', 'float', 'int', 'iterable', 'mixed', 'never', 'null', 'object', 'string', 'void']]]></code>
+      <code><![CDATA[TRAVERSABLE_ARRAY = ['\Traversable', 'array']]]></code>
+    </MissingClassConstType>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new InvalidArgumentException('Unknown ReflectionType: ' . get_debug_type($type));]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
-      <code><![CDATA[$innterType]]></code>
-      <code><![CDATA[$type->getTypes()]]></code>
-      <code><![CDATA[$type->getTypes()]]></code>
       <code><![CDATA[$typeHint]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$innterType]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$type]]></code>
       <code><![CDATA[$typeHint]]></code>
     </MixedAssignment>
     <MixedReturnTypeCoercion>
@@ -1603,15 +2122,13 @@
     <PossiblyNullArgument>
       <code><![CDATA[$declaringClass]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getSimplestReturnType]]></code>
-    </PossiblyUnusedMethod>
     <RedundantCondition>
       <code><![CDATA[! $type instanceof ReflectionType && method_exists($method, 'getTentativeReturnType')]]></code>
       <code><![CDATA[! $type instanceof ReflectionType && method_exists($method, 'getTentativeReturnType')]]></code>
     </RedundantCondition>
     <UndefinedMethod>
       <code><![CDATA[getName]]></code>
+      <code><![CDATA[isBuiltin]]></code>
     </UndefinedMethod>
   </file>
   <file src="library/Mockery/Undefined.php">
@@ -1639,6 +2156,11 @@
       <code><![CDATA[withArgs]]></code>
       <code><![CDATA[withNoArgs]]></code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="library/Mockery/VerificationExpectation.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function __clone()]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="library/helpers.php">
     <LessSpecificReturnType>
@@ -1695,9 +2217,9 @@
       <code><![CDATA[$exception]]></code>
     </ArgumentTypeCoercion>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertInstanceOf($class, mock($class))]]></code>
-      <code><![CDATA[self::assertInstanceOf($class, mock($class))]]></code>
-      <code><![CDATA[self::assertInstanceOf($class, mock($class))]]></code>
+      <code><![CDATA[self::assertInstanceOf($class, \mock($class))]]></code>
+      <code><![CDATA[self::assertInstanceOf($class, \mock($class))]]></code>
+      <code><![CDATA[self::assertInstanceOf($class, \mock($class))]]></code>
     </MissingThrowsDocblock>
     <PossiblyUnusedMethod>
       <code><![CDATA[assertInvalidMock]]></code>
@@ -1775,6 +2297,9 @@
       <code><![CDATA[setTestResultObject]]></code>
       <code><![CDATA[wasSuccessful]]></code>
     </InternalMethod>
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$container]]></code>
       <code><![CDATA[$listener]]></code>
@@ -1846,6 +2371,10 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/AdhocTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[public function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$container]]></code>
     </MissingPropertyType>
@@ -1891,22 +2420,22 @@
   </file>
   <file src="tests/Unit/Mockery/AllowsExpectsSyntaxTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('bar', $stub->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $stub->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $stub->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $stub->foo())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $stub->bar())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $stub->bar())]]></code>
-      <code><![CDATA[self::assertEquals(123, $mock->foo(456, 789))]]></code>
-      <code><![CDATA[self::assertEquals(123, $mock->foo(456, 789))]]></code>
-      <code><![CDATA[self::assertEquals(123, $mock->foo(456, 789))]]></code>
-      <code><![CDATA[self::assertEquals(123, $mock->foo(456, 789))]]></code>
-      <code><![CDATA[self::assertEquals(123, $stub->allows())]]></code>
-      <code><![CDATA[self::assertEquals(123, $stub->allows())]]></code>
-      <code><![CDATA[self::assertEquals(123, $stub->expects())]]></code>
-      <code><![CDATA[self::assertEquals(123, $stub->expects())]]></code>
-      <code><![CDATA[self::assertEquals(456, $stub->foo(123))]]></code>
-      <code><![CDATA[self::assertEquals(456, $stub->foo(123))]]></code>
+      <code><![CDATA[self::assertSame('bar', $stub->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $stub->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $stub->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $stub->foo())]]></code>
+      <code><![CDATA[self::assertSame('baz', $stub->bar())]]></code>
+      <code><![CDATA[self::assertSame('baz', $stub->bar())]]></code>
+      <code><![CDATA[self::assertSame(123, $mock->foo(456, 789))]]></code>
+      <code><![CDATA[self::assertSame(123, $mock->foo(456, 789))]]></code>
+      <code><![CDATA[self::assertSame(123, $mock->foo(456, 789))]]></code>
+      <code><![CDATA[self::assertSame(123, $mock->foo(456, 789))]]></code>
+      <code><![CDATA[self::assertSame(123, $stub->allows())]]></code>
+      <code><![CDATA[self::assertSame(123, $stub->allows())]]></code>
+      <code><![CDATA[self::assertSame(123, $stub->expects())]]></code>
+      <code><![CDATA[self::assertSame(123, $stub->expects())]]></code>
+      <code><![CDATA[self::assertSame(456, $stub->foo(123))]]></code>
+      <code><![CDATA[self::assertSame(456, $stub->foo(123))]]></code>
     </MissingThrowsDocblock>
     <MixedMethodCall>
       <code><![CDATA[andReturn]]></code>
@@ -1987,8 +2516,8 @@
       <code><![CDATA[function ($number) {]]></code>
     </MissingClosureReturnType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals(124, $spy(123))]]></code>
-      <code><![CDATA[self::assertEquals(124, $spy(123))]]></code>
+      <code><![CDATA[self::assertSame(124, $spy(123))]]></code>
+      <code><![CDATA[self::assertSame(124, $spy(123))]]></code>
     </MissingThrowsDocblock>
     <MixedMethodCall>
       <code><![CDATA[twice]]></code>
@@ -2013,6 +2542,10 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/DefaultMatchersTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[public function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$mock]]></code>
     </MissingPropertyType>
@@ -2044,46 +2577,53 @@
       <code><![CDATA['overload:mock1']]></code>
       <code><![CDATA['overload:mock2']]></code>
     </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[assertSame]]></code>
+    </DocblockTypeContradiction>
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[public function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals($bar, $a->foo()->bar())]]></code>
-      <code><![CDATA[self::assertEquals($bar, $a->foo()->bar())]]></code>
-      <code><![CDATA[self::assertEquals($qux, $a->foo()->qux())]]></code>
-      <code><![CDATA[self::assertEquals($qux, $a->foo()->qux())]]></code>
-      <code><![CDATA[self::assertEquals('first', $this->mock->levelOne() ->levelTwo() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('first', $this->mock->levelOne() ->levelTwo() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('second', $this->mock->levelOne() ->levelTwo() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('second', $this->mock->levelOne() ->levelTwo() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement() ->getFirst('parameter'))]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement() ->getFirst('parameter'))]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement()->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('something', $this->mock->getElement()->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond('secondParameter'))]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond('secondParameter'))]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement()->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getElement()->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getOtherElement() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('somethingElse', $this->mock->getOtherElement() ->getSecond())]]></code>
-      <code><![CDATA[self::assertEquals('somethingNew', $this->mock->getElement() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals('somethingNew', $this->mock->getElement() ->getFirst())]]></code>
-      <code><![CDATA[self::assertEquals(1, mock1::select()->some()->data())]]></code>
-      <code><![CDATA[self::assertEquals(1, mock1::select()->some()->data())]]></code>
-      <code><![CDATA[self::assertEquals(2, mock1::select()->some()->other()->data())]]></code>
-      <code><![CDATA[self::assertEquals(2, mock1::select()->some()->other()->data())]]></code>
-      <code><![CDATA[self::assertEquals(3, mock2::select()->some()->data())]]></code>
-      <code><![CDATA[self::assertEquals(3, mock2::select()->some()->data())]]></code>
-      <code><![CDATA[self::assertEquals(4, mock2::select()->some()->other()->data())]]></code>
-      <code><![CDATA[self::assertEquals(4, mock2::select()->some()->other()->data())]]></code>
       <code><![CDATA[self::assertInstanceOf(stdClass::class, $result)]]></code>
       <code><![CDATA[self::assertInstanceOf(stdClass::class, $result)]]></code>
       <code><![CDATA[self::assertInstanceOf(stdClass::class, $result)]]></code>
+      <code><![CDATA[self::assertSame($bar, $a->foo()->bar())]]></code>
+      <code><![CDATA[self::assertSame($bar, $a->foo()->bar())]]></code>
+      <code><![CDATA[self::assertSame($qux, $a->foo()->qux())]]></code>
+      <code><![CDATA[self::assertSame($qux, $a->foo()->qux())]]></code>
+      <code><![CDATA[self::assertSame('first', $this->mock->levelOne() ->levelTwo() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('first', $this->mock->levelOne() ->levelTwo() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('second', $this->mock->levelOne() ->levelTwo() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('second', $this->mock->levelOne() ->levelTwo() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement() ->getFirst('parameter'))]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement() ->getFirst('parameter'))]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement()->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('something', $this->mock->getElement()->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement() ->getSecond('secondParameter'))]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement() ->getSecond('secondParameter'))]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement()->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getElement()->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getOtherElement() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('somethingElse', $this->mock->getOtherElement() ->getSecond())]]></code>
+      <code><![CDATA[self::assertSame('somethingNew', $this->mock->getElement() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame('somethingNew', $this->mock->getElement() ->getFirst())]]></code>
+      <code><![CDATA[self::assertSame(1, mock1::select()->some()->data())]]></code>
+      <code><![CDATA[self::assertSame(1, mock1::select()->some()->data())]]></code>
+      <code><![CDATA[self::assertSame(2, mock1::select()->some()->other()->data())]]></code>
+      <code><![CDATA[self::assertSame(2, mock1::select()->some()->other()->data())]]></code>
+      <code><![CDATA[self::assertSame(3, mock2::select()->some()->data())]]></code>
+      <code><![CDATA[self::assertSame(3, mock2::select()->some()->data())]]></code>
+      <code><![CDATA[self::assertSame(4, mock2::select()->some()->other()->data())]]></code>
+      <code><![CDATA[self::assertSame(4, mock2::select()->some()->other()->data())]]></code>
     </MissingThrowsDocblock>
     <MixedMethodCall>
       <code><![CDATA[andReturn]]></code>
@@ -2207,6 +2747,27 @@
     <DocblockTypeContradiction>
       <code><![CDATA[assertSame]]></code>
       <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
     </DocblockTypeContradiction>
     <MissingClosureParamType>
       <code><![CDATA[$arg]]></code>
@@ -2239,6 +2800,10 @@
       <code><![CDATA[function ($odd, $even, $sum = null) {]]></code>
       <code><![CDATA[function ($v) {]]></code>
     </MissingClosureReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[public function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$mock]]></code>
     </MissingPropertyType>
@@ -2247,154 +2812,6 @@
       <code><![CDATA[mock]]></code>
       <code><![CDATA[self::assertEmpty($this->mock->bar)]]></code>
       <code><![CDATA[self::assertEmpty($this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals(
-            "[foo(['Spam' => 'Ham', 'Bar' => 'Baz', 0 => 'Bar', 1 => 'Baz', 2 => 'Bar', 3 => 'Baz', 4 => 'Bar', 5 => 'Baz', 6 => 'Bar', 7 => 'Baz', 8 => 'Bar', 9 => 'Baz', 10 => 'Bar', 11 => 'Baz', 12 => 'Bar', 13 => 'Baz', 14 => 'Bar', 15 => 'Baz', 16 => 'Bar', 17 => 'Baz', 18 => 'Bar', 19 => 'Baz', 20 => 'Bar', 21 => 'Baz', 22 => 'Bar', 23 => 'Baz', 24 => 'Bar', 25 => 'Baz', 26 => 'Bar', 27 => 'Baz', 28 => 'Bar', 29 => 'Baz', 30 => 'Bar', 31 => 'Baz', 32 => 'Bar', 33 => 'Baz', 34 => 'Bar', 35 => 'Baz', 36 => 'Bar', 37 => 'Baz', 38 => 'Bar', 39 => 'Baz', 40 => 'Bar', 41 => 'Baz', 42 => 'Bar', 43 => 'Baz', 44 => 'Bar', 45 => 'Baz', 46 => 'Baz', 47 => 'Bar', 48 => 'Baz', 49 => 'Bar', 50 => 'Baz', 51 => 'Bar', 52 => 'Baz', 53 => 'Bar', 54 => 'Baz', 55 => 'Bar', 56 => 'Baz', 57 => 'Baz', 58 => 'Bar', 59 => 'Baz', 60 => 'Bar', 61 => 'Baz', 62 => 'Bar', 63 => 'Baz', 64 => 'Bar', 65 => 'Baz', 66 => 'Bar', 67 => 'Baz', 68 => 'Baz', 69 => 'Bar', 70 => 'Baz', 71 => 'Bar', 72 => 'Baz', 73 => 'Bar', 74 => 'Baz', 7...])]",
-            (string) $exp
-        )]]></code>
-      <code><![CDATA[self::assertEquals(
-            "[foo(['Spam' => 'Ham', 'Bar' => 'Baz', 0 => 'Bar', 1 => 'Baz', 2 => 'Bar', 3 => 'Baz', 4 => 'Bar', 5 => 'Baz', 6 => 'Bar', 7 => 'Baz', 8 => 'Bar', 9 => 'Baz', 10 => 'Bar', 11 => 'Baz', 12 => 'Bar', 13 => 'Baz', 14 => 'Bar', 15 => 'Baz', 16 => 'Bar', 17 => 'Baz', 18 => 'Bar', 19 => 'Baz', 20 => 'Bar', 21 => 'Baz', 22 => 'Bar', 23 => 'Baz', 24 => 'Bar', 25 => 'Baz', 26 => 'Bar', 27 => 'Baz', 28 => 'Bar', 29 => 'Baz', 30 => 'Bar', 31 => 'Baz', 32 => 'Bar', 33 => 'Baz', 34 => 'Bar', 35 => 'Baz', 36 => 'Bar', 37 => 'Baz', 38 => 'Bar', 39 => 'Baz', 40 => 'Bar', 41 => 'Baz', 42 => 'Bar', 43 => 'Baz', 44 => 'Bar', 45 => 'Baz', 46 => 'Baz', 47 => 'Bar', 48 => 'Baz', 49 => 'Bar', 50 => 'Baz', 51 => 'Bar', 52 => 'Baz', 53 => 'Bar', 54 => 'Baz', 55 => 'Bar', 56 => 'Baz', 57 => 'Baz', 58 => 'Bar', 59 => 'Baz', 60 => 'Bar', 61 => 'Baz', 62 => 'Bar', 63 => 'Baz', 64 => 'Bar', 65 => 'Baz', 66 => 'Bar', 67 => 'Baz', 68 => 'Baz', 69 => 'Bar', 70 => 'Baz', 71 => 'Bar', 72 => 'Baz', 73 => 'Bar', 74 => 'Baz', 7...])]",
-            (string) $exp
-        )]]></code>
-      <code><![CDATA[self::assertEquals("[foo(1, 'bar', object(stdClass), ['Spam' => 'Ham', 'Bar' => 'Baz'])]", (string) $exp)]]></code>
-      <code><![CDATA[self::assertEquals("[foo(1, 'bar', object(stdClass), ['Spam' => 'Ham', 'Bar' => 'Baz'])]", (string) $exp)]]></code>
-      <code><![CDATA[self::assertEquals("{$this->mock}", 'dave')]]></code>
-      <code><![CDATA[self::assertEquals("{$this->mock}", 'dave')]]></code>
-      <code><![CDATA[self::assertEquals($args[$index], $this->mock->foo(...$args))]]></code>
-      <code><![CDATA[self::assertEquals($args[$index], $this->mock->foo(...$args))]]></code>
-      <code><![CDATA[self::assertEquals('123', $mock->foo('baz'))]]></code>
-      <code><![CDATA[self::assertEquals('123', $mock->foo('baz'))]]></code>
-      <code><![CDATA[self::assertEquals('123', $mock->foo('baz'))]]></code>
-      <code><![CDATA[self::assertEquals('123', $mock->foo('baz'))]]></code>
-      <code><![CDATA[self::assertEquals('456', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('456', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('[foo(1), bar(1)]', (string) $exp)]]></code>
-      <code><![CDATA[self::assertEquals('[foo(1), bar(1)]', (string) $exp)]]></code>
-      <code><![CDATA[self::assertEquals('a', $this->mock->foo('a'))]]></code>
-      <code><![CDATA[self::assertEquals('a', $this->mock->foo('a'))]]></code>
-      <code><![CDATA[self::assertEquals('b', $this->mock->foo('b'))]]></code>
-      <code><![CDATA[self::assertEquals('b', $this->mock->foo('b'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('baz'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('baz'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('qux'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('qux'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('qux'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('qux'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('qux'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo('qux'))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $this->mock->foo(1))]]></code>
-      <code><![CDATA[self::assertEquals('bar', $this->mock->foo(1))]]></code>
-      <code><![CDATA[self::assertEquals('baz', $mockInstanceOne->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $mockInstanceOne->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('baz', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $mockInstanceTwo->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $mockInstanceTwo->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazzz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazzz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazzz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('bazzz', $this->mock->bar)]]></code>
-      <code><![CDATA[self::assertEquals('blue', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('blue', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('first', $this->mock->foo(1))]]></code>
-      <code><![CDATA[self::assertEquals('first', $this->mock->foo(1))]]></code>
-      <code><![CDATA[self::assertEquals('first', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('first', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('foo', $e->getMessage())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $e->getMessage())]]></code>
-      <code><![CDATA[self::assertEquals('foobar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('foobar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('green', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('green', $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('infinity', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('infinity', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('infinity', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('infinity', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('infinity', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('infinity', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('newbar', $this->mock->foo('test'))]]></code>
-      <code><![CDATA[self::assertEquals('newbar', $this->mock->foo('test'))]]></code>
-      <code><![CDATA[self::assertEquals('rbar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('rbar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('rbaz', $mock->baz())]]></code>
-      <code><![CDATA[self::assertEquals('rbaz', $mock->baz())]]></code>
-      <code><![CDATA[self::assertEquals('second', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('second', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('second/third', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('second/third', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('second/third', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals('second/third', $this->mock->foo(2))]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->a())]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->a())]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(1, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(10, $this->mock->foo(1))]]></code>
-      <code><![CDATA[self::assertEquals(10, $this->mock->foo(1))]]></code>
-      <code><![CDATA[self::assertEquals(2, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(2, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(2, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(2, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(20, $this->mock->bar(2))]]></code>
-      <code><![CDATA[self::assertEquals(20, $this->mock->bar(2))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo('foo'))]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(3, $this->mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals(6, $this->mock->foo(5))]]></code>
-      <code><![CDATA[self::assertEquals(6, $this->mock->foo(5))]]></code>
       <code><![CDATA[self::assertFalse($service->hasBookmarksTagged('php'))]]></code>
       <code><![CDATA[self::assertFalse($service->hasBookmarksTagged('php'))]]></code>
       <code><![CDATA[self::assertFalse($service->hasBookmarksTagged('php'))]]></code>
@@ -2420,9 +2837,9 @@
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $this->mock->shouldIgnoreMissing()->asUndefined())]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $this->mock->shouldIgnoreMissing()->asUndefined())]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $this->mock->shouldIgnoreMissing()->asUndefined())]]></code>
-      <code><![CDATA[self::assertInstanceOf(MockInterface::class, mock('f')->byDefault())]]></code>
-      <code><![CDATA[self::assertInstanceOf(MockInterface::class, mock('f')->byDefault())]]></code>
-      <code><![CDATA[self::assertInstanceOf(MockInterface::class, mock('f')->byDefault())]]></code>
+      <code><![CDATA[self::assertInstanceOf(MockInterface::class, \mock('f')->byDefault())]]></code>
+      <code><![CDATA[self::assertInstanceOf(MockInterface::class, \mock('f')->byDefault())]]></code>
+      <code><![CDATA[self::assertInstanceOf(MockInterface::class, \mock('f')->byDefault())]]></code>
       <code><![CDATA[self::assertInstanceOf(Undefined::class, $this->mock->foo())]]></code>
       <code><![CDATA[self::assertInstanceOf(Undefined::class, $this->mock->foo())]]></code>
       <code><![CDATA[self::assertInstanceOf(Undefined::class, $this->mock->foo())]]></code>
@@ -2474,24 +2891,172 @@
       <code><![CDATA[self::assertNull($this->mock->foo(1))]]></code>
       <code><![CDATA[self::assertNull($this->mock->g(1, 2))]]></code>
       <code><![CDATA[self::assertNull($this->mock->g(1, 2))]]></code>
+      <code><![CDATA[self::assertSame(
+            "[foo(['Spam' => 'Ham', 'Bar' => 'Baz', 0 => 'Bar', 1 => 'Baz', 2 => 'Bar', 3 => 'Baz', 4 => 'Bar', 5 => 'Baz', 6 => 'Bar', 7 => 'Baz', 8 => 'Bar', 9 => 'Baz', 10 => 'Bar', 11 => 'Baz', 12 => 'Bar', 13 => 'Baz', 14 => 'Bar', 15 => 'Baz', 16 => 'Bar', 17 => 'Baz', 18 => 'Bar', 19 => 'Baz', 20 => 'Bar', 21 => 'Baz', 22 => 'Bar', 23 => 'Baz', 24 => 'Bar', 25 => 'Baz', 26 => 'Bar', 27 => 'Baz', 28 => 'Bar', 29 => 'Baz', 30 => 'Bar', 31 => 'Baz', 32 => 'Bar', 33 => 'Baz', 34 => 'Bar', 35 => 'Baz', 36 => 'Bar', 37 => 'Baz', 38 => 'Bar', 39 => 'Baz', 40 => 'Bar', 41 => 'Baz', 42 => 'Bar', 43 => 'Baz', 44 => 'Bar', 45 => 'Baz', 46 => 'Baz', 47 => 'Bar', 48 => 'Baz', 49 => 'Bar', 50 => 'Baz', 51 => 'Bar', 52 => 'Baz', 53 => 'Bar', 54 => 'Baz', 55 => 'Bar', 56 => 'Baz', 57 => 'Baz', 58 => 'Bar', 59 => 'Baz', 60 => 'Bar', 61 => 'Baz', 62 => 'Bar', 63 => 'Baz', 64 => 'Bar', 65 => 'Baz', 66 => 'Bar', 67 => 'Baz', 68 => 'Baz', 69 => 'Bar', 70 => 'Baz', 71 => 'Bar', 72 => 'Baz', 73 => 'Bar', 74 => 'Baz', 7...])]",
+            (string) $exp
+        )]]></code>
+      <code><![CDATA[self::assertSame(
+            "[foo(['Spam' => 'Ham', 'Bar' => 'Baz', 0 => 'Bar', 1 => 'Baz', 2 => 'Bar', 3 => 'Baz', 4 => 'Bar', 5 => 'Baz', 6 => 'Bar', 7 => 'Baz', 8 => 'Bar', 9 => 'Baz', 10 => 'Bar', 11 => 'Baz', 12 => 'Bar', 13 => 'Baz', 14 => 'Bar', 15 => 'Baz', 16 => 'Bar', 17 => 'Baz', 18 => 'Bar', 19 => 'Baz', 20 => 'Bar', 21 => 'Baz', 22 => 'Bar', 23 => 'Baz', 24 => 'Bar', 25 => 'Baz', 26 => 'Bar', 27 => 'Baz', 28 => 'Bar', 29 => 'Baz', 30 => 'Bar', 31 => 'Baz', 32 => 'Bar', 33 => 'Baz', 34 => 'Bar', 35 => 'Baz', 36 => 'Bar', 37 => 'Baz', 38 => 'Bar', 39 => 'Baz', 40 => 'Bar', 41 => 'Baz', 42 => 'Bar', 43 => 'Baz', 44 => 'Bar', 45 => 'Baz', 46 => 'Baz', 47 => 'Bar', 48 => 'Baz', 49 => 'Bar', 50 => 'Baz', 51 => 'Bar', 52 => 'Baz', 53 => 'Bar', 54 => 'Baz', 55 => 'Bar', 56 => 'Baz', 57 => 'Baz', 58 => 'Bar', 59 => 'Baz', 60 => 'Bar', 61 => 'Baz', 62 => 'Bar', 63 => 'Baz', 64 => 'Bar', 65 => 'Baz', 66 => 'Bar', 67 => 'Baz', 68 => 'Baz', 69 => 'Bar', 70 => 'Baz', 71 => 'Bar', 72 => 'Baz', 73 => 'Bar', 74 => 'Baz', 7...])]",
+            (string) $exp
+        )]]></code>
+      <code><![CDATA[self::assertSame("[foo(1, 'bar', object(stdClass), ['Spam' => 'Ham', 'Bar' => 'Baz'])]", (string) $exp)]]></code>
+      <code><![CDATA[self::assertSame("[foo(1, 'bar', object(stdClass), ['Spam' => 'Ham', 'Bar' => 'Baz'])]", (string) $exp)]]></code>
+      <code><![CDATA[self::assertSame("{$this->mock}", 'dave')]]></code>
+      <code><![CDATA[self::assertSame("{$this->mock}", 'dave')]]></code>
+      <code><![CDATA[self::assertSame($args[$index], $this->mock->foo(...$args))]]></code>
+      <code><![CDATA[self::assertSame($args[$index], $this->mock->foo(...$args))]]></code>
       <code><![CDATA[self::assertSame($object, $temp)]]></code>
       <code><![CDATA[self::assertSame($object, $temp)]]></code>
       <code><![CDATA[self::assertSame($this->mock, $this->mock->a()->b())]]></code>
       <code><![CDATA[self::assertSame($this->mock, $this->mock->a()->b())]]></code>
       <code><![CDATA[self::assertSame($this->mock, $this->mock->foo())]]></code>
       <code><![CDATA[self::assertSame($this->mock, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('123', $mock->foo('baz'))]]></code>
+      <code><![CDATA[self::assertSame('123', $mock->foo('baz'))]]></code>
+      <code><![CDATA[self::assertSame('123', $mock->foo('baz'))]]></code>
+      <code><![CDATA[self::assertSame('123', $mock->foo('baz'))]]></code>
+      <code><![CDATA[self::assertSame('456', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('456', $mock->foo())]]></code>
       <code><![CDATA[self::assertSame('Spam!', $demeter->doit())]]></code>
       <code><![CDATA[self::assertSame('Spam!', $demeter->doit())]]></code>
       <code><![CDATA[self::assertSame('Spam!', $demeter->doitWithArgs())]]></code>
       <code><![CDATA[self::assertSame('Spam!', $demeter->doitWithArgs())]]></code>
+      <code><![CDATA[self::assertSame('[foo(1), bar(1)]', (string) $exp)]]></code>
+      <code><![CDATA[self::assertSame('[foo(1), bar(1)]', (string) $exp)]]></code>
+      <code><![CDATA[self::assertSame('a', $this->mock->foo('a'))]]></code>
+      <code><![CDATA[self::assertSame('a', $this->mock->foo('a'))]]></code>
+      <code><![CDATA[self::assertSame('b', $this->mock->foo('b'))]]></code>
+      <code><![CDATA[self::assertSame('b', $this->mock->foo('b'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('baz'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('baz'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('qux'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('qux'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('qux'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('qux'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('qux'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo('qux'))]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $this->mock->foo(1))]]></code>
+      <code><![CDATA[self::assertSame('bar', $this->mock->foo(1))]]></code>
+      <code><![CDATA[self::assertSame('baz', $mockInstanceOne->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $mockInstanceOne->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('baz', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('bazz', $mockInstanceTwo->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $mockInstanceTwo->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazzz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazzz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazzz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('bazzz', $this->mock->bar)]]></code>
+      <code><![CDATA[self::assertSame('blue', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('blue', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('first', $this->mock->foo(1))]]></code>
+      <code><![CDATA[self::assertSame('first', $this->mock->foo(1))]]></code>
+      <code><![CDATA[self::assertSame('first', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('first', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('foo', $e->getMessage())]]></code>
+      <code><![CDATA[self::assertSame('foo', $e->getMessage())]]></code>
       <code><![CDATA[self::assertSame('foobar', $foo->foo($input))]]></code>
       <code><![CDATA[self::assertSame('foobar', $foo->foo($input))]]></code>
+      <code><![CDATA[self::assertSame('foobar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('foobar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('green', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('green', $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('infinity', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('infinity', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('infinity', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('infinity', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('infinity', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('infinity', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('newbar', $this->mock->foo('test'))]]></code>
+      <code><![CDATA[self::assertSame('newbar', $this->mock->foo('test'))]]></code>
+      <code><![CDATA[self::assertSame('rbar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('rbar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('rbaz', $mock->baz())]]></code>
+      <code><![CDATA[self::assertSame('rbaz', $mock->baz())]]></code>
+      <code><![CDATA[self::assertSame('second', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('second', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('second/third', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('second/third', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('second/third', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame('second/third', $this->mock->foo(2))]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->a())]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->a())]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(1, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(10, $this->mock->foo(1))]]></code>
+      <code><![CDATA[self::assertSame(10, $this->mock->foo(1))]]></code>
+      <code><![CDATA[self::assertSame(2, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(2, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(2, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(2, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(20, $this->mock->bar(2))]]></code>
+      <code><![CDATA[self::assertSame(20, $this->mock->bar(2))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo('foo'))]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(3, $this->mock->foo())]]></code>
       <code><![CDATA[self::assertSame(4, $temp)]]></code>
       <code><![CDATA[self::assertSame(4, $temp)]]></code>
       <code><![CDATA[self::assertSame(42, $mock->theAnswer())]]></code>
       <code><![CDATA[self::assertSame(42, $mock->theAnswer())]]></code>
-      <code><![CDATA[self::assertSame([1, 2, 3], iterator_to_array($this->mock->foo()))]]></code>
-      <code><![CDATA[self::assertSame([1, 2, 3], iterator_to_array($this->mock->foo()))]]></code>
+      <code><![CDATA[self::assertSame(6, $this->mock->foo(5))]]></code>
+      <code><![CDATA[self::assertSame(6, $this->mock->foo(5))]]></code>
+      <code><![CDATA[self::assertSame([1, 2, 3], \iterator_to_array($this->mock->foo()))]]></code>
+      <code><![CDATA[self::assertSame([1, 2, 3], \iterator_to_array($this->mock->foo()))]]></code>
       <code><![CDATA[self::assertTrue($mock->doFirst())]]></code>
       <code><![CDATA[self::assertTrue($mock->doFirst())]]></code>
       <code><![CDATA[self::assertTrue($service->addBookmark('http://example.com/1', 'some_tag1'))]]></code>
@@ -3769,6 +4334,14 @@
       <code><![CDATA[$this->mock->bar]]></code>
       <code><![CDATA[$this->mock->bar]]></code>
     </MixedPropertyFetch>
+    <NoValue>
+      <code><![CDATA[$this->mock->bar]]></code>
+      <code><![CDATA[$this->mock->bar]]></code>
+    </NoValue>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[assertSame]]></code>
+      <code><![CDATA[assertSame]]></code>
+    </RedundantConditionGivenDocblockType>
     <TooManyArguments>
       <code><![CDATA[expectException]]></code>
       <code><![CDATA[expectException]]></code>
@@ -3809,8 +4382,8 @@
             'bar' => 'rbar',
             'baz' => 'rbaz',
         ]]]></code>
-      <code><![CDATA[mock('f')]]></code>
-      <code><![CDATA[mock('f')]]></code>
+      <code><![CDATA[\mock('f')]]></code>
+      <code><![CDATA[\mock('f')]]></code>
     </UndefinedClass>
     <UndefinedInterfaceMethod>
       <code><![CDATA[addBookmark]]></code>
@@ -3890,10 +4463,10 @@
       <code><![CDATA[self::assertCount(1, $methods)]]></code>
       <code><![CDATA[self::assertCount(1, $methods)]]></code>
       <code><![CDATA[self::assertCount(1, $methods)]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
       <code><![CDATA[self::markTestSkipped('Need a builtin class with a method that is a reserved word')]]></code>
       <code><![CDATA[self::markTestSkipped('Need a builtin class with a method that is a reserved word')]]></code>
     </MissingThrowsDocblock>
@@ -3915,10 +4488,10 @@
         ]]]></code>
     </InvalidArgument>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, '__call($method, $args)'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, '__call($method, $args)'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, '__callStatic($method, $args)'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, '__callStatic($method, $args)'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, '__call($method, $args)'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, '__call($method, $args)'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, '__callStatic($method, $args)'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, '__callStatic($method, $args)'))]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
       <code><![CDATA[$config]]></code>
@@ -3937,6 +4510,9 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php">
+    <MissingClassConstType>
+      <code><![CDATA[CODE = 'namespace Mockery; class Mock {}']]></code>
+    </MissingClassConstType>
     <MissingThrowsDocblock>
       <code><![CDATA[self::assertStringContainsString($expected, $code)]]></code>
       <code><![CDATA[self::assertStringContainsString($expected, $code)]]></code>
@@ -3956,20 +4532,23 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$pass]]></code>
     </MissingPropertyType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertFalse(mb_strpos($code, 'namespace Mockery;'))]]></code>
-      <code><![CDATA[self::assertFalse(mb_strpos($code, 'namespace Mockery;'))]]></code>
-      <code><![CDATA[self::assertFalse(mb_strpos($code, 'namespace Mockery;'))]]></code>
-      <code><![CDATA[self::assertFalse(mb_strpos($code, 'namespace Mockery;'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'class Dave'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'class Dave'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'namespace Dave;'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'namespace Dave;'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'namespace Dave;'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'namespace Dave;'))]]></code>
+      <code><![CDATA[self::assertFalse(\mb_strpos($code, 'namespace Mockery;'))]]></code>
+      <code><![CDATA[self::assertFalse(\mb_strpos($code, 'namespace Mockery;'))]]></code>
+      <code><![CDATA[self::assertFalse(\mb_strpos($code, 'namespace Mockery;'))]]></code>
+      <code><![CDATA[self::assertFalse(\mb_strpos($code, 'namespace Mockery;'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'class Dave'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'class Dave'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'namespace Dave;'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'namespace Dave;'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'namespace Dave;'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'namespace Dave;'))]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
       <code><![CDATA[$code]]></code>
@@ -3998,12 +4577,15 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[['Testing\TestClass']]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$pass]]></code>
     </MissingPropertyType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface'))]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
       <code><![CDATA[$code]]></code>
@@ -4023,8 +4605,8 @@
   </file>
   <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/ConstantsPassTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, "const FOO = 'test'"))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, "const FOO = 'test'"))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, "const FOO = 'test'"))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, "const FOO = 'test'"))]]></code>
     </MissingThrowsDocblock>
     <UnusedClass>
       <code><![CDATA[ConstantsPassTest]]></code>
@@ -4032,12 +4614,12 @@
   </file>
   <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'protected $_mockery_ignoreVerification'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'protected $_mockery_ignoreVerification'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'public function __construct'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'public function __construct'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'protected $_mockery_ignoreVerification'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'protected $_mockery_ignoreVerification'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'public function __construct'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'public function __construct'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());'))]]></code>
     </MissingThrowsDocblock>
     <UnusedClass>
       <code><![CDATA[InstanceMockPassTest]]></code>
@@ -4066,10 +4648,10 @@
         ]]]></code>
     </InvalidArgument>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals(self::CODE, $code)]]></code>
-      <code><![CDATA[self::assertEquals(self::CODE, $code)]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'implements MockInterface, \Dave\Dave, \Paddy\Paddy'))]]></code>
-      <code><![CDATA[self::assertNotFalse(mb_strpos($code, 'implements MockInterface, \Dave\Dave, \Paddy\Paddy'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'implements MockInterface, \Dave\Dave, \Paddy\Paddy'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($code, 'implements MockInterface, \Dave\Dave, \Paddy\Paddy'))]]></code>
+      <code><![CDATA[self::assertSame(self::CODE, $code)]]></code>
+      <code><![CDATA[self::assertSame(self::CODE, $code)]]></code>
     </MissingThrowsDocblock>
     <UnusedClass>
       <code><![CDATA[InterfacePassTest]]></code>
@@ -4104,6 +4686,10 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/HamcrestExpectationTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[public function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$mock]]></code>
     </MissingPropertyType>
@@ -4125,6 +4711,9 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Loader/EvalLoaderTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getLoader(): Loader]]></code>
+    </MissingOverrideAttribute>
     <UnusedClass>
       <code><![CDATA[EvalLoaderTest]]></code>
     </UnusedClass>
@@ -4132,14 +4721,17 @@
   <file src="tests/Unit/Mockery/Loader/LoaderTestCase.php">
     <MissingThrowsDocblock>
       <code><![CDATA[new MockDefinition($config, $code)]]></code>
-      <code><![CDATA[self::assertTrue(class_exists($className))]]></code>
-      <code><![CDATA[self::assertTrue(class_exists($className))]]></code>
+      <code><![CDATA[self::assertTrue(\class_exists($className))]]></code>
+      <code><![CDATA[self::assertTrue(\class_exists($className))]]></code>
     </MissingThrowsDocblock>
     <PossiblyUnusedMethod>
       <code><![CDATA[testLoad]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/Unit/Mockery/Loader/RequireLoaderTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getLoader(): Loader]]></code>
+    </MissingOverrideAttribute>
     <UnusedClass>
       <code><![CDATA[RequireLoaderTest]]></code>
     </UnusedClass>
@@ -4214,14 +4806,14 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockClassWithFinalToStringTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[protected function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$container]]></code>
     </MissingPropertyType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
-      <code><![CDATA[self::assertEquals(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
-      <code><![CDATA[self::assertEquals(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
-      <code><![CDATA[self::assertEquals(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
       <code><![CDATA[self::assertInstanceOf(TestWithFinalToString::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(TestWithFinalToString::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(TestWithFinalToString::class, $mock)]]></code>
@@ -4231,8 +4823,12 @@
       <code><![CDATA[self::assertInstanceOf(TestWithNonFinalToString::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(TestWithNonFinalToString::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(TestWithNonFinalToString::class, $mock)]]></code>
-      <code><![CDATA[self::assertNotEquals('bar', $mock->__toString())]]></code>
-      <code><![CDATA[self::assertNotEquals('bar', $mock->__toString())]]></code>
+      <code><![CDATA[self::assertNotSame('bar', $mock->__toString())]]></code>
+      <code><![CDATA[self::assertNotSame('bar', $mock->__toString())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalToString::class . '::__toString', $mock->__toString())]]></code>
     </MissingThrowsDocblock>
     <MixedAssignment>
       <code><![CDATA[$mock]]></code>
@@ -4333,32 +4929,32 @@
       <code><![CDATA[self::assertCount(2, $methods)]]></code>
       <code><![CDATA[self::assertCount(2, $methods)]]></code>
       <code><![CDATA[self::assertCount(2, $methods)]]></code>
-      <code><![CDATA[self::assertEquals('bar', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $methods[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(Iterator::class, $interfaces[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(Iterator::class, $interfaces[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(IteratorAggregate::class, $first->getName())]]></code>
-      <code><![CDATA[self::assertEquals(IteratorAggregate::class, $first->getName())]]></code>
-      <code><![CDATA[self::assertEquals(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(TestTraversableInterface2::class, $interfaces[1]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(TestTraversableInterface2::class, $interfaces[1]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(TestTraversableInterface3::class, $interfaces[1]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(TestTraversableInterface3::class, $interfaces[1]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(TestTraversableInterface::class, $interfaces[1]->getName())]]></code>
-      <code><![CDATA[self::assertEquals(TestTraversableInterface::class, $interfaces[1]->getName())]]></code>
+      <code><![CDATA[self::assertSame('bar', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('bar', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('bar', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('bar', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('bar', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('bar', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame('foo', $methods[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(Iterator::class, $interfaces[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(Iterator::class, $interfaces[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(IteratorAggregate::class, $first->getName())]]></code>
+      <code><![CDATA[self::assertSame(IteratorAggregate::class, $first->getName())]]></code>
+      <code><![CDATA[self::assertSame(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(IteratorAggregate::class, $interfaces[0]->getName())]]></code>
+      <code><![CDATA[self::assertSame(TestTraversableInterface2::class, $interfaces[1]->getName())]]></code>
+      <code><![CDATA[self::assertSame(TestTraversableInterface2::class, $interfaces[1]->getName())]]></code>
+      <code><![CDATA[self::assertSame(TestTraversableInterface3::class, $interfaces[1]->getName())]]></code>
+      <code><![CDATA[self::assertSame(TestTraversableInterface3::class, $interfaces[1]->getName())]]></code>
+      <code><![CDATA[self::assertSame(TestTraversableInterface::class, $interfaces[1]->getName())]]></code>
+      <code><![CDATA[self::assertSame(TestTraversableInterface::class, $interfaces[1]->getName())]]></code>
     </MissingThrowsDocblock>
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$interfaces[0]]]></code>
@@ -4392,14 +4988,6 @@
       <code><![CDATA[foo]]></code>
     </InaccessibleMethod>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('foo', (string) $mock)]]></code>
-      <code><![CDATA[self::assertEquals('foo', (string) $mock)]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock->mockery_getExpectationCount())]]></code>
       <code><![CDATA[self::assertInstanceOf(ErrorException::class, $errorException)]]></code>
       <code><![CDATA[self::assertInstanceOf(ErrorException::class, $errorException)]]></code>
       <code><![CDATA[self::assertInstanceOf(ErrorException::class, $errorException)]]></code>
@@ -4415,10 +5003,10 @@
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $m->shouldAllowMockingProtectedMethods('testFunction'))]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $m->shouldAllowMockingProtectedMethods('testFunction'))]]></code>
       <code><![CDATA[self::assertInstanceOf(MockInterface::class, $m->shouldAllowMockingProtectedMethods('testFunction'))]]></code>
-      <code><![CDATA[self::assertNotEquals('', (string) $mock)]]></code>
-      <code><![CDATA[self::assertNotEquals('', (string) $mock)]]></code>
-      <code><![CDATA[self::assertNotEquals('', (string) $mock)]]></code>
-      <code><![CDATA[self::assertNotEquals('', (string) $mock)]]></code>
+      <code><![CDATA[self::assertNotSame('', (string) $mock)]]></code>
+      <code><![CDATA[self::assertNotSame('', (string) $mock)]]></code>
+      <code><![CDATA[self::assertNotSame('', (string) $mock)]]></code>
+      <code><![CDATA[self::assertNotSame('', (string) $mock)]]></code>
       <code><![CDATA[self::assertNull($mock->bar())]]></code>
       <code><![CDATA[self::assertNull($mock->bar())]]></code>
       <code><![CDATA[self::assertNull($mock->foo())]]></code>
@@ -4433,18 +5021,26 @@
       <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
       <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
       <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('foo', (string) $mock)]]></code>
+      <code><![CDATA[self::assertSame('foo', (string) $mock)]]></code>
       <code><![CDATA[self::assertSame('new_foo', $mock->foo())]]></code>
       <code><![CDATA[self::assertSame('new_foo', $mock->foo())]]></code>
       <code><![CDATA[self::assertSame('result', $mock->nonExistentMethod())]]></code>
       <code><![CDATA[self::assertSame('result', $mock->nonExistentMethod())]]></code>
+      <code><![CDATA[self::assertSame(2, $mock->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(2, $mock->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(2, $mock->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(2, $mock->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(2, $mock->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(2, $mock->mockery_getExpectationCount())]]></code>
       <code><![CDATA[self::assertTrue($m->foo())]]></code>
       <code><![CDATA[self::assertTrue($m->foo())]]></code>
       <code><![CDATA[self::assertTrue($m->test123())]]></code>
       <code><![CDATA[self::assertTrue($m->test123())]]></code>
       <code><![CDATA[self::assertTrue($m->testSomeNonExistentMethod())]]></code>
       <code><![CDATA[self::assertTrue($m->testSomeNonExistentMethod())]]></code>
-      <code><![CDATA[self::assertTrue(method_exists($mock, '__toString'))]]></code>
-      <code><![CDATA[self::assertTrue(method_exists($mock, '__toString'))]]></code>
+      <code><![CDATA[self::assertTrue(\method_exists($mock, '__toString'))]]></code>
+      <code><![CDATA[self::assertTrue(\method_exists($mock, '__toString'))]]></code>
     </MissingThrowsDocblock>
     <MixedAssignment>
       <code><![CDATA[$mock]]></code>
@@ -4527,10 +5123,10 @@
   </file>
   <file src="tests/Unit/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('foo', $mock->include())]]></code>
-      <code><![CDATA[self::assertEquals('foo', $mock->include())]]></code>
-      <code><![CDATA[self::assertTrue(method_exists($mock, 'include'))]]></code>
-      <code><![CDATA[self::assertTrue(method_exists($mock, 'include'))]]></code>
+      <code><![CDATA[self::assertSame('foo', $mock->include())]]></code>
+      <code><![CDATA[self::assertSame('foo', $mock->include())]]></code>
+      <code><![CDATA[self::assertTrue(\method_exists($mock, 'include'))]]></code>
+      <code><![CDATA[self::assertTrue(\method_exists($mock, 'include'))]]></code>
     </MissingThrowsDocblock>
     <MixedMethodCall>
       <code><![CDATA[andReturn]]></code>
@@ -4576,14 +5172,14 @@
       <code><![CDATA['overload:' . ClassWithConstants::class]]></code>
     </ArgumentTypeCoercion>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('baz', $mock::FOO)]]></code>
-      <code><![CDATA[self::assertEquals('baz', $mock::FOO)]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock::X)]]></code>
-      <code><![CDATA[self::assertEquals(2, $mock::X)]]></code>
-      <code><![CDATA[self::assertEquals([
+      <code><![CDATA[self::assertSame('baz', $mock::FOO)]]></code>
+      <code><![CDATA[self::assertSame('baz', $mock::FOO)]]></code>
+      <code><![CDATA[self::assertSame(2, $mock::X)]]></code>
+      <code><![CDATA[self::assertSame(2, $mock::X)]]></code>
+      <code><![CDATA[self::assertSame([
             'qux' => 'daz',
         ], $mock::BAZ)]]></code>
-      <code><![CDATA[self::assertEquals([
+      <code><![CDATA[self::assertSame([
             'qux' => 'daz',
         ], $mock::BAZ)]]></code>
     </MissingThrowsDocblock>
@@ -4700,20 +5296,20 @@
   </file>
   <file src="tests/Unit/Mockery/MockingProtectedMethodsTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('abstractProtected', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('abstractProtected', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('foobar', $mock->foobar())]]></code>
-      <code><![CDATA[self::assertEquals('foobar', $mock->foobar())]]></code>
-      <code><![CDATA[self::assertEquals('notbar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('notbar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('notbar', $mock->bar())]]></code>
-      <code><![CDATA[self::assertEquals('notbar', $mock->bar())]]></code>
       <code><![CDATA[self::assertNull($mock->foo())]]></code>
       <code><![CDATA[self::assertNull($mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('abstractProtected', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('abstractProtected', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('bar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('foobar', $mock->foobar())]]></code>
+      <code><![CDATA[self::assertSame('foobar', $mock->foobar())]]></code>
+      <code><![CDATA[self::assertSame('notbar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('notbar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('notbar', $mock->bar())]]></code>
+      <code><![CDATA[self::assertSame('notbar', $mock->bar())]]></code>
     </MissingThrowsDocblock>
     <MixedAssignment>
       <code><![CDATA[$mock]]></code>
@@ -4740,7 +5336,7 @@
     </MixedMethodCall>
     <UndefinedClass>
       <code><![CDATA[$mock]]></code>
-      <code><![CDATA[mock(TestWithProtectedMethods::class . '[protectedBar]')]]></code>
+      <code><![CDATA[\mock(TestWithProtectedMethods::class . '[protectedBar]')]]></code>
     </UndefinedClass>
     <UndefinedMethod>
       <code><![CDATA[makePartial]]></code>
@@ -4782,8 +5378,8 @@
   </file>
   <file src="tests/Unit/Mockery/MockingVariadicArgumentsTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('notbar', $mock->foo())]]></code>
-      <code><![CDATA[self::assertEquals('notbar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('notbar', $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame('notbar', $mock->foo())]]></code>
     </MissingThrowsDocblock>
     <MixedMethodCall>
       <code><![CDATA[andReturn]]></code>
@@ -4800,8 +5396,6 @@
       <code><![CDATA['\Mockery\Dave123']]></code>
     </ArgumentTypeCoercion>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('dave', $mock->getDave())]]></code>
-      <code><![CDATA[self::assertEquals('dave', $mock->getDave())]]></code>
       <code><![CDATA[self::assertInstanceOf('\Mockery\Dave123', $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf('\Mockery\Dave123', $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf('\Mockery\Dave123', $mock)]]></code>
@@ -4811,6 +5405,8 @@
       <code><![CDATA[self::assertInstanceOf(Habitat::class, $animal->habitat())]]></code>
       <code><![CDATA[self::assertInstanceOf(Habitat::class, $animal->habitat())]]></code>
       <code><![CDATA[self::assertInstanceOf(Habitat::class, $animal->habitat())]]></code>
+      <code><![CDATA[self::assertSame('dave', $mock->getDave())]]></code>
+      <code><![CDATA[self::assertSame('dave', $mock->getDave())]]></code>
       <code><![CDATA[self::assertTrue($gardener->water($cactus))]]></code>
       <code><![CDATA[self::assertTrue($gardener->water($cactus))]]></code>
     </MissingThrowsDocblock>
@@ -4878,10 +5474,10 @@
   </file>
   <file src="tests/Unit/Mockery/SpyTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals(1, $spy->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(1, $spy->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(1, $spy->mockery_getExpectationCount())]]></code>
-      <code><![CDATA[self::assertEquals(1, $spy->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(1, $spy->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(1, $spy->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(1, $spy->mockery_getExpectationCount())]]></code>
+      <code><![CDATA[self::assertSame(1, $spy->mockery_getExpectationCount())]]></code>
     </MissingThrowsDocblock>
     <TooFewArguments>
       <code><![CDATA[shouldHaveReceived]]></code>
@@ -4931,14 +5527,14 @@
   </file>
   <file src="tests/Unit/Mockery/TraitsTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals('bar', $trait->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $trait->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $trait->foo())]]></code>
-      <code><![CDATA[self::assertEquals('bar', $trait->foo())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $trait->baz())]]></code>
-      <code><![CDATA[self::assertEquals('baz', $trait->baz())]]></code>
-      <code><![CDATA[self::assertEquals(123, $trait->baz())]]></code>
-      <code><![CDATA[self::assertEquals(123, $trait->baz())]]></code>
+      <code><![CDATA[self::assertSame('bar', $trait->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $trait->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $trait->foo())]]></code>
+      <code><![CDATA[self::assertSame('bar', $trait->foo())]]></code>
+      <code><![CDATA[self::assertSame('baz', $trait->baz())]]></code>
+      <code><![CDATA[self::assertSame('baz', $trait->baz())]]></code>
+      <code><![CDATA[self::assertSame(123, $trait->baz())]]></code>
+      <code><![CDATA[self::assertSame(123, $trait->baz())]]></code>
     </MissingThrowsDocblock>
     <UndefinedClass>
       <code><![CDATA[$trait]]></code>
@@ -4951,14 +5547,14 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP73/MockClassWithFinalWakeupTest.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function mockeryTestSetUp(): void]]></code>
+      <code><![CDATA[protected function mockeryTestTearDown(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingPropertyType>
       <code><![CDATA[$container]]></code>
     </MissingPropertyType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
-      <code><![CDATA[self::assertEquals(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
-      <code><![CDATA[self::assertEquals(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
-      <code><![CDATA[self::assertEquals(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
       <code><![CDATA[self::assertInstanceOf(SubclassWithFinalWakeup::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(SubclassWithFinalWakeup::class, $mock)]]></code>
       <code><![CDATA[self::assertInstanceOf(SubclassWithFinalWakeup::class, $mock)]]></code>
@@ -4970,6 +5566,10 @@
       <code><![CDATA[self::assertInstanceOf(TestWithNonFinalWakeup::class, $mock)]]></code>
       <code><![CDATA[self::assertNull($mock->__wakeup())]]></code>
       <code><![CDATA[self::assertNull($mock->__wakeup())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
+      <code><![CDATA[self::assertSame(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup())]]></code>
     </MissingThrowsDocblock>
     <MixedAssignment>
       <code><![CDATA[$mock]]></code>
@@ -4999,9 +5599,9 @@
   </file>
   <file src="tests/Unit/PHP73/MockingVoidMethodsTest.php">
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, mock(MethodWithVoidReturnType::class))]]></code>
-      <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, mock(MethodWithVoidReturnType::class))]]></code>
-      <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, mock(MethodWithVoidReturnType::class))]]></code>
+      <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, \mock(MethodWithVoidReturnType::class))]]></code>
+      <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, \mock(MethodWithVoidReturnType::class))]]></code>
+      <code><![CDATA[self::assertInstanceOf(MethodWithVoidReturnType::class, \mock(MethodWithVoidReturnType::class))]]></code>
     </MissingThrowsDocblock>
     <UndefinedMethod>
       <code><![CDATA[expects]]></code>
@@ -5073,6 +5673,9 @@
     <MissingClosureReturnType>
       <code><![CDATA[function ($class, $nesting) {]]></code>
     </MissingClosureReturnType>
+    <MissingOverrideAttribute>
+      <code><![CDATA[protected function setUp(): void]]></code>
+    </MissingOverrideAttribute>
     <MissingParamType>
       <code><![CDATA[$expected]]></code>
       <code><![CDATA[$obj]]></code>
@@ -5081,8 +5684,8 @@
       <code><![CDATA[$shouldNotContains]]></code>
     </MissingParamType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals($expected, $formatted ? $formatted['formatter'] : null)]]></code>
-      <code><![CDATA[self::assertEquals($expected, $formatted ? $formatted['formatter'] : null)]]></code>
+      <code><![CDATA[self::assertSame($expected, $formatted ? $formatted['formatter'] : null)]]></code>
+      <code><![CDATA[self::assertSame($expected, $formatted ? $formatted['formatter'] : null)]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
       <code><![CDATA[$containString]]></code>
@@ -5121,14 +5724,14 @@
       <code><![CDATA[$expected]]></code>
     </MissingParamType>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals($expected, Mockery::formatObjects($args))]]></code>
-      <code><![CDATA[self::assertEquals($expected, Mockery::formatObjects($args))]]></code>
-      <code><![CDATA[self::assertSame(mb_strpos($string, 'Missing argument 1 for'), false)]]></code>
-      <code><![CDATA[self::assertSame(mb_strpos($string, 'Missing argument 1 for'), false)]]></code>
-      <code><![CDATA[self::assertSame(mb_strpos($string, 'excludedProperty'), false)]]></code>
-      <code><![CDATA[self::assertSame(mb_strpos($string, 'excludedProperty'), false)]]></code>
-      <code><![CDATA[self::assertSame(mb_strpos($string, 'getExcluded'), false)]]></code>
-      <code><![CDATA[self::assertSame(mb_strpos($string, 'getExcluded'), false)]]></code>
+      <code><![CDATA[self::assertSame($expected, Mockery::formatObjects($args))]]></code>
+      <code><![CDATA[self::assertSame($expected, Mockery::formatObjects($args))]]></code>
+      <code><![CDATA[self::assertSame(\mb_strpos($string, 'Missing argument 1 for'), false)]]></code>
+      <code><![CDATA[self::assertSame(\mb_strpos($string, 'Missing argument 1 for'), false)]]></code>
+      <code><![CDATA[self::assertSame(\mb_strpos($string, 'excludedProperty'), false)]]></code>
+      <code><![CDATA[self::assertSame(\mb_strpos($string, 'excludedProperty'), false)]]></code>
+      <code><![CDATA[self::assertSame(\mb_strpos($string, 'getExcluded'), false)]]></code>
+      <code><![CDATA[self::assertSame(\mb_strpos($string, 'getExcluded'), false)]]></code>
     </MissingThrowsDocblock>
     <MixedArgument>
       <code><![CDATA[$args]]></code>
@@ -5163,8 +5766,8 @@
       <code><![CDATA[[1]]]></code>
     </InvalidArgument>
     <MissingThrowsDocblock>
-      <code><![CDATA[self::assertEquals(2, $banana->test())]]></code>
-      <code><![CDATA[self::assertEquals(2, $banana->test())]]></code>
+      <code><![CDATA[self::assertSame(2, $banana->test())]]></code>
+      <code><![CDATA[self::assertSame(2, $banana->test())]]></code>
     </MissingThrowsDocblock>
     <MixedAssignment>
       <code><![CDATA[$banana]]></code>
@@ -5189,9 +5792,6 @@
       <code><![CDATA[self::assertSame('#BlackLivesMatter', $mock->blm())]]></code>
       <code><![CDATA[self::assertSame('#BlackLivesMatter', $mock->blm())]]></code>
     </MissingThrowsDocblock>
-    <ParseError>
-      <code><![CDATA[LegacyMockInterface|MockInterface]]></code>
-    </ParseError>
     <UndefinedInterfaceMethod>
       <code><![CDATA[blm]]></code>
     </UndefinedInterfaceMethod>
@@ -5252,9 +5852,6 @@
     <RedundantCondition>
       <code><![CDATA[assertIsObject]]></code>
     </RedundantCondition>
-    <ReservedWord>
-      <code><![CDATA[$mock->foo()]]></code>
-    </ReservedWord>
     <UndefinedMethod>
       <code><![CDATA[allows]]></code>
       <code><![CDATA[allows]]></code>
@@ -5273,6 +5870,70 @@
     </MissingThrowsDocblock>
     <UnusedClass>
       <code><![CDATA[TestCase1414Test]]></code>
+    </UnusedClass>
+  </file>
+  <file src="tests/Unit/PHP81/Php81LanguageFeaturesTest.php">
+    <InvalidArgument>
+      <code><![CDATA[Mockery::mock(IntersectionTypeHelper1Interface::class)]]></code>
+    </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code><![CDATA[self::assertInstanceOf(ClassWithNewInInitializer::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(ClassWithNewInInitializer::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(ClassWithNewInInitializer::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(PDO::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(PDO::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(PDO::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Serializable::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Serializable::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Serializable::class, $mock)]]></code>
+      <code><![CDATA[self::assertNull($mock->getTimestamp())]]></code>
+      <code><![CDATA[self::assertNull($mock->getTimestamp())]]></code>
+      <code><![CDATA[self::assertSame('it works', (new HandlerClass())->doStuff($class))]]></code>
+      <code><![CDATA[self::assertSame('it works', (new HandlerClass())->doStuff($class))]]></code>
+      <code><![CDATA[self::assertSame(0, $mock->exec('select * from foo.bar'))]]></code>
+      <code><![CDATA[self::assertSame(0, $mock->exec('select * from foo.bar'))]]></code>
+      <code><![CDATA[self::assertSame(0, $mock->getTimestamp())]]></code>
+      <code><![CDATA[self::assertSame(0, $mock->getTimestamp())]]></code>
+      <code><![CDATA[self::assertSame(0.0, $mock->getTimestamp())]]></code>
+      <code><![CDATA[self::assertSame(0.0, $mock->getTimestamp())]]></code>
+      <code><![CDATA[self::assertSame(123, \pcntl_wexitstatus($status))]]></code>
+      <code><![CDATA[self::assertSame(123, \pcntl_wexitstatus($status))]]></code>
+      <code><![CDATA[self::assertSame(SimpleEnum::first, $mock->enum)]]></code>
+      <code><![CDATA[self::assertSame(SimpleEnum::first, $mock->enum)]]></code>
+      <code><![CDATA[self::markTestSkipped("Couldn't fork for exit test")]]></code>
+      <code><![CDATA[self::markTestSkipped("Couldn't fork for exit test")]]></code>
+    </MissingThrowsDocblock>
+    <MixedArgument>
+      <code><![CDATA[$class]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$class]]></code>
+      <code><![CDATA[$mock]]></code>
+      <code><![CDATA[$mock]]></code>
+    </MixedAssignment>
+    <MixedMethodCall>
+      <code><![CDATA[andReturn]]></code>
+      <code><![CDATA[exits]]></code>
+      <code><![CDATA[foo]]></code>
+      <code><![CDATA[getMock]]></code>
+      <code><![CDATA[once]]></code>
+      <code><![CDATA[once]]></code>
+      <code><![CDATA[throws]]></code>
+      <code><![CDATA[with]]></code>
+    </MixedMethodCall>
+    <TypeDoesNotContainNull>
+      <code><![CDATA[assertNull]]></code>
+    </TypeDoesNotContainNull>
+    <UndefinedMethod>
+      <code><![CDATA[allows]]></code>
+      <code><![CDATA[expects]]></code>
+      <code><![CDATA[makePartial]]></code>
+      <code><![CDATA[makePartial]]></code>
+      <code><![CDATA[shouldReceive]]></code>
+      <code><![CDATA[shouldReceive]]></code>
+    </UndefinedMethod>
+    <UnusedClass>
+      <code><![CDATA[Php81LanguageFeaturesTest]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP82/Php82LanguageFeaturesTest.php">
@@ -5343,14 +6004,10 @@
       <code><![CDATA[$reflectionClass->getMethod($expectedMethod->getName())
             ->getParameters()[0]]]></code>
     </PossiblyUndefinedIntArrayOffset>
-    <ReservedWord>
-      <code><![CDATA[$mock->testFalseMethod()]]></code>
-      <code><![CDATA[$mock->testTrueMethod()]]></code>
-    </ReservedWord>
-    <TypeDoesNotContainType>
+    <RedundantCondition>
       <code><![CDATA[assertFalse]]></code>
       <code><![CDATA[assertTrue]]></code>
-    </TypeDoesNotContainType>
+    </RedundantCondition>
     <UndefinedClass>
       <code><![CDATA[$class->foo]]></code>
       <code><![CDATA[$class->foo]]></code>
@@ -5373,6 +6030,38 @@
     </UndefinedMagicMethod>
     <UnusedClass>
       <code><![CDATA[TestCase1439Test]]></code>
+    </UnusedClass>
+  </file>
+  <file src="tests/Unit/PHP83/Php83LanguageFeaturesTest.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[self::assertInstanceOf(Classes::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Classes::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Classes::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Interfaces::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Interfaces::class, $mock)]]></code>
+      <code><![CDATA[self::assertInstanceOf(Interfaces::class, $mock)]]></code>
+      <code><![CDATA[self::assertSame(ClassName::CONSTANT, $mock::CONSTANT)]]></code>
+      <code><![CDATA[self::assertSame(ClassName::CONSTANT, $mock::CONSTANT)]]></code>
+      <code><![CDATA[self::assertSame(ClassName::CONSTANT, $mock::{$constant})]]></code>
+      <code><![CDATA[self::assertSame(ClassName::CONSTANT, $mock::{$constant})]]></code>
+      <code><![CDATA[self::assertSame(ClassName::{$constant}, $mock::CONSTANT)]]></code>
+      <code><![CDATA[self::assertSame(ClassName::{$constant}, $mock::CONSTANT)]]></code>
+      <code><![CDATA[self::assertSame(ClassName::{$constant}, $mock::{$constant})]]></code>
+      <code><![CDATA[self::assertSame(ClassName::{$constant}, $mock::{$constant})]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock->foo())]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock::BAR)]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock::BAR)]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock::BAR)]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock::BAR)]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock::BAR)]]></code>
+      <code><![CDATA[self::assertSame(Enums::FOO, $mock::BAR)]]></code>
+    </MissingThrowsDocblock>
+    <UndefinedClass>
+      <code><![CDATA[$mock]]></code>
+    </UndefinedClass>
+    <UnusedClass>
+      <code><![CDATA[Php83LanguageFeaturesTest]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/PHP84/Php84LanguageFeaturesTest.php">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -27,7 +27,7 @@
     useDocblockPropertyTypes="true"
     usePhpDocMethodsWithoutMagicCall="true"
     usePhpDocPropertiesWithoutMagicCall="true"
-    phpVersion="7.3"
+    phpVersion="8.3"
 >
     <projectFiles>
         <directory name="library"/>
@@ -35,16 +35,10 @@
         <ignoreFiles>
             <directory name="tests/Fixture"/>
             <directory name="vendor"/>
-            <file name="library/Mockery/Mock.php" />
             <file name="tests/Unit/Mockery/ContainerTest.php"/>
-            <file name="tests/Unit/PHP81/Php81LanguageFeaturesTest.php"/>
-            <file name="tests/Unit/PHP83/Php83LanguageFeaturesTest.php"/>
         </ignoreFiles>
     </projectFiles>
     <extraFiles>
         <directory name="tests/Fixture"/>
     </extraFiles>
-    <plugins>
-<!--        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>-->
-    </plugins>
 </psalm>

--- a/tests/Unit/AbstractTestCase.php
+++ b/tests/Unit/AbstractTestCase.php
@@ -6,8 +6,6 @@ namespace Tests\Unit;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
-use function mock;
-
 abstract class AbstractTestCase extends MockeryTestCase
 {
     public function assertInvalidMock(string $class, string $exception, string $message): void
@@ -15,11 +13,11 @@ abstract class AbstractTestCase extends MockeryTestCase
         $this->expectException($exception);
         $this->expectExceptionMessage($message);
 
-        mock($class);
+        \mock($class);
     }
 
     public function assertValidMock(string $class): void
     {
-        self::assertInstanceOf($class, mock($class));
+        self::assertInstanceOf($class, \mock($class));
     }
 }

--- a/tests/Unit/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php
@@ -9,9 +9,6 @@ use Mockery\Exception\BadMethodCallException;
 use PHP73\BaseClassStub;
 use Throwable;
 
-use function mock;
-use function spy;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -19,7 +16,7 @@ final class MockeryPHPUnitIntegrationTest extends MockeryTestCase
 {
     public function testItMarksAPassingTestAsRiskyIfWeThrewExceptions(): void
     {
-        $mock = mock();
+        $mock = \mock();
 
         try {
             $mock->foobar();
@@ -27,7 +24,7 @@ final class MockeryPHPUnitIntegrationTest extends MockeryTestCase
             // exception swallowed...
         }
 
-        $test = spy(BaseClassStub::class)->makePartial();
+        $test = \spy(BaseClassStub::class)->makePartial();
         $test->finish();
 
         $test->shouldHaveReceived()
@@ -36,7 +33,7 @@ final class MockeryPHPUnitIntegrationTest extends MockeryTestCase
 
     public function testTheUserCanManuallyDismissAnExceptionToAvoidTheRiskyTest(): void
     {
-        $mock = mock();
+        $mock = \mock();
 
         try {
             $mock->foobar();
@@ -44,7 +41,7 @@ final class MockeryPHPUnitIntegrationTest extends MockeryTestCase
             $e->dismiss();
         }
 
-        $test = spy(BaseClassStub::class)->makePartial();
+        $test = \spy(BaseClassStub::class)->makePartial();
         $test->finish();
 
         $test->shouldNotHaveReceived()

--- a/tests/Unit/Mockery/Adapter/Phpunit/PhpUnitConstraintExpectationTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/PhpUnitConstraintExpectationTest.php
@@ -9,8 +9,6 @@ use Mockery\Exception;
 use PHPUnit\Framework\Constraint\GreaterThan;
 use PHPUnit\Framework\Constraint\IsIdentical;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -18,7 +16,7 @@ final class PhpUnitConstraintExpectationTest extends MockeryTestCase
 {
     public function testAnythingConstraintMatchesArgument(): void
     {
-        $mock = mock('foo');
+        $mock = \mock('foo');
 
         $mock->shouldReceive('foo')
             ->with(new IsIdentical(2))
@@ -38,7 +36,7 @@ final class PhpUnitConstraintExpectationTest extends MockeryTestCase
 
         $greaterThan = new GreaterThan(1);
 
-        $mock = mock('foo');
+        $mock = \mock('foo');
         $mock->shouldReceive('foo')
             ->with($greaterThan);
 
@@ -50,7 +48,7 @@ final class PhpUnitConstraintExpectationTest extends MockeryTestCase
 
     public function testGreaterThanConstraintMatchesArgument(): void
     {
-        $mock = mock('foo');
+        $mock = \mock('foo');
 
         $mock->shouldReceive('foo')
             ->with(new GreaterThan(1))
@@ -63,7 +61,7 @@ final class PhpUnitConstraintExpectationTest extends MockeryTestCase
     {
         $greaterThan = new GreaterThan(1);
 
-        $mock = mock('foo');
+        $mock = \mock('foo');
         $mock->shouldReceive('foo')
             ->with($greaterThan);
 

--- a/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -13,8 +13,6 @@ use PHPUnit\Framework\TestSuite;
 use PHPUnit\Util\Blacklist;
 use ReflectionClass;
 
-use function method_exists;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -65,7 +63,7 @@ final class TestListenerTest extends MockeryTestCase
     {
         $suite = Mockery::mock(TestSuite::class);
 
-        if (method_exists(Blacklist::class, 'addDirectory')) {
+        if (\method_exists(Blacklist::class, 'addDirectory')) {
             self::assertFalse(
                 (new Blacklist())->isBlacklisted((new ReflectionClass(Mockery::class))->getFileName())
             );

--- a/tests/Unit/Mockery/AllowsExpectsSyntaxTest.php
+++ b/tests/Unit/Mockery/AllowsExpectsSyntaxTest.php
@@ -20,7 +20,7 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
         $stub = Mockery::mock();
         $stub->allows('foo')
             ->andReturns('bar');
-        self::assertEquals('bar', $stub->foo());
+        self::assertSame('bar', $stub->foo());
     }
 
     public function testAllowsCanTakeAnArrayOfCalls(): void
@@ -31,8 +31,8 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
             'bar' => 'baz',
         ]);
 
-        self::assertEquals('bar', $stub->foo());
-        self::assertEquals('baz', $stub->bar());
+        self::assertSame('bar', $stub->foo());
+        self::assertSame('baz', $stub->bar());
     }
 
     public function testAllowsSetsUpMethodStub(): void
@@ -42,7 +42,7 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
             ->foo(123)
             ->andReturns(456);
 
-        self::assertEquals(456, $stub->foo(123));
+        self::assertSame(456, $stub->foo(123));
     }
 
     public function testCallVerificationCountCanBeOverridenAfterExpects(): void
@@ -76,7 +76,7 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
             ->withAnyArgs()
             ->andReturns(123);
 
-        self::assertEquals(123, $mock->foo(456, 789));
+        self::assertSame(123, $mock->foo(456, 789));
     }
 
     public function testExpectsCanTakeAString(): void
@@ -85,7 +85,7 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
         $mock->expects('foo')
             ->andReturns(123);
 
-        self::assertEquals(123, $mock->foo(456, 789));
+        self::assertSame(123, $mock->foo(456, 789));
     }
 
     public function testExpectsSetsUpExpectationOfOneCall(): void
@@ -105,7 +105,7 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
         $stub->shouldReceive('allows')
             ->andReturn(123);
 
-        self::assertEquals(123, $stub->allows());
+        self::assertSame(123, $stub->allows());
     }
 
     public function testGenerateSkipsExpectsMethodIfAlreadyExists(): void
@@ -115,6 +115,6 @@ final class AllowsExpectsSyntaxTest extends MockeryTestCase
         $stub->shouldReceive('expects')
             ->andReturn(123);
 
-        self::assertEquals(123, $stub->expects());
+        self::assertSame(123, $stub->expects());
     }
 }

--- a/tests/Unit/Mockery/CallableSpyTest.php
+++ b/tests/Unit/Mockery/CallableSpyTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception\InvalidCountException;
 
-use function spy;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,17 +14,17 @@ final class CallableSpyTest extends MockeryTestCase
 {
     public function testItActsAsPartial(): void
     {
-        $spy = spy(function ($number) {
+        $spy = \spy(function ($number) {
             return $number + 1;
         });
 
-        self::assertEquals(124, $spy(123));
+        self::assertSame(124, $spy(123));
         $spy->shouldHaveBeenCalled();
     }
 
     public function testItCanVerifyItWasCalledANumberOfTimes(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
         $spy();
@@ -37,7 +35,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItCanVerifyItWasCalledANumberOfTimesWithParticularArguments(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy(123);
         $spy(123);
@@ -49,7 +47,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfItWasCalledLessThanTheNumberOfTimesWeExpected(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
 
@@ -60,7 +58,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfItWasCalledLessThanTheNumberOfTimesWeExpectedWithParticularArguments(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
         $spy(123);
@@ -73,7 +71,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfItWasCalledMoreThanTheNumberOfTimesWeExpected(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
         $spy();
@@ -86,7 +84,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfItWasCalledMoreThanTheNumberOfTimesWeExpectedWithParticularArguments(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy(123);
         $spy(123);
@@ -100,7 +98,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfItWasCalledWhenWeExpectedItToNotHaveBeenCalled(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
 
@@ -110,7 +108,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfItWasCalledWithTheArgsWeWereNotExpecting(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy(123);
 
@@ -120,7 +118,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfTheArgumentsDoNotMatch(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy(123);
 
@@ -131,7 +129,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfTheCallableWasNotCalledAtAll(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $this->expectException(InvalidCountException::class);
         $spy->shouldHaveBeenCalled();
@@ -139,7 +137,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItThrowsIfThereWereNoArgumentsButWeExpectedSome(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
 
@@ -150,7 +148,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItVerifiesItWasNotCalledWithSomeParticularArgumentsWhenCalledWithDifferentArgs(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy(456);
 
@@ -159,7 +157,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItVerifiesItWasNotCalledWithSomeParticularArgumentsWhenCalledWithNoArgs(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
 
@@ -168,7 +166,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItVerifiesTheClosureWasCalled(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy();
 
@@ -177,7 +175,7 @@ final class CallableSpyTest extends MockeryTestCase
 
     public function testItVerifiesTheClosureWasNotCalled(): void
     {
-        $spy = spy(function (): void {});
+        $spy = \spy(function (): void {});
 
         $spy->shouldNotHaveBeenCalled();
     }

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -97,24 +97,31 @@ use Traversable;
 
 use const PHP_MAJOR_VERSION;
 
-use function class_exists;
-use function extension_loaded;
-use function fopen;
-use function get_class;
 use function mock;
-use function preg_match;
-use function random_int;
-use function time;
-use function uniqid;
 
 /**
  * @coversDefaultClass \Mockery
  */
 final class ContainerTest extends MockeryTestCase
 {
+    /**
+     * @return Generator<string,array{0: bool, 1: string}>
+     */
+    public static function provideIsValidClassNameCases(): iterable
+    {
+        yield from [
+            'empty string' => [false, ''],
+            'just a space' => [false, ' '],
+            'class name with dot' => [false, 'ClassName.WithDot'],
+            'too many backslashes' => [false, '\\\\TooManyBackSlashes'],
+            'global class name' => [true, 'Foo'],
+            'namespaced class name' => [true, Bar::class],
+        ];
+    }
+
     public function testBlockForwardingToPartialObject(): void
     {
-        $m = mock(new MockeryTestBar1(), [
+        $m = \mock(new MockeryTestBar1(), [
             'foo' => 1,
             Container::BLOCKS => ['method1'],
         ]);
@@ -126,7 +133,7 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testCallingSelfOnlyReturnsLastMockCreatedOrCurrentMockBeingProgrammedSinceTheyAreOneAndTheSame(): void
     {
-        $m = mock(MockeryTestFoo::class);
+        $m = \mock(MockeryTestFoo::class);
         self::assertNotInstanceOf(MockeryTestFoo2::class, Mockery::self());
         //$m = mock('\PHP73\MockeryTestFoo2');
         //self::assertInstanceOf(MockeryTestFoo2::class, self());
@@ -143,7 +150,7 @@ final class ContainerTest extends MockeryTestCase
 
         Mockery::getConfiguration()->setInternalClassMethodParamMap(DateTime::class, 'modify', ['&$string']);
         // @ used to avoid E_STRICT for incompatible signature
-        @$m = mock(DateTime::class);
+        @$m = \mock(DateTime::class);
         self::assertInstanceOf(MockInterface::class, $m, 'Mocking failed, remove @ error suppresion to debug');
         $rc = new ReflectionClass($m);
         $rm = $rc->getMethod('modify');
@@ -152,7 +159,7 @@ final class ContainerTest extends MockeryTestCase
 
         Mockery::getConfiguration()->resetInternalClassMethodParamMaps();
 
-        $m = mock(DateTime::class);
+        $m = \mock(DateTime::class);
         self::assertInstanceOf(MockInterface::class, $m, 'Mocking failed');
         $rc = new ReflectionClass($m);
         $rm = $rc->getMethod('modify');
@@ -164,19 +171,19 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockAbstractClassWithAbstractPublicMethod(): void
     {
-        $m = mock(MockeryTest_AbstractWithAbstractPublicMethod::class);
+        $m = \mock(MockeryTest_AbstractWithAbstractPublicMethod::class);
         self::assertInstanceOf(MockeryTest_AbstractWithAbstractPublicMethod::class, $m);
     }
 
     public function testCanMockAbstractWithAbstractProtectedMethod(): void
     {
-        $m = mock(MockeryTest_AbstractWithAbstractMethod::class);
+        $m = \mock(MockeryTest_AbstractWithAbstractMethod::class);
         self::assertInstanceOf(MockeryTest_AbstractWithAbstractMethod::class, $m);
     }
 
     public function testCanMockClassAndApplyMultipleInterfaces(): void
     {
-        $m = mock('\PHP73\MockeryTestFoo, \PHP73\MockeryTest_Interface1, \PHP73\MockeryTest_Interface2');
+        $m = \mock('\PHP73\MockeryTestFoo, \PHP73\MockeryTest_Interface1, \PHP73\MockeryTest_Interface2');
         self::assertInstanceOf(MockeryTestFoo::class, $m);
         self::assertInstanceOf(MockeryTest_Interface1::class, $m);
         self::assertInstanceOf(MockeryTest_Interface2::class, $m);
@@ -184,19 +191,19 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockClassContainingAPublicWakeupMethod(): void
     {
-        $m = mock(MockeryTest_Wakeup1::class);
+        $m = \mock(MockeryTest_Wakeup1::class);
         self::assertInstanceOf(MockeryTest_Wakeup1::class, $m);
     }
 
     public function testCanMockClassContainingMagicCallMethod(): void
     {
-        $m = mock(MockeryTest_Call1::class);
+        $m = \mock(MockeryTest_Call1::class);
         self::assertInstanceOf(MockeryTest_Call1::class, $m);
     }
 
     public function testCanMockClassContainingMagicCallMethodWithoutTypeHinting(): void
     {
-        $m = mock(MockeryTest_Call2::class);
+        $m = \mock(MockeryTest_Call2::class);
         self::assertInstanceOf(MockeryTest_Call2::class, $m);
     }
 
@@ -215,28 +222,28 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockClassWithConstructor(): void
     {
-        $m = mock(MockeryTest_ClassConstructor::class);
+        $m = \mock(MockeryTest_ClassConstructor::class);
         self::assertInstanceOf(MockeryTest_ClassConstructor::class, $m);
     }
 
     public function testCanMockClassWithConstructorNeedingClassArgs(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class);
+        $m = \mock(MockeryTest_ClassConstructor2::class);
         self::assertInstanceOf(MockeryTest_ClassConstructor2::class, $m);
     }
 
     public function testCanMockClassWithReservedWordMethod(): void
     {
-        if (! extension_loaded('redis')) {
+        if (! \extension_loaded('redis')) {
             self::markTestSkipped('phpredis not installed');
         }
 
-        self::assertInstanceOf(Redis::class, mock(Redis::class));
+        self::assertInstanceOf(Redis::class, \mock(Redis::class));
     }
 
     public function testCanMockClassesThatDescendFromInternalClasses(): void
     {
-        $mock = mock(MockeryTest_ClassThatDescendsFromInternalClass::class);
+        $mock = \mock(MockeryTest_ClassThatDescendsFromInternalClass::class);
         self::assertInstanceOf(DateTime::class, $mock);
     }
 
@@ -245,19 +252,19 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testCanMockClassesThatImplementSerializable(): void
     {
-        $mock = mock(MockeryTest_ClassThatImplementsSerializable::class);
+        $mock = \mock(MockeryTest_ClassThatImplementsSerializable::class);
         self::assertInstanceOf(Serializable::class, $mock);
     }
 
     public function testCanMockInterface(): void
     {
-        $m = mock(MockeryTest_Interface::class);
+        $m = \mock(MockeryTest_Interface::class);
         self::assertInstanceOf(MockeryTest_Interface::class, $m);
     }
 
     public function testCanMockInterfaceWithAbstractMethod(): void
     {
-        $m = mock(MockeryTest_InterfaceWithAbstractMethod::class);
+        $m = \mock(MockeryTest_InterfaceWithAbstractMethod::class);
         self::assertInstanceOf(MockeryTest_InterfaceWithAbstractMethod::class, $m);
         $m->shouldReceive('foo')
             ->andReturn(1);
@@ -266,13 +273,13 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockInterfaceWithPublicStaticMethod(): void
     {
-        $m = mock(MockeryTest_InterfaceWithPublicStaticMethod::class);
+        $m = \mock(MockeryTest_InterfaceWithPublicStaticMethod::class);
         self::assertInstanceOf(MockeryTest_InterfaceWithPublicStaticMethod::class, $m);
     }
 
     public function testCanMockInterfacesAlongsideTraversable(): void
     {
-        $mock = mock('\stdClass, \ArrayAccess, \Countable, \Traversable');
+        $mock = \mock('\stdClass, \ArrayAccess, \Countable, \Traversable');
         self::assertInstanceOf(stdClass::class, $mock);
         self::assertInstanceOf(ArrayAccess::class, $mock);
         self::assertInstanceOf(Countable::class, $mock);
@@ -281,7 +288,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockInterfacesExtendingTraversable(): void
     {
-        $mock = mock(MockeryTest_InterfaceWithTraversable::class);
+        $mock = \mock(MockeryTest_InterfaceWithTraversable::class);
         self::assertInstanceOf(MockeryTest_InterfaceWithTraversable::class, $mock);
         self::assertInstanceOf(ArrayAccess::class, $mock);
         self::assertInstanceOf(Countable::class, $mock);
@@ -290,27 +297,27 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockInternalClassesThatImplementSerializable(): void
     {
-        $mock = mock(ArrayObject::class);
+        $mock = \mock(ArrayObject::class);
         self::assertInstanceOf(Serializable::class, $mock);
     }
 
     public function testCanMockMethodsWithRequiredParamsThatHaveDefaultValues(): void
     {
-        $mock = mock(MockeryTest_MethodWithRequiredParamWithDefaultValue::class);
+        $mock = \mock(MockeryTest_MethodWithRequiredParamWithDefaultValue::class);
         $mock->shouldIgnoreMissing();
         self::assertNull($mock->foo(123, null));
     }
 
     public function testCanMockMultipleInterfaces(): void
     {
-        $m = mock('\PHP73\MockeryTest_Interface1, \PHP73\MockeryTest_Interface2');
+        $m = \mock('\PHP73\MockeryTest_Interface1, \PHP73\MockeryTest_Interface2');
         self::assertInstanceOf(MockeryTest_Interface1::class, $m);
         self::assertInstanceOf(MockeryTest_Interface2::class, $m);
     }
 
     public function testCanMockMultipleInterfacesThatMayNotExist(): void
     {
-        $m = mock(
+        $m = \mock(
             'NonExistingClass, \PHP73\MockeryTest_Interface1, \PHP73\MockeryTest_Interface2, \Some\Thing\That\Doesnt\Exist'
         );
         self::assertInstanceOf(MockeryTest_Interface1::class, $m);
@@ -320,13 +327,13 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanMockSpl(): void
     {
-        $m = mock(SplFixedArray::class);
+        $m = \mock(SplFixedArray::class);
         self::assertInstanceOf(SplFixedArray::class, $m);
     }
 
     public function testCanMockStaticMethods(): void
     {
-        $m = mock('alias:MyNamespace\MyClass2');
+        $m = \mock('alias:MyNamespace\MyClass2');
         $m->shouldReceive('staticFoo')
             ->andReturn('bar');
         self::assertSame('bar', MyClass2::staticFoo());
@@ -338,7 +345,7 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testCanOverrideExpectedParametersOfExtensionPHPClassesToPreserveRefs(): void
     {
-        if (! class_exists(MongoCollection::class, false)) {
+        if (! \class_exists(MongoCollection::class, false)) {
             self::markTestSkipped('ext/mongo not installed');
         }
         if (PHP_MAJOR_VERSION > 7) {
@@ -350,7 +357,7 @@ final class ContainerTest extends MockeryTestCase
             ['&$data', '$options']
         );
         // @ used to avoid E_STRICT for incompatible signature
-        @$m = mock(MongoCollection::class);
+        @$m = \mock(MongoCollection::class);
         self::assertInstanceOf(MockInterface::class, $m, 'Mocking failed, remove @ error suppresion to debug');
         $m->shouldReceive('insert')
             ->with(Mockery::on(static function (&$data) {
@@ -382,7 +389,7 @@ final class ContainerTest extends MockeryTestCase
 
         Mockery::getConfiguration()->setInternalClassMethodParamMap(DateTime::class, 'modify', ['&$string']);
         // @ used to avoid E_STRICT for incompatible signature
-        @$m = mock(DateTime::class);
+        @$m = \mock(DateTime::class);
         self::assertInstanceOf(MockInterface::class, $m, 'Mocking failed, remove @ error suppresion to debug');
         $m->shouldReceive('modify')
             ->with(Mockery::on(static function (&$string) {
@@ -405,7 +412,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanPartiallyMockANormalClass(): void
     {
-        $m = mock(MockeryTest_PartialNormalClass::class . '[foo]');
+        $m = \mock(MockeryTest_PartialNormalClass::class . '[foo]');
         self::assertInstanceOf(MockeryTest_PartialNormalClass::class, $m);
         $m->shouldReceive('foo')
             ->andReturn('cba');
@@ -415,7 +422,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanPartiallyMockANormalClassWith2Methods(): void
     {
-        $m = mock(MockeryTest_PartialNormalClass2::class . '[foo, baz]');
+        $m = \mock(MockeryTest_PartialNormalClass2::class . '[foo, baz]');
         self::assertInstanceOf(MockeryTest_PartialNormalClass2::class, $m);
         $m->shouldReceive('foo')
             ->andReturn('cba');
@@ -428,7 +435,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanPartiallyMockAnAbstractClass(): void
     {
-        $m = mock(MockeryTest_PartialAbstractClass::class . '[foo]');
+        $m = \mock(MockeryTest_PartialAbstractClass::class . '[foo]');
         self::assertInstanceOf(MockeryTest_PartialAbstractClass::class, $m);
         $m->shouldReceive('foo')
             ->andReturn('cba');
@@ -438,7 +445,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanPartiallyMockAnAbstractClassWith2Methods(): void
     {
-        $m = mock(MockeryTest_PartialAbstractClass2::class . '[foo,baz]');
+        $m = \mock(MockeryTest_PartialAbstractClass2::class . '[foo,baz]');
         self::assertInstanceOf(MockeryTest_PartialAbstractClass2::class, $m);
         $m->shouldReceive('foo')
             ->andReturn('cba');
@@ -456,7 +463,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanUseBlacklistAndExpectionOnNonBlacklistedMethod(): void
     {
-        $m = mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
+        $m = \mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
         $m->shouldReceive('bar')
             ->andReturn('test')
             ->once();
@@ -465,19 +472,19 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCanUseEmptyMethodlist(): void
     {
-        $m = mock(MockeryTest_PartialNormalClass2::class . '[]');
+        $m = \mock(MockeryTest_PartialNormalClass2::class . '[]');
         self::assertInstanceOf(MockeryTest_PartialNormalClass2::class, $m);
     }
 
     public function testCanUseExclamationToBlacklistMethod(): void
     {
-        $m = mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
+        $m = \mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
         self::assertSame('abc', $m->foo());
     }
 
     public function testCantCallMethodWhenUsingBlacklistAndNoExpectation(): void
     {
-        $m = mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
+        $m = \mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessageMatches('/::bar\(\), but no expectations were specified/');
         $m->bar();
@@ -488,7 +495,7 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testClassDeclaringIssetDoesNotThrowException(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryTest_IssetMethod::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryTest_IssetMethod::class));
     }
 
     /**
@@ -496,12 +503,12 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testClassDeclaringUnsetDoesNotThrowException(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryTest_UnsetMethod::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryTest_UnsetMethod::class));
     }
 
     public function testClassesWithFinalMethodsCanBeProperPartialMocks(): void
     {
-        $m = mock(MockeryFoo4::class . '[bar]');
+        $m = \mock(MockeryFoo4::class . '[bar]');
         $m->shouldReceive('bar')
             ->andReturn('baz');
         self::assertSame('baz', $m->foo());
@@ -511,7 +518,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testClassesWithFinalMethodsCanBeProperPartialMocksButFinalMethodsNotPartialed(): void
     {
-        $m = mock(MockeryFoo4::class . '[foo]');
+        $m = \mock(MockeryFoo4::class . '[foo]');
         $m->shouldReceive('foo')
             ->andReturn('foo');
         self::assertSame('baz', $m->foo()); // partial expectation ignored - will fail callcount assertion
@@ -520,7 +527,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testClassesWithFinalMethodsCanBeProxyPartialMocks(): void
     {
-        $m = mock(new MockeryFoo4());
+        $m = \mock(new MockeryFoo4());
         $m->shouldReceive('foo')
             ->andReturn('baz');
         self::assertSame('baz', $m->foo());
@@ -530,7 +537,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCreatingAPartialAllowsDynamicExpectationsAndPassesThroughUnexpectedMethods(): void
     {
-        $m = mock(new MockeryTestFoo());
+        $m = \mock(new MockeryTestFoo());
         $m->shouldReceive('bar')
             ->andReturn('bar');
         self::assertSame('bar', $m->bar());
@@ -540,7 +547,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCreatingAPartialAllowsExpectationsToInterceptCallsToImplementedMethods(): void
     {
-        $m = mock(new MockeryTestFoo2());
+        $m = \mock(new MockeryTestFoo2());
         $m->shouldReceive('bar')
             ->andReturn('baz');
         self::assertSame('baz', $m->bar());
@@ -553,7 +560,7 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testCreatingMockOfClassWithExistingToStringMethodDoesntCreateClassWithTwoToStringMethods(): void
     {
-        $m = mock(MockeryTest_WithToString::class); // this would fatal
+        $m = \mock(MockeryTest_WithToString::class); // this would fatal
         $m->shouldReceive('__toString')
             ->andReturn('dave');
         self::assertSame('dave', "{$m}");
@@ -561,19 +568,19 @@ final class ContainerTest extends MockeryTestCase
 
     public function testCreationOfInstanceMock(): void
     {
-        $m = mock('overload:MyNamespace\MyClass4');
+        $m = \mock('overload:MyNamespace\MyClass4');
         self::assertInstanceOf(MyClass4::class, $m);
     }
 
     public function testCreationOfInstanceMockWithFullyQualifiedName(): void
     {
-        $m = mock('overload:\MyNamespace\MyClass11');
+        $m = \mock('overload:\MyNamespace\MyClass11');
         self::assertInstanceOf(MyClass11::class, $m);
     }
 
     public function testExceptionOutputMakesBooleansLookLikeBooleans(): void
     {
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with(123);
 
@@ -585,7 +592,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testExistingStaticMethodMocking(): void
     {
-        $mock = mock('\PHP73\MockeryTest_PartialStatic[mockMe]');
+        $mock = \mock('\PHP73\MockeryTest_PartialStatic[mockMe]');
 
         $mock->shouldReceive('mockMe')
             ->with(5)
@@ -597,7 +604,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testFinalClassesCanBePartialMocks(): void
     {
-        $m = mock(new MockeryFoo3());
+        $m = \mock(new MockeryFoo3());
         $m->shouldReceive('foo')
             ->andReturn('baz');
         self::assertSame('baz', $m->foo());
@@ -611,7 +618,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testGetExpectationCountMockWithAtLeast(): void
     {
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('foo')
             ->atLeast()
             ->once();
@@ -622,7 +629,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testGetExpectationCountMockWithNever(): void
     {
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('foo')
             ->never();
         self::assertSame(1, Mockery::getContainer()->mockery_getExpectationCount());
@@ -630,7 +637,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testGetExpectationCountMockWithOnce(): void
     {
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('foo')
             ->once();
         self::assertSame(1, Mockery::getContainer()->mockery_getExpectationCount());
@@ -639,18 +646,18 @@ final class ContainerTest extends MockeryTestCase
 
     public function testGetExpectationCountStub(): void
     {
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('foo');
         self::assertSame(0, Mockery::getContainer()->mockery_getExpectationCount());
     }
 
     public function testGetKeyOfDemeterMockShouldReturnKeyWhenMatchingMock(): void
     {
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('foo->bar');
         self::assertMatchesRegularExpression(
             '/Mockery_(\d+)__demeter_([0-9a-f]+)_foo/',
-            Mockery::getContainer()->getKeyOfDemeterMockFor('foo', get_class($m))
+            Mockery::getContainer()->getKeyOfDemeterMockFor('foo', \get_class($m))
         );
     }
 
@@ -659,12 +666,12 @@ final class ContainerTest extends MockeryTestCase
         $method = 'unknownMethod';
         self::assertNull(Mockery::getContainer()->getKeyOfDemeterMockFor($method, 'any'));
 
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('method');
-        self::assertNull(Mockery::getContainer()->getKeyOfDemeterMockFor($method, get_class($m)));
+        self::assertNull(Mockery::getContainer()->getKeyOfDemeterMockFor($method, \get_class($m)));
 
         $m->shouldReceive('foo->bar');
-        self::assertNull(Mockery::getContainer()->getKeyOfDemeterMockFor($method, get_class($m)));
+        self::assertNull(Mockery::getContainer()->getKeyOfDemeterMockFor($method, \get_class($m)));
     }
 
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithCircularArray(): void
@@ -672,7 +679,7 @@ final class ContainerTest extends MockeryTestCase
         $testArray = [];
         $testArray['myself'] = &$testArray;
 
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with([
                 'yourself' => 21,
@@ -689,7 +696,7 @@ final class ContainerTest extends MockeryTestCase
         $testArray['a_scalar'] = 2;
         $testArray['an_array'] = [1, 2, 3];
 
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with([
                 'yourself' => 21,
@@ -706,7 +713,7 @@ final class ContainerTest extends MockeryTestCase
         $testArray['a_scalar'] = 2;
         $testArray['a_closure'] = static function (): void {};
 
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with([
                 'yourself' => 21,
@@ -723,7 +730,7 @@ final class ContainerTest extends MockeryTestCase
         $testArray['a_scalar'] = 2;
         $testArray['an_object'] = new stdClass();
 
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with([
                 'yourself' => 21,
@@ -738,9 +745,9 @@ final class ContainerTest extends MockeryTestCase
     {
         $testArray = [];
         $testArray['a_scalar'] = 2;
-        $testArray['a_resource'] = fopen('php://memory', 'r');
+        $testArray['a_resource'] = \fopen('php://memory', 'r');
 
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with([
                 'yourself' => 21,
@@ -753,7 +760,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testHandlesMethodWithArgumentExpectationWhenCalledWithResource(): void
     {
-        $mock = mock('MyTestClass');
+        $mock = \mock('MyTestClass');
         $mock->shouldReceive('foo')
             ->with([
                 'yourself' => 21,
@@ -761,12 +768,12 @@ final class ContainerTest extends MockeryTestCase
 
         $this->expectException(NoMatchingExpectationException::class);
         $this->expectExceptionMessage('MyTestClass::foo(resource(...))');
-        $mock->foo(fopen('php://memory', 'r'));
+        $mock->foo(\fopen('php://memory', 'r'));
     }
 
     public function testInstanceMocksShouldIgnoreMissing(): void
     {
-        $m = mock('overload:MyNamespace\MyClass12');
+        $m = \mock('overload:MyNamespace\MyClass12');
         $m->shouldIgnoreMissing();
 
         $instance = new MyClass12();
@@ -775,14 +782,14 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMock(): void
     {
-        $m = mock('overload:MyNamespace\MyClass5');
+        $m = \mock('overload:MyNamespace\MyClass5');
         $instance = new MyClass5();
         self::assertInstanceOf(MyClass5::class, $instance);
     }
 
     public function testInstantiationOfInstanceMockImportsDefaultExpectations(): void
     {
-        $m = mock('overload:MyNamespace\MyClass6');
+        $m = \mock('overload:MyNamespace\MyClass6');
         $m->shouldReceive('foo')
             ->andReturn('bar')
             ->byDefault();
@@ -793,7 +800,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMockImportsDefaultExpectationsInTheCorrectOrder(): void
     {
-        $m = mock('overload:MyNamespace\MyClass6');
+        $m = \mock('overload:MyNamespace\MyClass6');
         $m->shouldReceive('foo')
             ->andReturn(1)
             ->byDefault();
@@ -810,7 +817,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMockImportsExpectations(): void
     {
-        $m = mock('overload:MyNamespace\MyClass6');
+        $m = \mock('overload:MyNamespace\MyClass6');
         $m->shouldReceive('foo')
             ->andReturn('bar');
         $instance = new MyClass6();
@@ -819,9 +826,9 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMockWithConstructorParameterValidation(): void
     {
-        $m = mock('overload:MyNamespace\MyClass14');
+        $m = \mock('overload:MyNamespace\MyClass14');
         $params = [
-            'value1' => uniqid('test_', false),
+            'value1' => \uniqid('test_', false),
         ];
         $m->shouldReceive('__construct')
             ->with($params)
@@ -832,9 +839,9 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMockWithConstructorParameterValidationException(): void
     {
-        $m = mock('overload:MyNamespace\MyClass16');
+        $m = \mock('overload:MyNamespace\MyClass16');
         $m->shouldReceive('__construct')
-            ->andThrow(new Exception('instanceMock ' . random_int(100, 999)));
+            ->andThrow(new Exception('instanceMock ' . \random_int(100, 999)));
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessageMatches('/^instanceMock \d{3}$/');
@@ -843,9 +850,9 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMockWithConstructorParameterValidationNegative(): void
     {
-        $m = mock('overload:MyNamespace\MyClass15');
+        $m = \mock('overload:MyNamespace\MyClass15');
         $params = [
-            'value1' => uniqid('test_', false),
+            'value1' => \uniqid('test_', false),
         ];
         $m->shouldReceive('__construct')
             ->with($params);
@@ -856,7 +863,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMocksAddsThemToContainerForVerification(): void
     {
-        $m = mock('overload:MyNamespace\MyClass8');
+        $m = \mock('overload:MyNamespace\MyClass8');
         $m->shouldReceive('foo')
             ->once();
         $instance = new MyClass8();
@@ -866,7 +873,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMocksDoesNotHaveCountValidatorCrossover(): void
     {
-        $m = mock('overload:MyNamespace\MyClass9');
+        $m = \mock('overload:MyNamespace\MyClass9');
         $m->shouldReceive('foo')
             ->once();
         $instance1 = new MyClass9();
@@ -877,7 +884,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMocksDoesNotHaveCountValidatorCrossover2(): void
     {
-        $m = mock('overload:MyNamespace\MyClass10');
+        $m = \mock('overload:MyNamespace\MyClass10');
         $m->shouldReceive('foo')
             ->once();
         $instance1 = new MyClass10();
@@ -889,7 +896,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInstantiationOfInstanceMocksIgnoresVerificationOfOriginMock(): void
     {
-        $m = mock('overload:MyNamespace\MyClass7');
+        $m = \mock('overload:MyNamespace\MyClass7');
         $m->shouldReceive('foo')
             ->once()
             ->andReturn('bar');
@@ -897,14 +904,14 @@ final class ContainerTest extends MockeryTestCase
 
     public function testInterfacesCanHaveAssertions(): void
     {
-        $m = mock('\stdClass, \ArrayAccess, \Countable, \Traversable');
+        $m = \mock('\stdClass, \ArrayAccess, \Countable, \Traversable');
         $m->shouldReceive('foo')
             ->once();
         $m->foo();
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider provideIsValidClassNameCases
      */
     public function testIsValidClassName($expected, $className): void
     {
@@ -913,8 +920,8 @@ final class ContainerTest extends MockeryTestCase
 
     public function testIssetMappingUsingProxiedPartialsCheckNoExceptionThrown(): void
     {
-        $var = mock(new MockeryTestIsset_Bar());
-        $mock = mock(new MockeryTestIsset_Foo($var));
+        $var = \mock(new MockeryTestIsset_Bar());
+        $mock = \mock(new MockeryTestIsset_Foo($var));
         $mock->shouldReceive('bar')
             ->once();
         $mock->bar();
@@ -925,7 +932,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMethodParamsPassedByReferenceHaveReferencePreserved(): void
     {
-        $m = mock(MockeryTestRef1::class);
+        $m = \mock(MockeryTestRef1::class);
         $m->shouldReceive('foo')
             ->with(Mockery::on(static function (&$a) {
                 ++$a;
@@ -940,7 +947,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMethodParamsPassedByReferenceThroughWithArgsHaveReferencePreserved(): void
     {
-        $m = mock(MockeryTestRef1::class);
+        $m = \mock(MockeryTestRef1::class);
         $m->shouldReceive('foo')
             ->withArgs(static function (&$a, $b) {
                 ++$a;
@@ -956,8 +963,8 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMethodsReturningParamsByReferenceDoesNotErrorOut(): void
     {
-        mock(MockeryTest_ReturnByRef::class);
-        $mock = mock(MockeryTest_ReturnByRef::class);
+        \mock(MockeryTest_ReturnByRef::class);
+        $mock = \mock(MockeryTest_ReturnByRef::class);
         $mock->shouldReceive('get')
             ->andReturn($var = 123);
         self::assertSame($var, $mock->get());
@@ -965,12 +972,12 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockCallableTypeHint(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryTest_MockCallableTypeHint::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryTest_MockCallableTypeHint::class));
     }
 
     public function testMockedStaticMethodsObeyMethodCounting(): void
     {
-        $m = mock('alias:MyNamespace\MyClass3');
+        $m = \mock('alias:MyNamespace\MyClass3');
         $m->shouldReceive('staticFoo')
             ->once()
             ->andReturn('bar');
@@ -980,7 +987,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockedStaticThrowsExceptionWhenMethodDoesNotExist(): void
     {
-        $m = mock('alias:MyNamespace\StaticNoMethod');
+        $m = \mock('alias:MyNamespace\StaticNoMethod');
 
         try {
             StaticNoMethod::staticFoo();
@@ -1011,42 +1018,42 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockeryDoesntTryAndMockLowercaseToString(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryTest_Lowercase_ToString::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryTest_Lowercase_ToString::class));
     }
 
     public function testMockeryShouldCallConstructorByDefaultWhenRequestingPartials(): void
     {
-        $mock = mock('\PHP73\EmptyConstructorTest[foo]');
+        $mock = \mock('\PHP73\EmptyConstructorTest[foo]');
         self::assertSame(0, $mock->numberOfConstructorArgs);
     }
 
     public function testMockeryShouldDistinguishBetweenConstructorParamsAndClosures(): void
     {
         $obj = new MockeryTestFoo();
-        self::assertInstanceOf(MockInterface::class, mock('\PHP73\MockeryTest_ClassMultipleConstructorParams[dave]', [
+        self::assertInstanceOf(MockInterface::class, \mock('\PHP73\MockeryTest_ClassMultipleConstructorParams[dave]', [
             &$obj, 'foo',
         ]));
     }
 
     public function testMockeryShouldInterpretEmptyArrayAsConstructorArgs(): void
     {
-        $mock = mock(EmptyConstructorTest::class, []);
+        $mock = \mock(EmptyConstructorTest::class, []);
         self::assertSame(0, $mock->numberOfConstructorArgs);
     }
 
     public function testMockeryShouldNotMockCallstaticMagicMethod(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryTest_CallStatic::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryTest_CallStatic::class));
     }
 
     public function testMockeryShouldRespectInterfaceWithMethodParamSelf(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryTest_InterfaceWithMethodParamSelf::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryTest_InterfaceWithMethodParamSelf::class));
     }
 
     public function testMockingAConcreteObjectCreatesAPartialWithoutError(): void
     {
-        $m = mock(new stdClass());
+        $m = \mock(new stdClass());
         $m->shouldReceive('foo')
             ->andReturn('bar');
         self::assertSame('bar', $m->foo());
@@ -1055,7 +1062,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingAKnownConcreteClassCanBeGrantedAnArbitraryClassType(): void
     {
-        $m = mock('alias:MyNamespace\MyClass');
+        $m = \mock('alias:MyNamespace\MyClass');
         $m->shouldReceive('foo')
             ->andReturn('bar');
 
@@ -1065,7 +1072,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingAKnownConcreteClassSoMockInheritsClassType(): void
     {
-        $m = mock(stdClass::class);
+        $m = \mock(stdClass::class);
         $m->shouldReceive('foo')
             ->andReturn('bar');
         self::assertSame('bar', $m->foo());
@@ -1074,24 +1081,24 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingAKnownConcreteClassWithFinalMethodsThrowsNoException(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock(MockeryFoo4::class));
+        self::assertInstanceOf(MockInterface::class, \mock(MockeryFoo4::class));
     }
 
     public function testMockingAKnownConcreteFinalClassThrowsErrorsOnlyPartialMocksCanMockFinalElements(): void
     {
         $this->expectException(Mockery\Exception::class);
-        $m = mock(MockeryFoo3::class);
+        $m = \mock(MockeryFoo3::class);
     }
 
     public function testMockingAKnownUserClassSoMockInheritsClassType(): void
     {
-        $m = mock(MockeryTest_TestInheritedType::class);
+        $m = \mock(MockeryTest_TestInheritedType::class);
         self::assertInstanceOf(MockeryTest_TestInheritedType::class, $m);
     }
 
     public function testMockingAllowsPublicPropertyStubbingOnNamedMock(): void
     {
-        $m = mock('Foo');
+        $m = \mock('Foo');
         $m->foo = 'bar';
         self::assertSame('bar', $m->foo);
         //self::assertArrayHasKey('foo', $m->mockery_getMockableProperties());
@@ -1099,7 +1106,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingAllowsPublicPropertyStubbingOnPartials(): void
     {
-        $m = mock(new stdClass());
+        $m = \mock(new stdClass());
         $m->foo = 'bar';
         self::assertSame('bar', $m->foo);
         //self::assertArrayHasKey('foo', $m->mockery_getMockableProperties());
@@ -1107,7 +1114,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingAllowsPublicPropertyStubbingOnRealClass(): void
     {
-        $m = mock(MockeryTestFoo::class);
+        $m = \mock(MockeryTestFoo::class);
         $m->foo = 'bar';
         self::assertSame('bar', $m->foo);
         //self::assertArrayHasKey('foo', $m->mockery_getMockableProperties());
@@ -1115,14 +1122,14 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingDoesNotStubNonStubbedPropertiesOnPartials(): void
     {
-        $m = mock(new MockeryTest_ExistingProperty());
+        $m = \mock(new MockeryTest_ExistingProperty());
         self::assertSame('bar', $m->foo);
         self::assertArrayNotHasKey('foo', $m->mockery_getMockableProperties());
     }
 
     public function testMockingInterfaceThatExtendsIteratorAggregateDoesNotImplementIterator(): void
     {
-        $mock = mock(MockeryTest_InterfaceThatExtendsIteratorAggregate::class);
+        $mock = \mock(MockeryTest_InterfaceThatExtendsIteratorAggregate::class);
         self::assertInstanceOf(IteratorAggregate::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
         self::assertNotInstanceOf(Iterator::class, $mock);
@@ -1130,7 +1137,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingInterfaceThatExtendsIteratorDoesNotImplementIterator(): void
     {
-        $mock = mock(MockeryTest_InterfaceThatExtendsIterator::class);
+        $mock = \mock(MockeryTest_InterfaceThatExtendsIterator::class);
         self::assertInstanceOf(Iterator::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
     }
@@ -1140,7 +1147,7 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testMockingIteratorAggregateDoesNotImplementIterator(): void
     {
-        $mock = mock(MockeryTest_ImplementsIteratorAggregate::class);
+        $mock = \mock(MockeryTest_ImplementsIteratorAggregate::class);
         self::assertInstanceOf(IteratorAggregate::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
         self::assertNotInstanceOf(Iterator::class, $mock);
@@ -1148,7 +1155,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testMockingIteratorAggregateDoesNotImplementIteratorAlongside(): void
     {
-        $mock = mock(IteratorAggregate::class);
+        $mock = \mock(IteratorAggregate::class);
         self::assertInstanceOf(IteratorAggregate::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
         self::assertNotInstanceOf(Iterator::class, $mock);
@@ -1159,29 +1166,29 @@ final class ContainerTest extends MockeryTestCase
      */
     public function testMockingIteratorDoesNotImplementIterator(): void
     {
-        $mock = mock(MockeryTest_ImplementsIterator::class);
+        $mock = \mock(MockeryTest_ImplementsIterator::class);
         self::assertInstanceOf(Iterator::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
     }
 
     public function testMockingIteratorDoesNotImplementIteratorAlongside(): void
     {
-        $mock = mock(Iterator::class);
+        $mock = \mock(Iterator::class);
         self::assertInstanceOf(Iterator::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
     }
 
     public function testMockingPhpredisExtensionClassWorks(): void
     {
-        if (! class_exists('Redis')) {
+        if (! \class_exists('Redis')) {
             self::markTestSkipped('PHPRedis extension required for this test');
         }
-        self::assertInstanceOf(Redis::class, mock(Redis::class));
+        self::assertInstanceOf(Redis::class, \mock(Redis::class));
     }
 
     public function testNamedMockMultipleInterfaces(): void
     {
-        $m = mock('\stdClass, \ArrayAccess, \Countable', [
+        $m = \mock('\stdClass, \ArrayAccess, \Countable', [
             'foo' => 1,
             'bar' => 2,
         ]);
@@ -1190,15 +1197,15 @@ final class ContainerTest extends MockeryTestCase
         try {
             $m->f();
         } catch (BadMethodCallException $e) {
-            self::assertTrue((bool) preg_match('/stdClass/', $e->getMessage()));
-            self::assertTrue((bool) preg_match('/ArrayAccess/', $e->getMessage()));
-            self::assertTrue((bool) preg_match('/Countable/', $e->getMessage()));
+            self::assertTrue((bool) \preg_match('/stdClass/', $e->getMessage()));
+            self::assertTrue((bool) \preg_match('/ArrayAccess/', $e->getMessage()));
+            self::assertTrue((bool) \preg_match('/Countable/', $e->getMessage()));
         }
     }
 
     public function testNamedMockWithArrayDefs(): void
     {
-        $m = mock(__FUNCTION__, [
+        $m = \mock(__FUNCTION__, [
             'foo' => 1,
             'bar' => 2,
         ]);
@@ -1214,7 +1221,7 @@ final class ContainerTest extends MockeryTestCase
     public function testNamedMockWithArrayDefsCanBeOverridden(): void
     {
         // eg. In shared test setup
-        $m = mock(__FUNCTION__, [
+        $m = \mock(__FUNCTION__, [
             'foo' => 1,
         ]);
 
@@ -1235,7 +1242,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testNamedMockWithConstructorArgs(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()]);
+        $m = \mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()]);
         $m->shouldReceive('foo')
             ->andReturn(123);
         self::assertSame(123, $m->foo());
@@ -1244,7 +1251,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testNamedMockWithConstructorArgsAndArrayDefs(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()], [
+        $m = \mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()], [
             'foo' => 123,
         ]);
         self::assertSame(123, $m->foo());
@@ -1253,14 +1260,14 @@ final class ContainerTest extends MockeryTestCase
 
     public function testNamedMockWithConstructorArgsButNoQuickDefsShouldLeaveConstructorIntact(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
+        $m = \mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
         $m->makePartial();
         self::assertSame($param1, $m->getParam1());
     }
 
     public function testNamedMockWithConstructorArgsWithInternalCallToMockedMethod(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()]);
+        $m = \mock(MockeryTest_ClassConstructor2::class . '[foo]', [$param1 = new stdClass()]);
         $m->shouldReceive('foo')
             ->andReturn(123);
         self::assertSame(123, $m->bar());
@@ -1268,7 +1275,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testNamedMockWithMakePartial(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
+        $m = \mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
         $m->makePartial();
         self::assertSame('foo', $m->bar());
         $m->shouldReceive('bar')
@@ -1278,7 +1285,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testNamedMockWithMakePartialThrowsIfNotAvailable(): void
     {
-        $m = mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
+        $m = \mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
         $m->makePartial();
         $this->expectException(\BadMethodCallException::class);
         $m->foorbar123();
@@ -1287,7 +1294,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testNamedMocksAddNameToExceptions(): void
     {
-        $m = mock(__FUNCTION__);
+        $m = \mock(__FUNCTION__);
         $m->shouldReceive('foo')
             ->with(1)
             ->andReturn('bar');
@@ -1300,7 +1307,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testPartialWithArrayDefs(): void
     {
-        $m = mock(new MockeryTestBar1(), [
+        $m = \mock(new MockeryTestBar1(), [
             'foo' => 1,
             Container::BLOCKS => ['method1'],
         ]);
@@ -1309,7 +1316,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testPassingClosureAsFinalParameterUsedToDefineExpectations(): void
     {
-        $m = mock('foo', static function ($m): void {
+        $m = \mock('foo', static function ($m): void {
             $m->shouldReceive('foo')
                 ->once()
                 ->andReturn('bar');
@@ -1319,7 +1326,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testSettingPropertyOnInstanceMockWillSetItOnActualInstance(): void
     {
-        $m = mock('overload:MyNamespace\MyClass13');
+        $m = \mock('overload:MyNamespace\MyClass13');
         $m->shouldReceive('foo')
             ->andSet('bar', 'baz');
         $instance = new MyClass13();
@@ -1330,7 +1337,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testShouldThrowIfAttemptingToStubPrivateMethod(): void
     {
-        $mock = mock(MockeryTest_WithProtectedAndPrivate::class);
+        $mock = \mock(MockeryTest_WithProtectedAndPrivate::class);
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('privateMethod() cannot be mocked as it is a private method');
         $mock->shouldReceive('privateMethod');
@@ -1338,7 +1345,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testShouldThrowIfAttemptingToStubProtectedMethod(): void
     {
-        $mock = mock(MockeryTest_WithProtectedAndPrivate::class);
+        $mock = \mock(MockeryTest_WithProtectedAndPrivate::class);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -1349,7 +1356,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testSimpleMockWithArrayDefs(): void
     {
-        $m = mock([
+        $m = \mock([
             'foo' => 1,
             'bar' => 2,
         ]);
@@ -1360,7 +1367,7 @@ final class ContainerTest extends MockeryTestCase
     public function testSimpleMockWithArrayDefsCanBeOverridden(): void
     {
         // eg. In shared test setup
-        $m = mock([
+        $m = \mock([
             'foo' => 1,
             'bar' => 2,
         ]);
@@ -1381,7 +1388,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testSimplestMockCreation(): void
     {
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('foo')
             ->andReturn('bar');
         self::assertSame('bar', $m->foo());
@@ -1389,7 +1396,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testSplClassWithFinalMethodsCanBeMocked(): void
     {
-        $m = mock(SplFileInfo::class);
+        $m = \mock(SplFileInfo::class);
         $m->shouldReceive('foo')
             ->andReturn('baz');
         self::assertSame('baz', $m->foo());
@@ -1398,8 +1405,8 @@ final class ContainerTest extends MockeryTestCase
 
     public function testSplClassWithFinalMethodsCanBeMockedMultipleTimes(): void
     {
-        mock(SplFileInfo::class);
-        $m = mock(SplFileInfo::class);
+        \mock(SplFileInfo::class);
+        $m = \mock(SplFileInfo::class);
         $m->shouldReceive('foo')
             ->andReturn('baz');
         self::assertSame('baz', $m->foo());
@@ -1408,7 +1415,7 @@ final class ContainerTest extends MockeryTestCase
 
     public function testSplfileinfoClassMockPassesUserExpectations(): void
     {
-        $file = mock('\SplFileInfo[getFilename,getPathname,getExtension,getMTime]', [__FILE__]);
+        $file = \mock('\SplFileInfo[getFilename,getPathname,getExtension,getMTime]', [__FILE__]);
         $file->shouldReceive('getFilename')
             ->once()
             ->andReturn('foo');
@@ -1420,7 +1427,7 @@ final class ContainerTest extends MockeryTestCase
             ->andReturn('css');
         $file->shouldReceive('getMTime')
             ->once()
-            ->andReturn(time());
+            ->andReturn(\time());
 
         // not sure what this test is for, maybe something special about
         // SplFileInfo
@@ -1444,13 +1451,13 @@ final class ContainerTest extends MockeryTestCase
     {
         $this->expectException(Mockery\Exception::class);
 
-        mock('PartialNormalClassXYZ[foo]');
+        \mock('PartialNormalClassXYZ[foo]');
     }
 
     public function testThrowsExceptionIfSettingExpectationForNonMockedMethodOfPartialMock(): void
     {
         self::markTestSkipped('For now...');
-        $m = mock(MockeryTest_PartialNormalClass::class . '[foo]');
+        $m = \mock(MockeryTest_PartialNormalClass::class . '[foo]');
         self::assertInstanceOf(MockeryTest_PartialNormalClass::class, $m);
         $this->expectException(Mockery\Exception::class);
         $m->shouldReceive('bar')
@@ -1463,47 +1470,32 @@ final class ContainerTest extends MockeryTestCase
         $builder->setName('DateTime');
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not load mock DateTime, class already exists');
-        $mock = mock($builder);
+        $mock = \mock($builder);
     }
 
     public function testUndeclaredClassIsDeclared(): void
     {
-        self::assertFalse(class_exists('BlahBlah'));
-        $mock = mock('BlahBlah');
+        self::assertFalse(\class_exists('BlahBlah'));
+        $mock = \mock('BlahBlah');
         self::assertInstanceOf('\BlahBlah', $mock);
     }
 
     public function testUndeclaredClassWithNamespaceIncludingLeadingOperatorIsDeclared(): void
     {
-        self::assertFalse(class_exists('\MyClasses\DaveBlah\BlahBlah'));
-        $mock = mock('\MyClasses\DaveBlah\BlahBlah');
+        self::assertFalse(\class_exists('\MyClasses\DaveBlah\BlahBlah'));
+        $mock = \mock('\MyClasses\DaveBlah\BlahBlah');
         self::assertInstanceOf('\MyClasses\DaveBlah\BlahBlah', $mock);
     }
 
     public function testUndeclaredClassWithNamespaceIsDeclared(): void
     {
-        self::assertFalse(class_exists('MyClasses\Blah\BlahBlah'));
-        $mock = mock('MyClasses\Blah\BlahBlah');
+        self::assertFalse(\class_exists('MyClasses\Blah\BlahBlah'));
+        $mock = \mock('MyClasses\Blah\BlahBlah');
         self::assertInstanceOf('\MyClasses\Blah\BlahBlah', $mock);
     }
 
     public function testWakeupMagicIsNotMockedToAllowSerialisationInstanceHack(): void
     {
-        self::assertInstanceOf(DateTime::class, mock(DateTime::class));
-    }
-
-    /**
-     * @return Generator<string,array{0: bool, 1: string}>
-     */
-    public static function classNameProvider(): Generator
-    {
-        yield from [
-            'empty string' => [false, ''],
-            'just a space' => [false, ' '],
-            'class name with dot' => [false, 'ClassName.WithDot'],
-            'too many backslashes' => [false, '\\\\TooManyBackSlashes'],
-            'global class name' => [true, 'Foo'],
-            'namespaced class name' => [true, Bar::class],
-        ];
+        self::assertInstanceOf(DateTime::class, \mock(DateTime::class));
     }
 }

--- a/tests/Unit/Mockery/DefaultMatchersTest.php
+++ b/tests/Unit/Mockery/DefaultMatchersTest.php
@@ -12,8 +12,6 @@ use PHP73\CustomValueObject;
 use PHP73\CustomValueObjectInterface;
 use PHP73\CustomValueObjectMatcher;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -23,7 +21,7 @@ final class DefaultMatchersTest extends MockeryTestCase
 
     protected function mockeryTestSetUp(): void
     {
-        $this->mock = mock('foo');
+        $this->mock = \mock('foo');
     }
 
     public function mockeryTestTearDown(): void

--- a/tests/Unit/Mockery/DemeterChainTest.php
+++ b/tests/Unit/Mockery/DemeterChainTest.php
@@ -38,7 +38,7 @@ final class DemeterChainTest extends MockeryTestCase
             ->once()
             ->andReturn('somethingElse');
 
-        self::assertEquals('somethingElse', $this->mock->getElement()->getFirst());
+        self::assertSame('somethingElse', $this->mock->getElement()->getFirst());
     }
 
     public function testDemeterChainsWithClassReturnTypeHints(): void
@@ -77,8 +77,8 @@ final class DemeterChainTest extends MockeryTestCase
         $this->mock->shouldReceive('levelOne->levelTwo->getSecond')
             ->andReturn('second');
 
-        self::assertEquals('second', $this->mock->levelOne() ->levelTwo() ->getSecond());
-        self::assertEquals('first', $this->mock->levelOne() ->levelTwo() ->getFirst());
+        self::assertSame('second', $this->mock->levelOne() ->levelTwo() ->getSecond());
+        self::assertSame('first', $this->mock->levelOne() ->levelTwo() ->getFirst());
     }
 
     public function testMultipleDemeterChainsWithClassReturnTypeHints(): void
@@ -90,8 +90,8 @@ final class DemeterChainTest extends MockeryTestCase
             ->andReturn($bar);
         $a->shouldReceive('foo->qux')
             ->andReturn($qux);
-        self::assertEquals($bar, $a->foo()->bar());
-        self::assertEquals($qux, $a->foo()->qux());
+        self::assertSame($bar, $a->foo()->bar());
+        self::assertSame($qux, $a->foo()->qux());
     }
 
     public function testSimilarDemeterChainsOnDifferentClasses(): void
@@ -108,10 +108,10 @@ final class DemeterChainTest extends MockeryTestCase
         $mock2->shouldReceive('select->some->other->data')
             ->andReturn(4);
 
-        self::assertEquals(1, mock1::select()->some()->data());
-        self::assertEquals(2, mock1::select()->some()->other()->data());
-        self::assertEquals(3, mock2::select()->some()->data());
-        self::assertEquals(4, mock2::select()->some()->other()->data());
+        self::assertSame(1, mock1::select()->some()->data());
+        self::assertSame(2, mock1::select()->some()->other()->data());
+        self::assertSame(3, mock2::select()->some()->data());
+        self::assertSame(4, mock2::select()->some()->other()->data());
     }
 
     public function testThreeChains(): void
@@ -124,12 +124,12 @@ final class DemeterChainTest extends MockeryTestCase
             ->once()
             ->andReturn('somethingElse');
 
-        self::assertEquals('something', $this->mock->getElement() ->getFirst());
-        self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond());
+        self::assertSame('something', $this->mock->getElement() ->getFirst());
+        self::assertSame('somethingElse', $this->mock->getElement() ->getSecond());
         $this->mock->shouldReceive('getElement->getFirst')
             ->once()
             ->andReturn('somethingNew');
-        self::assertEquals('somethingNew', $this->mock->getElement() ->getFirst());
+        self::assertSame('somethingNew', $this->mock->getElement() ->getFirst());
     }
 
     public function testTwoChains(): void
@@ -142,8 +142,8 @@ final class DemeterChainTest extends MockeryTestCase
             ->once()
             ->andReturn('somethingElse');
 
-        self::assertEquals('something', $this->mock->getElement() ->getFirst());
-        self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond());
+        self::assertSame('something', $this->mock->getElement() ->getFirst());
+        self::assertSame('somethingElse', $this->mock->getElement() ->getSecond());
         $this->mock->mockery_getContainer()
             ->mockery_close();
     }
@@ -160,8 +160,8 @@ final class DemeterChainTest extends MockeryTestCase
             ->with('secondParameter')
             ->andReturn('somethingElse');
 
-        self::assertEquals('something', $this->mock->getElement() ->getFirst('parameter'));
-        self::assertEquals('somethingElse', $this->mock->getElement() ->getSecond('secondParameter'));
+        self::assertSame('something', $this->mock->getElement() ->getFirst('parameter'));
+        self::assertSame('somethingElse', $this->mock->getElement() ->getSecond('secondParameter'));
         $this->mock->mockery_getContainer()
             ->mockery_close();
     }
@@ -176,7 +176,7 @@ final class DemeterChainTest extends MockeryTestCase
             ->once()
             ->andReturn('somethingElse');
 
-        self::assertEquals('somethingElse', $this->mock->getOtherElement() ->getSecond());
-        self::assertEquals('something', $this->mock->getElement()->getFirst());
+        self::assertSame('somethingElse', $this->mock->getOtherElement() ->getSecond());
+        self::assertSame('something', $this->mock->getElement()->getFirst());
     }
 }

--- a/tests/Unit/Mockery/ExpectationTest.php
+++ b/tests/Unit/Mockery/ExpectationTest.php
@@ -29,14 +29,6 @@ use PHP73\MockeryTest_SubjectCall1;
 use PHP73\MyService2;
 use stdClass;
 
-use function dirname;
-use function fopen;
-use function get_class;
-use function is_array;
-use function iterator_to_array;
-use function ksort;
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -46,7 +38,7 @@ final class ExpectationTest extends MockeryTestCase
 
     protected function mockeryTestSetUp(): void
     {
-        $this->mock = mock('Foo');
+        $this->mock = \mock('Foo');
     }
 
     public function mockeryTestTearDown(): void
@@ -56,7 +48,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testAnExampleWithSomeExpectationAmends(): void
     {
-        $service = mock('MyService');
+        $service = \mock('MyService');
         $service->shouldReceive('login')
             ->with('user', 'pass')
             ->once()
@@ -82,7 +74,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testAnExampleWithSomeExpectationAmendsOnCallCounts(): void
     {
-        $service = mock('MyService');
+        $service = \mock('MyService');
         $service->shouldReceive('login')
             ->with('user', 'pass')
             ->once()
@@ -110,7 +102,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testAnExampleWithSomeExpectationAmendsOnCallCountsPHPUnitTest(): void
     {
         /** @var MockInterface $service */
-        $service = mock(MyService2::class);
+        $service = \mock(MyService2::class);
 
         $service->expects('login')
             ->once()
@@ -158,8 +150,8 @@ final class ExpectationTest extends MockeryTestCase
             ->with('a', Mockery::andAnyOthers())->andReturn('a');
         $this->mock->shouldReceive('foo')
             ->with('b', Mockery::andAnyOthers())->andReturn('b');
-        self::assertEquals('a', $this->mock->foo('a'));
-        self::assertEquals('b', $this->mock->foo('b'));
+        self::assertSame('a', $this->mock->foo('a'));
+        self::assertSame('b', $this->mock->foo('b'));
     }
 
     public function testAndThrowExceptions(): void
@@ -207,7 +199,7 @@ final class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')
             ->andYield(1, 2, 3);
-        self::assertSame([1, 2, 3], iterator_to_array($this->mock->foo()));
+        self::assertSame([1, 2, 3], \iterator_to_array($this->mock->foo()));
     }
 
     /**
@@ -375,7 +367,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testByDefaultOnAMockDoesSquatWithoutExpectations(): void
     {
-        self::assertInstanceOf(MockInterface::class, mock('f')->byDefault());
+        self::assertInstanceOf(MockInterface::class, \mock('f')->byDefault());
     }
 
     public function testByDefaultOperatesFromMockConstruction(): void
@@ -388,9 +380,9 @@ final class ExpectationTest extends MockeryTestCase
         ])->byDefault();
         $mock->shouldReceive('foo')
             ->andReturn('foobar');
-        self::assertEquals('foobar', $mock->foo());
-        self::assertEquals('rbar', $mock->bar());
-        self::assertEquals('rbaz', $mock->baz());
+        self::assertSame('foobar', $mock->foo());
+        self::assertSame('rbar', $mock->bar());
+        self::assertSame('rbaz', $mock->baz());
     }
 
     public function testByDefaultPreventedFromSettingDefaultWhenDefaultingExpectationWasReplaced(): void
@@ -768,8 +760,8 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->andReturn('baz')
             ->twice();
-        self::assertEquals('baz', $this->mock->foo());
-        self::assertEquals('baz', $this->mock->foo());
+        self::assertSame('baz', $this->mock->foo());
+        self::assertSame('baz', $this->mock->foo());
     }
 
     public function testDefaultExpectationsCanBeOrdered(): void
@@ -815,7 +807,7 @@ final class ExpectationTest extends MockeryTestCase
             ->andReturn('newbar')
             ->byDefault();
         $this->mock->foo('test');
-        self::assertEquals('newbar', $this->mock->foo('test'));
+        self::assertSame('newbar', $this->mock->foo('test'));
     }
 
     public function testDefaultExpectationsValidatedInCorrectOrder(): void
@@ -830,8 +822,8 @@ final class ExpectationTest extends MockeryTestCase
             ->once()
             ->andReturn('second')
             ->byDefault();
-        self::assertEquals('first', $this->mock->foo(1));
-        self::assertEquals('second', $this->mock->foo(2));
+        self::assertSame('first', $this->mock->foo(1));
+        self::assertSame('second', $this->mock->foo(2));
     }
 
     public function testDifferentArgumentsAndOrderingsPassWithoutException(): void
@@ -921,7 +913,7 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->globally()
             ->ordered();
-        $mock2 = mock('bar');
+        $mock2 = \mock('bar');
         $mock2->shouldReceive('bar')
             ->globally()
             ->ordered();
@@ -936,7 +928,7 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->ordered()
             ->once();
-        $mock2 = mock('bar');
+        $mock2 = \mock('bar');
         $mock2->shouldReceive('bar')
             ->ordered()
             ->once();
@@ -978,8 +970,8 @@ final class ExpectationTest extends MockeryTestCase
             ->andReturn('green');
         $this->mock->shouldReceive('foo')
             ->andReturn('blue');
-        self::assertEquals('green', $this->mock->foo());
-        self::assertEquals('blue', $this->mock->foo());
+        self::assertSame('green', $this->mock->foo());
+        self::assertSame('blue', $this->mock->foo());
     }
 
     public function testExpectationCastToStringFormatting(): void
@@ -989,7 +981,7 @@ final class ExpectationTest extends MockeryTestCase
                 'Spam' => 'Ham',
                 'Bar' => 'Baz',
             ]);
-        self::assertEquals("[foo(1, 'bar', object(stdClass), ['Spam' => 'Ham', 'Bar' => 'Baz'])]", (string) $exp);
+        self::assertSame("[foo(1, 'bar', object(stdClass), ['Spam' => 'Ham', 'Bar' => 'Baz'])]", (string) $exp);
     }
 
     public function testExpectationFallsBackToDefaultExpectationWhenConcreteExpectationsAreUsedUp(): void
@@ -1003,8 +995,8 @@ final class ExpectationTest extends MockeryTestCase
             ->with(2)
             ->andReturn('baz')
             ->once();
-        self::assertEquals('baz', $this->mock->foo(2));
-        self::assertEquals('bar', $this->mock->foo(1));
+        self::assertSame('baz', $this->mock->foo(2));
+        self::assertSame('bar', $this->mock->foo(1));
     }
 
     public function testExpectationMatchingWithAnyArgsOrderings(): void
@@ -1050,7 +1042,7 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->andReturn('bar')
             ->byDefault();
-        self::assertEquals('bar', $this->mock->foo());
+        self::assertSame('bar', $this->mock->foo());
     }
 
     public function testExpectsAnyArguments(): void
@@ -1286,7 +1278,7 @@ final class ExpectationTest extends MockeryTestCase
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage("Mockery can't find 'SomeMadeUpClass' so can't mock it");
-        $mock = mock('SomeMadeUpClass');
+        $mock = \mock('SomeMadeUpClass');
         $mock->shouldReceive('foo');
         Mockery::close();
     }
@@ -1294,7 +1286,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnClasses(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(stdClass::class);
+        $mock = \mock(stdClass::class);
         $this->expectException(Exception::class);
         $mock->shouldReceive('foo');
         Mockery::close();
@@ -1303,7 +1295,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigMayForbidMockingNonExistentMethodsOnObjects(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(new stdClass());
+        $mock = \mock(new stdClass());
         $this->expectException(Exception::class);
         $mock->shouldReceive('foo');
         Mockery::close();
@@ -1312,7 +1304,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigQuickDefinitionsConfigurationDefaultExpectation(): void
     {
         Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(false);
-        mock([
+        \mock([
             'foo' => 1,
         ]);
         $this->expectNotToPerformAssertions();
@@ -1322,7 +1314,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testGlobalConfigQuickDefinitionsConfigurationMockAtLeastOnce(): void
     {
         Mockery::getConfiguration()->getQuickDefinitions()->shouldBeCalledAtLeastOnce(true);
-        mock([
+        \mock([
             'foo' => 1,
         ]);
         $this->expectException(InvalidCountException::class);
@@ -1354,12 +1346,12 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->with(2)
             ->andReturn('infinity');
-        self::assertEquals('first', $this->mock->foo(2));
-        self::assertEquals('second/third', $this->mock->foo(2));
-        self::assertEquals('second/third', $this->mock->foo(2));
-        self::assertEquals('infinity', $this->mock->foo(2));
-        self::assertEquals('infinity', $this->mock->foo(2));
-        self::assertEquals('infinity', $this->mock->foo(2));
+        self::assertSame('first', $this->mock->foo(2));
+        self::assertSame('second/third', $this->mock->foo(2));
+        self::assertSame('second/third', $this->mock->foo(2));
+        self::assertSame('infinity', $this->mock->foo(2));
+        self::assertSame('infinity', $this->mock->foo(2));
+        self::assertSame('infinity', $this->mock->foo(2));
     }
 
     public function testGroupedUngroupedOrderingDoNotOverlap(): void
@@ -1448,11 +1440,11 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testIfCallingMethodWithNoExpectationsHasSpecificExceptionMessage(): void
     {
-        $mock = mock(Mockery_Duck::class);
+        $mock = \mock(Mockery_Duck::class);
 
         $this->expectException(
             BadMethodCallException::class,
-            'Received ' . get_class($mock) .
+            'Received ' . \get_class($mock) .
             '::quack(), ' . 'but no expectations were specified'
         );
 
@@ -1462,11 +1454,11 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testIfExceptionIndicatesAbsenceOfMethodAndExpectationsOnMock(): void
     {
-        $mock = mock(Mockery_Duck::class);
+        $mock = \mock(Mockery_Duck::class);
 
         $this->expectException(
             BadMethodCallException::class,
-            'Method ' . get_class($mock) .
+            'Method ' . \get_class($mock) .
             '::nonExistent() does not exist on this mock object'
         );
 
@@ -1702,7 +1694,7 @@ final class ExpectationTest extends MockeryTestCase
                 'Baz',
                 'End',
             ]);
-        self::assertEquals(
+        self::assertSame(
             "[foo(['Spam' => 'Ham', 'Bar' => 'Baz', 0 => 'Bar', 1 => 'Baz', 2 => 'Bar', 3 => 'Baz', 4 => 'Bar', 5 => 'Baz', 6 => 'Bar', 7 => 'Baz', 8 => 'Bar', 9 => 'Baz', 10 => 'Bar', 11 => 'Baz', 12 => 'Bar', 13 => 'Baz', 14 => 'Bar', 15 => 'Baz', 16 => 'Bar', 17 => 'Baz', 18 => 'Bar', 19 => 'Baz', 20 => 'Bar', 21 => 'Baz', 22 => 'Bar', 23 => 'Baz', 24 => 'Bar', 25 => 'Baz', 26 => 'Bar', 27 => 'Baz', 28 => 'Bar', 29 => 'Baz', 30 => 'Bar', 31 => 'Baz', 32 => 'Bar', 33 => 'Baz', 34 => 'Bar', 35 => 'Baz', 36 => 'Bar', 37 => 'Baz', 38 => 'Bar', 39 => 'Baz', 40 => 'Bar', 41 => 'Baz', 42 => 'Bar', 43 => 'Baz', 44 => 'Bar', 45 => 'Baz', 46 => 'Baz', 47 => 'Bar', 48 => 'Baz', 49 => 'Bar', 50 => 'Baz', 51 => 'Bar', 52 => 'Baz', 53 => 'Bar', 54 => 'Baz', 55 => 'Bar', 56 => 'Baz', 57 => 'Baz', 58 => 'Bar', 59 => 'Baz', 60 => 'Bar', 61 => 'Baz', 62 => 'Bar', 63 => 'Baz', 64 => 'Bar', 65 => 'Baz', 66 => 'Bar', 67 => 'Baz', 68 => 'Baz', 69 => 'Bar', 70 => 'Baz', 71 => 'Bar', 72 => 'Baz', 73 => 'Bar', 74 => 'Baz', 7...])]",
             (string) $exp
         );
@@ -1710,27 +1702,27 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testMakePartialExpectationBasedOnArgs(): void
     {
-        $mock = mock(MockeryTest_SubjectCall1::class)->makePartial();
+        $mock = \mock(MockeryTest_SubjectCall1::class)->makePartial();
 
-        self::assertEquals('bar', $mock->foo());
-        self::assertEquals('bar', $mock->foo('baz'));
-        self::assertEquals('bar', $mock->foo('qux'));
+        self::assertSame('bar', $mock->foo());
+        self::assertSame('bar', $mock->foo('baz'));
+        self::assertSame('bar', $mock->foo('qux'));
 
         $mock->shouldReceive('foo')
             ->with('baz')
             ->twice()
             ->andReturn('123');
-        self::assertEquals('bar', $mock->foo());
-        self::assertEquals('123', $mock->foo('baz'));
-        self::assertEquals('bar', $mock->foo('qux'));
+        self::assertSame('bar', $mock->foo());
+        self::assertSame('123', $mock->foo('baz'));
+        self::assertSame('bar', $mock->foo('qux'));
 
         $mock->shouldReceive('foo')
             ->withNoArgs()
             ->once()
             ->andReturn('456');
-        self::assertEquals('456', $mock->foo());
-        self::assertEquals('123', $mock->foo('baz'));
-        self::assertEquals('bar', $mock->foo('qux'));
+        self::assertSame('456', $mock->foo());
+        self::assertSame('123', $mock->foo('baz'));
+        self::assertSame('bar', $mock->foo('qux'));
     }
 
     public function testMatchPrecedenceBasedOnExpectedCallsFavouringAnyMatch(): void
@@ -1755,13 +1747,13 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testMockShouldNotBeAnonymousWhenImplementingSpecificInterface(): void
     {
-        $waterMock = mock(IWater::class);
+        $waterMock = \mock(IWater::class);
         self::assertFalse($waterMock->mockery_isAnonymous());
     }
 
     public function testMockedMethodsCallableFromWithinOriginalClass(): void
     {
-        $mock = mock(MockeryTest_InterMethod1::class . '[doThird]');
+        $mock = \mock(MockeryTest_InterMethod1::class . '[doThird]');
         $mock->shouldReceive('doThird')
             ->andReturn(true);
         self::assertTrue($mock->doFirst());
@@ -1769,7 +1761,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testMockingDemeterChainsPassesMockeryExpectationToCompositeExpectation(): void
     {
-        $mock = mock(Mockery_Demeterowski::class);
+        $mock = \mock(Mockery_Demeterowski::class);
         $mock->shouldReceive('foo->bar->baz')
             ->andReturn('Spam!');
         $demeter = new Mockery_UseDemeter($mock);
@@ -1778,7 +1770,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testMockingDemeterChainsPassesMockeryExpectationToCompositeExpectationWithArgs(): void
     {
-        $mock = mock(Mockery_Demeterowski::class);
+        $mock = \mock(Mockery_Demeterowski::class);
         $mock->shouldReceive('foo->bar->baz')
             ->andReturn('Spam!');
         $demeter = new Mockery_UseDemeter($mock);
@@ -1789,7 +1781,7 @@ final class ExpectationTest extends MockeryTestCase
     {
         $exp = $this->mock->shouldReceive('foo', 'bar')
             ->with(1);
-        self::assertEquals('[foo(1), bar(1)]', (string) $exp);
+        self::assertSame('[foo(1), bar(1)]', (string) $exp);
     }
 
     public function testMultipleExpectationsWithReturns(): void
@@ -1800,8 +1792,8 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('bar')
             ->with(2)
             ->andReturn(20);
-        self::assertEquals(10, $this->mock->foo(1));
-        self::assertEquals(20, $this->mock->bar(2));
+        self::assertSame(10, $this->mock->foo(1));
+        self::assertSame(20, $this->mock->bar(2));
     }
 
     public function testMustBeConstraintMatchesArgument(): void
@@ -1898,7 +1890,7 @@ final class ExpectationTest extends MockeryTestCase
             ->andReturn('foobar');
 
         // only sort the input to change the order but not the values.
-        ksort($input);
+        \ksort($input);
 
         self::assertSame('foobar', $foo->foo($input));
     }
@@ -2051,7 +2043,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testOnConstraintMatchesArgumentOfTypeArrayClosureEvaluatesToTrue(): void
     {
         $function = function ($arg) {
-            return is_array($arg);
+            return \is_array($arg);
         };
         $this->mock->shouldReceive('foo')
             ->with(Mockery::on($function))->once();
@@ -2072,7 +2064,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testOptionalMockRetrieval(): void
     {
-        $m = mock('f')
+        $m = \mock('f')
             ->shouldReceive('foo')
             ->with(1)
             ->andReturn(3)
@@ -2172,7 +2164,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testPassthruCallMagic(): void
     {
-        $mock = mock(Mockery_Magic::class);
+        $mock = \mock(Mockery_Magic::class);
         $mock->shouldReceive('theAnswer')
             ->once()
             ->passthru();
@@ -2181,11 +2173,11 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testPassthruEnsuresRealMethodCalledForReturnValues(): void
     {
-        $mock = mock(MockeryTest_SubjectCall1::class);
+        $mock = \mock(MockeryTest_SubjectCall1::class);
         $mock->shouldReceive('foo')
             ->once()
             ->passthru();
-        self::assertEquals('bar', $mock->foo());
+        self::assertSame('bar', $mock->foo());
     }
 
     public function testPatternConstraintMatchesArgument(): void
@@ -2244,7 +2236,7 @@ final class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')
             ->with(Mockery::type('resource'))->once();
-        $r = fopen(dirname(__FILE__, 3) . '/Fixture/_files/file.txt', 'rb');
+        $r = \fopen(\dirname(__FILE__, 3) . '/Fixture/_files/file.txt', 'rb');
         $this->mock->foo($r);
     }
 
@@ -2307,7 +2299,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testReturnsNullForMockedExistingClassIfAndReturnNullCalled(): void
     {
-        $mock = mock(MockeryTest_Foo::class);
+        $mock = \mock(MockeryTest_Foo::class);
         $mock->shouldReceive('foo')
             ->andReturn(null);
         self::assertNull($mock->foo());
@@ -2315,7 +2307,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testReturnsNullForMockedExistingClassIfNullIsReturnValue(): void
     {
-        $mock = mock(MockeryTest_Foo::class);
+        $mock = \mock(MockeryTest_Foo::class);
         $mock->shouldReceive('foo')
             ->andReturnNull();
         self::assertNull($mock->foo());
@@ -2350,14 +2342,14 @@ final class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('foo')
             ->andReturn(1);
-        self::assertEquals(1, $this->mock->foo());
+        self::assertSame(1, $this->mock->foo());
     }
 
     public function testReturnsSameValueForAllIfNoArgsExpectationAndSomeGiven(): void
     {
         $this->mock->shouldReceive('foo')
             ->andReturn(1);
-        self::assertEquals(1, $this->mock->foo('foo'));
+        self::assertSame(1, $this->mock->foo('foo'));
     }
 
     public function testReturnsTrueIfTrueIsReturnValue(): void
@@ -2379,7 +2371,7 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->andReturn(1, 2, 3);
         $this->mock->foo('foo');
-        self::assertEquals(2, $this->mock->foo('foo'));
+        self::assertSame(2, $this->mock->foo('foo'));
     }
 
     public function testReturnsValueFromSequenceSequentiallyAndRepeatedlyReturnsFinalValueOnExtraCalls(): void
@@ -2388,8 +2380,8 @@ final class ExpectationTest extends MockeryTestCase
             ->andReturn(1, 2, 3);
         $this->mock->foo('foo');
         $this->mock->foo('foo');
-        self::assertEquals(3, $this->mock->foo('foo'));
-        self::assertEquals(3, $this->mock->foo('foo'));
+        self::assertSame(3, $this->mock->foo('foo'));
+        self::assertSame(3, $this->mock->foo('foo'));
     }
 
     public function testReturnsValueFromSequenceSequentiallyAndRepeatedlyReturnsFinalValueOnExtraCallsWithManyAndReturnCalls(): void
@@ -2399,8 +2391,8 @@ final class ExpectationTest extends MockeryTestCase
             ->andReturn(2, 3);
         $this->mock->foo('foo');
         $this->mock->foo('foo');
-        self::assertEquals(3, $this->mock->foo('foo'));
-        self::assertEquals(3, $this->mock->foo('foo'));
+        self::assertSame(3, $this->mock->foo('foo'));
+        self::assertSame(3, $this->mock->foo('foo'));
     }
 
     public function testReturnsValueOfArgument(): void
@@ -2410,7 +2402,7 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->shouldReceive('foo')
             ->withArgs($args)
             ->andReturnArg($index);
-        self::assertEquals($args[$index], $this->mock->foo(...$args));
+        self::assertSame($args[$index], $this->mock->foo(...$args));
     }
 
     public function testReturnsValueOfClosure(): void
@@ -2420,16 +2412,16 @@ final class ExpectationTest extends MockeryTestCase
             ->andReturnUsing(function ($v) {
                 return $v + 1;
             });
-        self::assertEquals(6, $this->mock->foo(5));
+        self::assertSame(6, $this->mock->foo(5));
     }
 
     public function testReturnsValuesSetAsArray(): void
     {
         $this->mock->shouldReceive('foo')
             ->andReturnValues([1, 2, 3]);
-        self::assertEquals(1, $this->mock->foo());
-        self::assertEquals(2, $this->mock->foo());
-        self::assertEquals(3, $this->mock->foo());
+        self::assertSame(1, $this->mock->foo());
+        self::assertSame(2, $this->mock->foo());
+        self::assertSame(3, $this->mock->foo());
     }
 
     public function testScalarConstraintMatchesArgument(): void
@@ -2461,8 +2453,8 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testSetsPublicPropertiesCorrectlyForDifferentInstancesOfSameClass(): void
     {
-        $mockInstanceOne = mock(MockeryTest_Foo::class);
-        $mockInstanceTwo = mock(MockeryTest_Foo::class);
+        $mockInstanceOne = \mock(MockeryTest_Foo::class);
+        $mockInstanceTwo = \mock(MockeryTest_Foo::class);
 
         $mockInstanceOne->shouldReceive('foo')
             ->andSet('bar', 'baz');
@@ -2473,8 +2465,8 @@ final class ExpectationTest extends MockeryTestCase
         $mockInstanceOne->foo();
         $mockInstanceTwo->foo();
 
-        self::assertEquals('baz', $mockInstanceOne->bar);
-        self::assertEquals('bazz', $mockInstanceTwo->bar);
+        self::assertSame('baz', $mockInstanceOne->bar);
+        self::assertSame('bazz', $mockInstanceTwo->bar);
     }
 
     public function testSetsPublicPropertiesWhenRequested(): void
@@ -2484,11 +2476,11 @@ final class ExpectationTest extends MockeryTestCase
             ->andSet('bar', 'baz', 'bazz', 'bazzz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazzz', $this->mock->bar);
+        self::assertSame('bazzz', $this->mock->bar);
     }
 
     public function testSetsPublicPropertiesWhenRequestedMoreTimesThanSetValues(): void
@@ -2498,11 +2490,11 @@ final class ExpectationTest extends MockeryTestCase
             ->andSet('bar', 'baz', 'bazz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
     }
 
     public function testSetsPublicPropertiesWhenRequestedMoreTimesThanSetValuesUsingAlias(): void
@@ -2512,11 +2504,11 @@ final class ExpectationTest extends MockeryTestCase
             ->andSet('bar', 'baz', 'bazz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
     }
 
     public function testSetsPublicPropertiesWhenRequestedMoreTimesThanSetValuesWithDirectSet(): void
@@ -2526,9 +2518,9 @@ final class ExpectationTest extends MockeryTestCase
             ->andSet('bar', 'baz', 'bazz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
         $this->mock->bar = null;
         $this->mock->foo();
         self::assertNull($this->mock->bar);
@@ -2541,9 +2533,9 @@ final class ExpectationTest extends MockeryTestCase
             ->set('bar', 'baz', 'bazz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
         $this->mock->bar = null;
         $this->mock->foo();
         self::assertNull($this->mock->bar);
@@ -2556,11 +2548,11 @@ final class ExpectationTest extends MockeryTestCase
             ->set('bar', 'baz', 'bazz', 'bazzz');
         self::assertEmpty($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazz', $this->mock->bar);
+        self::assertSame('bazz', $this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('bazzz', $this->mock->bar);
+        self::assertSame('bazzz', $this->mock->bar);
     }
 
     public function testSetsPublicPropertyWhenRequested(): void
@@ -2570,7 +2562,7 @@ final class ExpectationTest extends MockeryTestCase
             ->andSet('bar', 'baz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
     }
 
     public function testSetsPublicPropertyWhenRequestedUsingAlias(): void
@@ -2580,7 +2572,7 @@ final class ExpectationTest extends MockeryTestCase
             ->set('bar', 'baz');
         self::assertNull($this->mock->bar);
         $this->mock->foo();
-        self::assertEquals('baz', $this->mock->bar);
+        self::assertSame('baz', $this->mock->bar);
     }
 
     public function testShouldIgnoreMissingAsDefinedProxiesToUndefinedAllowingToString(): void
@@ -2599,7 +2591,7 @@ final class ExpectationTest extends MockeryTestCase
     public function testShouldIgnoreMissingDefaultReturnValue(): void
     {
         $this->mock->shouldIgnoreMissing(1);
-        self::assertEquals(1, $this->mock->a());
+        self::assertSame(1, $this->mock->a());
     }
 
     /**
@@ -2613,7 +2605,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testShouldIgnoreMissingExpectationBasedOnArgs(): void
     {
-        $mock = mock(MyService2::class)->shouldIgnoreMissing();
+        $mock = \mock(MyService2::class)->shouldIgnoreMissing();
         $mock->shouldReceive('hasBookmarksTagged')
             ->with('dave')
             ->once();
@@ -2633,7 +2625,7 @@ final class ExpectationTest extends MockeryTestCase
 
     public function testShouldNotReceiveCanBeAddedToCompositeExpectation(): void
     {
-        $mock = mock('Foo');
+        $mock = \mock('Foo');
         $mock->shouldReceive('a')
             ->once()
             ->andReturn('Spam!')
@@ -2710,7 +2702,7 @@ final class ExpectationTest extends MockeryTestCase
         try {
             $this->mock->foo();
         } catch (OutOfBoundsException $e) {
-            self::assertEquals('foo', $e->getMessage());
+            self::assertSame('foo', $e->getMessage());
         }
     }
 
@@ -2781,7 +2773,7 @@ final class ExpectationTest extends MockeryTestCase
     {
         $this->mock->shouldReceive('__toString')
             ->andReturn('dave');
-        self::assertEquals("{$this->mock}", 'dave');
+        self::assertSame("{$this->mock}", 'dave');
     }
 
     public function testUnorderedCallsIgnoredForOrdering(): void

--- a/tests/Unit/Mockery/Generator/MockConfigurationBuilderTest.php
+++ b/tests/Unit/Mockery/Generator/MockConfigurationBuilderTest.php
@@ -21,7 +21,7 @@ final class MockConfigurationBuilderTest extends TestCase
         $methods = $builder->getMockConfiguration()
             ->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('foo', $methods[0]->getName());
+        self::assertSame('foo', $methods[0]->getName());
     }
 
     public function testReservedWordsAreBlackListedByDefault(): void
@@ -41,6 +41,6 @@ final class MockConfigurationBuilderTest extends TestCase
         $methods = $builder->getMockConfiguration()
             ->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('foo', $methods[0]->getName());
+        self::assertSame('foo', $methods[0]->getName());
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
@@ -9,8 +9,6 @@ use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\CallTypeHintPass;
 use PHPUnit\Framework\TestCase;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -27,7 +25,7 @@ final class CallTypeHintPassTest extends TestCase
             'requiresCallStaticTypeHintRemoval' => true,
         ])->makePartial();
         $code = $pass->apply(self::CODE, $config);
-        self::assertNotFalse(mb_strpos($code, '__callStatic($method, $args)'));
+        self::assertNotFalse(\mb_strpos($code, '__callStatic($method, $args)'));
     }
 
     public function testShouldRemoveCallTypeHintIfRequired(): void
@@ -37,6 +35,6 @@ final class CallTypeHintPassTest extends TestCase
             'requiresCallTypeHintRemoval' => true,
         ])->makePartial();
         $code = $pass->apply(self::CODE, $config);
-        self::assertNotFalse(mb_strpos($code, '__call($method, $args)'));
+        self::assertNotFalse(\mb_strpos($code, '__call($method, $args)'));
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Mockery\Generator\StringManipulation\Pass;
 
-use Generator;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\ClassAttributesPass;
 use Mockery\Generator\UndefinedTargetClass;
-
-use function file_get_contents;
-use function mock;
 
 /**
  * @coversDefaultClass \Mockery
@@ -23,7 +19,7 @@ class ClassAttributesPassTest extends MockeryTestCase
     /**
      * @see testCanApplyClassAttributes
      */
-    public static function providerCanApplyClassAttributes(): Generator
+    public static function provideCanApplyClassAttributesCases(): iterable
     {
         yield 'has no attributes' => [
             'attributes' => [],
@@ -42,23 +38,23 @@ class ClassAttributesPassTest extends MockeryTestCase
     }
 
     /**
-     * @dataProvider providerCanApplyClassAttributes
+     * @dataProvider provideCanApplyClassAttributesCases
      */
     public function testCanApplyClassAttributes(array $attributes, string $expected): void
     {
-        $undefinedTargetClass = mock(UndefinedTargetClass::class);
+        $undefinedTargetClass = \mock(UndefinedTargetClass::class);
         $undefinedTargetClass->expects('getAttributes')
             ->once()
             ->andReturn($attributes);
 
-        $config = mock(MockConfiguration::class);
+        $config = \mock(MockConfiguration::class);
         $config->expects('getTargetClass')
             ->once()
             ->andReturn($undefinedTargetClass);
 
         $pass = new ClassAttributesPass();
 
-        $code = $pass->apply(file_get_contents(__FILE__), $config);
+        $code = $pass->apply(\file_get_contents(__FILE__), $config);
 
         self::assertStringContainsString($expected, $code);
     }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassNamePassTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\ClassNamePass;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -28,7 +26,7 @@ final class ClassNamePassTest extends MockeryTestCase
     {
         $config = new MockConfiguration([], [], [], 'Dave\Dave');
         $code = $this->pass->apply(static::CODE, $config);
-        self::assertNotFalse(mb_strpos($code, 'namespace Dave;'));
+        self::assertNotFalse(\mb_strpos($code, 'namespace Dave;'));
     }
 
     public function testShouldRemoveNamespaceDefinition(): void
@@ -36,21 +34,21 @@ final class ClassNamePassTest extends MockeryTestCase
         $config = new MockConfiguration([], [], [], 'Dave\Dave');
         $code = $this->pass->apply(self::CODE, $config);
 
-        self::assertFalse(mb_strpos($code, 'namespace Mockery;'));
+        self::assertFalse(\mb_strpos($code, 'namespace Mockery;'));
     }
 
     public function testShouldReplaceClassNameWithSpecifiedName(): void
     {
         $config = new MockConfiguration([], [], [], 'Dave');
         $code = $this->pass->apply(static::CODE, $config);
-        self::assertNotFalse(mb_strpos($code, 'class Dave'));
+        self::assertNotFalse(\mb_strpos($code, 'class Dave'));
     }
 
     public function testShouldReplaceNamespaceIfClassNameIsNamespaced(): void
     {
         $config = new MockConfiguration([], [], [], 'Dave\Dave');
         $code = $this->pass->apply(self::CODE, $config);
-        self::assertFalse(mb_strpos($code, 'namespace Mockery;'));
-        self::assertNotFalse(mb_strpos($code, 'namespace Dave;'));
+        self::assertFalse(\mb_strpos($code, 'namespace Mockery;'));
+        self::assertNotFalse(\mb_strpos($code, 'namespace Dave;'));
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassPassTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\ClassPass;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -30,6 +28,6 @@ final class ClassPassTest extends MockeryTestCase
 
         $code = $this->pass->apply(self::CODE, $config);
 
-        self::assertNotFalse(mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface'));
+        self::assertNotFalse(\mb_strpos($code, 'class Mock extends \Testing\TestClass implements MockInterface'));
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/ConstantsPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/ConstantsPassTest.php
@@ -9,8 +9,6 @@ use Mockery\Generator\StringManipulation\Pass\ConstantsPass;
 use PHP73\ClassWithConstants;
 use PHPUnit\Framework\TestCase;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -39,6 +37,6 @@ final class ConstantsPassTest extends TestCase
 
         $code = $pass->apply(static::CODE, $config);
 
-        self::assertNotFalse(mb_strpos($code, "const FOO = 'test'"));
+        self::assertNotFalse(\mb_strpos($code, "const FOO = 'test'"));
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/InstanceMockPassTest.php
@@ -8,8 +8,6 @@ use Mockery\Generator\MockConfigurationBuilder;
 use Mockery\Generator\StringManipulation\Pass\InstanceMockPass;
 use PHPUnit\Framework\TestCase;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -23,10 +21,10 @@ final class InstanceMockPassTest extends TestCase
         $pass = new InstanceMockPass();
         $code = $pass->apply('class Dave { }', $config);
 
-        self::assertNotFalse(mb_strpos($code, 'public function __construct'));
+        self::assertNotFalse(\mb_strpos($code, 'public function __construct'));
 
-        self::assertNotFalse(mb_strpos($code, 'protected $_mockery_ignoreVerification'));
+        self::assertNotFalse(\mb_strpos($code, 'protected $_mockery_ignoreVerification'));
 
-        self::assertNotFalse(mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());'));
+        self::assertNotFalse(\mb_strpos($code, 'this->_mockery_constructorCalled(func_get_args());'));
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
@@ -9,8 +9,6 @@ use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\InterfacePass;
 use PHPUnit\Framework\TestCase;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -35,7 +33,7 @@ final class InterfacePassTest extends TestCase
 
         $code = $pass->apply(self::CODE, $config);
 
-        self::assertNotFalse(mb_strpos($code, 'implements MockInterface, \Dave\Dave, \Paddy\Paddy'));
+        self::assertNotFalse(\mb_strpos($code, 'implements MockInterface, \Dave\Dave, \Paddy\Paddy'));
     }
 
     public function testShouldNotAlterCodeIfNoTargetInterfaces(): void
@@ -47,6 +45,6 @@ final class InterfacePassTest extends TestCase
         ]);
 
         $code = $pass->apply(self::CODE, $config);
-        self::assertEquals(self::CODE, $code);
+        self::assertSame(self::CODE, $code);
     }
 }

--- a/tests/Unit/Mockery/GlobalHelpersTest.php
+++ b/tests/Unit/Mockery/GlobalHelpersTest.php
@@ -10,8 +10,6 @@ use Mockery\Matcher\AnyArgs;
 use Mockery\MockInterface;
 use Throwable;
 
-use function uniqid;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -54,7 +52,7 @@ final class GlobalHelpersTest extends MockeryTestCase
 
     public function testNamedMockCreatesANamedMock(): void
     {
-        $className = uniqid('Class');
+        $className = \uniqid('Class');
 
         $double = \namedMock($className);
 

--- a/tests/Unit/Mockery/HamcrestExpectationTest.php
+++ b/tests/Unit/Mockery/HamcrestExpectationTest.php
@@ -8,10 +8,6 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception;
 
-use function anything;
-use function greaterThan;
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -21,7 +17,7 @@ final class HamcrestExpectationTest extends MockeryTestCase
 
     protected function mockeryTestSetUp(): void
     {
-        $this->mock = mock('foo');
+        $this->mock = \mock('foo');
     }
 
     public function mockeryTestTearDown(): void
@@ -32,7 +28,7 @@ final class HamcrestExpectationTest extends MockeryTestCase
     public function testAnythingConstraintMatchesArgument(): void
     {
         $this->mock->shouldReceive('foo')
-            ->with(anything())
+            ->with(\anything())
             ->once();
         $this->mock->foo(2);
     }
@@ -40,7 +36,7 @@ final class HamcrestExpectationTest extends MockeryTestCase
     public function testGreaterThanConstraintMatchesArgument(): void
     {
         $this->mock->shouldReceive('foo')
-            ->with(greaterThan(1))
+            ->with(\greaterThan(1))
             ->once();
         $this->mock->foo(2);
     }
@@ -48,7 +44,7 @@ final class HamcrestExpectationTest extends MockeryTestCase
     public function testGreaterThanConstraintNotMatchesArgument(): void
     {
         $this->mock->shouldReceive('foo')
-            ->with(greaterThan(1));
+            ->with(\greaterThan(1));
         $this->expectException(Exception::class);
         $this->mock->foo(1);
         Mockery::close();

--- a/tests/Unit/Mockery/Loader/LoaderTestCase.php
+++ b/tests/Unit/Mockery/Loader/LoaderTestCase.php
@@ -9,16 +9,13 @@ use Mockery\Generator\MockDefinition;
 use Mockery\Loader\Loader;
 use PHPUnit\Framework\TestCase;
 
-use function class_exists;
-use function uniqid;
-
 abstract class LoaderTestCase extends TestCase
 {
     abstract public function getLoader(): Loader;
 
     public function testLoad(): void
     {
-        $className = uniqid('Mock_', false);
+        $className = \uniqid('Mock_', false);
 
         $config = new MockConfiguration([], [], [], $className);
 
@@ -29,6 +26,6 @@ abstract class LoaderTestCase extends TestCase
         $this->getLoader()
             ->load($definition);
 
-        self::assertTrue(class_exists($className));
+        self::assertTrue(\class_exists($className));
     }
 }

--- a/tests/Unit/Mockery/Loader/RequireLoaderTest.php
+++ b/tests/Unit/Mockery/Loader/RequireLoaderTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\Mockery\Loader;
 use Mockery\Loader\Loader;
 use Mockery\Loader\RequireLoader;
 
-use function sys_get_temp_dir;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,6 +14,6 @@ final class RequireLoaderTest extends LoaderTestCase
 {
     public function getLoader(): Loader
     {
-        return new RequireLoader(sys_get_temp_dir());
+        return new RequireLoader(\sys_get_temp_dir());
     }
 }

--- a/tests/Unit/Mockery/MockClassWithFinalToStringTest.php
+++ b/tests/Unit/Mockery/MockClassWithFinalToStringTest.php
@@ -36,11 +36,11 @@ final class MockClassWithFinalToStringTest extends MockeryTestCase
     {
         $mock = $this->container->mock(TestWithFinalToString::class);
         self::assertInstanceOf(TestWithFinalToString::class, $mock);
-        self::assertEquals(TestWithFinalToString::class . '::__toString', $mock->__toString());
+        self::assertSame(TestWithFinalToString::class . '::__toString', $mock->__toString());
 
         $mock = $this->container->mock(SubclassWithFinalToString::class);
         self::assertInstanceOf(TestWithFinalToString::class, $mock);
-        self::assertEquals(TestWithFinalToString::class . '::__toString', $mock->__toString());
+        self::assertSame(TestWithFinalToString::class . '::__toString', $mock->__toString());
     }
 
     public function testCreateMockForClassWithNonFinalToString(): void
@@ -49,6 +49,6 @@ final class MockClassWithFinalToStringTest extends MockeryTestCase
         self::assertInstanceOf(TestWithNonFinalToString::class, $mock);
 
         // Make sure __toString is overridden.
-        self::assertNotEquals('bar', $mock->__toString());
+        self::assertNotSame('bar', $mock->__toString());
     }
 }

--- a/tests/Unit/Mockery/MockClassWithIterableReturnTypeTest.php
+++ b/tests/Unit/Mockery/MockClassWithIterableReturnTypeTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\ReturnTypeIterableTypeHint;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,7 +14,7 @@ final class MockClassWithIterableReturnTypeTest extends MockeryTestCase
 {
     public function testMockingIterableReturnType(): void
     {
-        $mock = mock(ReturnTypeIterableTypeHint::class);
+        $mock = \mock(ReturnTypeIterableTypeHint::class);
 
         $mock->expects('returnIterable');
 

--- a/tests/Unit/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Unit/Mockery/MockClassWithMethodOverloadingTest.php
@@ -9,8 +9,6 @@ use Mockery\Exception\BadMethodCallException;
 use PHP73\TestWithMethodOverloading;
 use PHP73\TestWithMethodOverloadingWithoutCall;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -18,7 +16,7 @@ final class MockClassWithMethodOverloadingTest extends MockeryTestCase
 {
     public function testCreateMockForClassWithMethodOverloading(): void
     {
-        $mock = mock(TestWithMethodOverloading::class)->makePartial();
+        $mock = \mock(TestWithMethodOverloading::class)->makePartial();
 
         self::assertInstanceOf(TestWithMethodOverloading::class, $mock);
 
@@ -27,7 +25,7 @@ final class MockClassWithMethodOverloadingTest extends MockeryTestCase
 
     public function testCreateMockForClassWithMethodOverloadingWithExistingMethod(): void
     {
-        $mock = mock(TestWithMethodOverloading::class)->makePartial();
+        $mock = \mock(TestWithMethodOverloading::class)->makePartial();
 
         self::assertInstanceOf(TestWithMethodOverloading::class, $mock);
 
@@ -36,7 +34,7 @@ final class MockClassWithMethodOverloadingTest extends MockeryTestCase
 
     public function testThrowsWhenMethodDoesNotExist(): void
     {
-        $mock = mock(TestWithMethodOverloadingWithoutCall::class)->makePartial();
+        $mock = \mock(TestWithMethodOverloadingWithoutCall::class)->makePartial();
 
         self::assertInstanceOf(TestWithMethodOverloadingWithoutCall::class, $mock);
 

--- a/tests/Unit/Mockery/MockClassWithUnknownTypeHintTest.php
+++ b/tests/Unit/Mockery/MockClassWithUnknownTypeHintTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use PHP73\HasUnknownClassAsTypeHintOnMethod;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -17,7 +15,7 @@ final class MockClassWithUnknownTypeHintTest extends MockeryTestCase
 {
     public function testItShouldSuccessfullyBuildTheMock(): void
     {
-        $mock = mock(HasUnknownClassAsTypeHintOnMethod::class);
+        $mock = \mock(HasUnknownClassAsTypeHintOnMethod::class);
 
         self::assertInstanceOf(MockInterface::class, $mock);
     }

--- a/tests/Unit/Mockery/MockConfigurationTest.php
+++ b/tests/Unit/Mockery/MockConfigurationTest.php
@@ -37,8 +37,6 @@ use PHP73\TestTraversableInterface3;
 use PHPUnit\Framework\TestCase;
 use Traversable;
 
-use function array_shift;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -50,7 +48,7 @@ class MockConfigurationTest extends TestCase
 
         $methods = $config->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('bar', $methods[0]->getName());
+        self::assertSame('bar', $methods[0]->getName());
     }
 
     public function testBlackListsAreCaseInsensitive(): void
@@ -59,7 +57,7 @@ class MockConfigurationTest extends TestCase
 
         $methods = $config->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('bar', $methods[0]->getName());
+        self::assertSame('bar', $methods[0]->getName());
     }
 
     public function testFinalMethodsAreExcluded(): void
@@ -68,7 +66,7 @@ class MockConfigurationTest extends TestCase
 
         $methods = $config->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('bar', $methods[0]->getName());
+        self::assertSame('bar', $methods[0]->getName());
     }
 
     public function testOnlyWhiteListedMethodsShouldBeInListToBeMocked(): void
@@ -77,7 +75,7 @@ class MockConfigurationTest extends TestCase
 
         $methods = $config->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('foo', $methods[0]->getName());
+        self::assertSame('foo', $methods[0]->getName());
     }
 
     public function testShouldBringIteratorAggregateToHeadOfTargetListIfTraversablePresent(): void
@@ -86,8 +84,8 @@ class MockConfigurationTest extends TestCase
 
         $interfaces = $config->getTargetInterfaces();
         self::assertCount(2, $interfaces);
-        self::assertEquals(IteratorAggregate::class, $interfaces[0]->getName());
-        self::assertEquals(TestTraversableInterface3::class, $interfaces[1]->getName());
+        self::assertSame(IteratorAggregate::class, $interfaces[0]->getName());
+        self::assertSame(TestTraversableInterface3::class, $interfaces[1]->getName());
     }
 
     public function testShouldBringIteratorToHeadOfTargetListIfTraversablePresent(): void
@@ -96,8 +94,8 @@ class MockConfigurationTest extends TestCase
 
         $interfaces = $config->getTargetInterfaces();
         self::assertCount(2, $interfaces);
-        self::assertEquals(Iterator::class, $interfaces[0]->getName());
-        self::assertEquals(TestTraversableInterface2::class, $interfaces[1]->getName());
+        self::assertSame(Iterator::class, $interfaces[0]->getName());
+        self::assertSame(TestTraversableInterface2::class, $interfaces[1]->getName());
     }
 
     public function testShouldIncludeMethodsFromAllTargets(): void
@@ -113,8 +111,8 @@ class MockConfigurationTest extends TestCase
 
         $interfaces = $config->getTargetInterfaces();
         self::assertCount(2, $interfaces);
-        self::assertEquals(IteratorAggregate::class, $interfaces[0]->getName());
-        self::assertEquals(TestTraversableInterface::class, $interfaces[1]->getName());
+        self::assertSame(IteratorAggregate::class, $interfaces[0]->getName());
+        self::assertSame(TestTraversableInterface::class, $interfaces[1]->getName());
     }
 
     public function testShouldTargetIteratorAggregateIfTryingToMockTraversable(): void
@@ -123,8 +121,8 @@ class MockConfigurationTest extends TestCase
 
         $interfaces = $config->getTargetInterfaces();
         self::assertCount(1, $interfaces);
-        $first = array_shift($interfaces);
-        self::assertEquals(IteratorAggregate::class, $first->getName());
+        $first = \array_shift($interfaces);
+        self::assertSame(IteratorAggregate::class, $first->getName());
     }
 
     public function testShouldThrowIfTargetClassIsFinal(): void
@@ -140,7 +138,7 @@ class MockConfigurationTest extends TestCase
 
         $methods = $config->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('foo', $methods[0]->getName());
+        self::assertSame('foo', $methods[0]->getName());
     }
 
     public function testWhitelistOverRulesBlackList(): void
@@ -149,6 +147,6 @@ class MockConfigurationTest extends TestCase
 
         $methods = $config->getMethodsToMock();
         self::assertCount(1, $methods);
-        self::assertEquals('foo', $methods[0]->getName());
+        self::assertSame('foo', $methods[0]->getName());
     }
 }

--- a/tests/Unit/Mockery/MockTest.php
+++ b/tests/Unit/Mockery/MockTest.php
@@ -19,9 +19,6 @@ use PHP73\ClassWithProtectedMethod;
 use PHP73\ClassWithToString;
 use PHP73\ExampleClassForTestingNonExistentMethod;
 
-use function method_exists;
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -31,7 +28,7 @@ final class MockTest extends MockeryTestCase
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
 
-        $m = mock();
+        $m = \mock();
         $m->shouldReceive('test123')
             ->andReturn(true);
         self::assertTrue($m->test123());
@@ -70,7 +67,7 @@ final class MockTest extends MockeryTestCase
             ->once()
             ->byDefault();
 
-        self::assertEquals(2, $mock->mockery_getExpectationCount());
+        self::assertSame(2, $mock->mockery_getExpectationCount());
     }
 
     public function testExpectationCountWillCountExpectations(): void
@@ -81,7 +78,7 @@ final class MockTest extends MockeryTestCase
         $mock->shouldReceive('doThat')
             ->once();
 
-        self::assertEquals(2, $mock->mockery_getExpectationCount());
+        self::assertSame(2, $mock->mockery_getExpectationCount());
     }
 
     public function testExpectationCountWillIgnoreDefaultsIfOverriden(): void
@@ -95,34 +92,34 @@ final class MockTest extends MockeryTestCase
         $mock->shouldReceive('andThis')
             ->twice();
 
-        self::assertEquals(2, $mock->mockery_getExpectationCount());
+        self::assertSame(2, $mock->mockery_getExpectationCount());
     }
 
     public function testMockAddsToString(): void
     {
-        $mock = mock(ClassWithNoToString::class);
-        self::assertTrue(method_exists($mock, '__toString'));
+        $mock = \mock(ClassWithNoToString::class);
+        self::assertTrue(\method_exists($mock, '__toString'));
     }
 
     public function testMockToStringMayBeDeferred(): void
     {
-        $mock = mock(ClassWithToString::class)->makePartial();
-        self::assertEquals('foo', (string) $mock);
+        $mock = \mock(ClassWithToString::class)->makePartial();
+        self::assertSame('foo', (string) $mock);
     }
 
     public function testMockToStringShouldIgnoreMissingAlwaysReturnsString(): void
     {
-        $mock = mock(ClassWithNoToString::class)->shouldIgnoreMissing();
-        self::assertNotEquals('', (string) $mock);
+        $mock = \mock(ClassWithNoToString::class)->shouldIgnoreMissing();
+        self::assertNotSame('', (string) $mock);
 
         $mock->asUndefined();
-        self::assertNotEquals('', (string) $mock);
+        self::assertNotSame('', (string) $mock);
     }
 
     public function testMockWithNotAllowingMockingOfNonExistentMethodsCanBeGivenAdditionalMethodsToMockEvenIfTheyDontExistOnClass(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $m = mock(ExampleClassForTestingNonExistentMethod::class);
+        $m = \mock(ExampleClassForTestingNonExistentMethod::class);
         $m->shouldAllowMockingMethod('testSomeNonExistentMethod');
         $m->shouldReceive('testSomeNonExistentMethod')
             ->andReturn(true)
@@ -134,7 +131,7 @@ final class MockTest extends MockeryTestCase
     public function testProtectedMethodMockWithNotAllowingMockingOfNonExistentMethodsWhenShouldAllowMockingProtectedMethodsIsCalled(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $m = mock(ClassWithProtectedMethod::class);
+        $m = \mock(ClassWithProtectedMethod::class);
         $m->shouldAllowMockingProtectedMethods();
         $m->shouldReceive('foo')
             ->andReturn(true);
@@ -156,14 +153,14 @@ final class MockTest extends MockeryTestCase
 
     public function testShouldIgnoreMissing(): void
     {
-        $mock = mock(ClassWithNoToString::class)->shouldIgnoreMissing();
+        $mock = \mock(ClassWithNoToString::class)->shouldIgnoreMissing();
         self::assertNull($mock->nonExistingMethod());
     }
 
     public function testShouldIgnoreMissingCallingExistentMethods(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(ClassWithMethods::class)->shouldIgnoreMissing();
+        $mock = \mock(ClassWithMethods::class)->shouldIgnoreMissing();
 
         self::assertNull($mock->foo());
 
@@ -176,7 +173,7 @@ final class MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingCallingNonExistentMethods(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(true);
-        $mock = mock(ClassWithMethods::class)->shouldIgnoreMissing();
+        $mock = \mock(ClassWithMethods::class)->shouldIgnoreMissing();
 
         self::assertNull($mock->foo());
         self::assertNull($mock->bar());
@@ -197,7 +194,7 @@ final class MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingCallingNonExistentMethodsUsingGlobalConfiguration(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(ClassWithMethods::class)->shouldIgnoreMissing();
+        $mock = \mock(ClassWithMethods::class)->shouldIgnoreMissing();
         $this->expectException(BadMethodCallException::class);
         $mock->nonExistentMethod();
     }
@@ -205,7 +202,7 @@ final class MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingDisallowMockingNonExistentMethodsUsingGlobalConfiguration(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(ClassWithMethods::class)->shouldIgnoreMissing();
+        $mock = \mock(ClassWithMethods::class)->shouldIgnoreMissing();
         $this->expectException(MockeryException::class);
         $mock->shouldReceive('nonExistentMethod');
     }
@@ -213,6 +210,6 @@ final class MockTest extends MockeryTestCase
     public function testShouldThrowExceptionWithInvalidClassName(): void
     {
         $this->expectException(MockeryException::class);
-        mock('ClassName.CannotContainDot');
+        \mock('ClassName.CannotContainDot');
     }
 }

--- a/tests/Unit/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php
+++ b/tests/Unit/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php
@@ -8,8 +8,6 @@ use Mockery;
 use PHP73\SemiReservedWordsAsMethods;
 use PHPUnit\Framework\TestCase;
 
-use function method_exists;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -22,7 +20,7 @@ final class MockeryCanMockClassesWithSemiReservedWordsTest extends TestCase
         $mock->shouldReceive('include')
             ->andReturn('foo');
 
-        self::assertTrue(method_exists($mock, 'include'));
-        self::assertEquals('foo', $mock->include());
+        self::assertTrue(\method_exists($mock, 'include'));
+        self::assertSame('foo', $mock->include());
     }
 }

--- a/tests/Unit/Mockery/MockingAllLowerCasedMethodsTest.php
+++ b/tests/Unit/Mockery/MockingAllLowerCasedMethodsTest.php
@@ -8,8 +8,6 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\ClassWithAllLowerCaseMethod;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -21,7 +19,7 @@ final class MockingAllLowerCasedMethodsTest extends MockeryTestCase
 
         $expected = 'mocked';
 
-        $mock = mock(ClassWithAllLowerCaseMethod::class);
+        $mock = \mock(ClassWithAllLowerCaseMethod::class);
 
         $mock->shouldReceive('userExpectsCamelCaseMethod')
             ->andReturn($expected);

--- a/tests/Unit/Mockery/MockingClassConstantsTest.php
+++ b/tests/Unit/Mockery/MockingClassConstantsTest.php
@@ -27,9 +27,9 @@ final class MockingClassConstantsTest extends MockeryTestCase
 
         $mock = Mockery::mock('overload:' . ClassWithConstants::class);
 
-        self::assertEquals('baz', $mock::FOO);
-        self::assertEquals(2, $mock::X);
-        self::assertEquals([
+        self::assertSame('baz', $mock::FOO);
+        self::assertSame(2, $mock::X);
+        self::assertSame([
             'qux' => 'daz',
         ], $mock::BAZ);
     }

--- a/tests/Unit/Mockery/MockingMethodsWithIterableTypeHintsTest.php
+++ b/tests/Unit/Mockery/MockingMethodsWithIterableTypeHintsTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\MethodWithIterableTypeHints;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,7 +14,7 @@ final class MockingMethodsWithIterableTypeHintsTest extends MockeryTestCase
 {
     public function testItShouldSuccessfullyBuildTheMock(): void
     {
-        $mock = mock(MethodWithIterableTypeHints::class);
+        $mock = \mock(MethodWithIterableTypeHints::class);
 
         self::assertInstanceOf(MethodWithIterableTypeHints::class, $mock);
     }

--- a/tests/Unit/Mockery/MockingMethodsWithNullableParametersTest.php
+++ b/tests/Unit/Mockery/MockingMethodsWithNullableParametersTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\MethodWithNullableTypedParameter;
 use PHP73\MethodWithParametersWithDefaultValues;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -17,14 +15,14 @@ final class MockingMethodsWithNullableParametersTest extends MockeryTestCase
 {
     public function testItCanHandleDefaultParameters(): void
     {
-        $mock = mock(MethodWithParametersWithDefaultValues::class);
+        $mock = \mock(MethodWithParametersWithDefaultValues::class);
 
         self::assertInstanceOf(MethodWithParametersWithDefaultValues::class, $mock);
     }
 
     public function testItCanHandleNullableTypedParameters(): void
     {
-        $mock = mock(MethodWithNullableTypedParameter::class);
+        $mock = \mock(MethodWithNullableTypedParameter::class);
 
         self::assertInstanceOf(MethodWithNullableTypedParameter::class, $mock);
     }

--- a/tests/Unit/Mockery/MockingNullableMethodsTest.php
+++ b/tests/Unit/Mockery/MockingNullableMethodsTest.php
@@ -10,8 +10,6 @@ use Mockery\Container;
 use PHP73\MethodWithNullableReturnType;
 use TypeError;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -61,7 +59,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowClassToBeSet(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nonNullableClass')
             ->andReturn(new MethodWithNullableReturnType())
@@ -72,7 +70,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowNonNullableTypeToBeSet(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nonNullablePrimitive')
             ->andReturn('a string')
@@ -82,7 +80,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowNullableClassToBeNull(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nullableClass')
             ->andReturn(null)
@@ -92,7 +90,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowNullableSelfToBeNull(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nullableSelf')
             ->andReturn(null)
@@ -102,7 +100,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowNullableSelfToBeSet(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nullableSelf')
             ->andReturn(new MethodWithNullableReturnType())
@@ -112,7 +110,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowNullalbeClassToBeSet(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nullableClass')
             ->andReturn(new MethodWithNullableReturnType())
@@ -122,7 +120,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowPrimitiveNullableToBeNull(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nullablePrimitive')
             ->andReturn(null)
@@ -132,7 +130,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowPrimitiveNullableToBeSet(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nullablePrimitive')
             ->andReturn('a string')
@@ -142,7 +140,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldAllowSelfToBeSet(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nonNullableSelf')
             ->andReturn(new MethodWithNullableReturnType())
@@ -152,7 +150,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldNotAllowClassToBeNull(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nonNullableClass')
             ->andReturn(null);
@@ -162,7 +160,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldNotAllowNonNullToBeNull(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nonNullablePrimitive')
             ->andReturn(null);
@@ -172,7 +170,7 @@ final class MockingNullableMethodsTest extends MockeryTestCase
 
     public function testItShouldNotAllowSelfToBeNull(): void
     {
-        $mock = mock(MethodWithNullableReturnType::class);
+        $mock = \mock(MethodWithNullableReturnType::class);
 
         $mock->shouldReceive('nonNullableSelf')
             ->andReturn(null);

--- a/tests/Unit/Mockery/MockingProtectedMethodsTest.php
+++ b/tests/Unit/Mockery/MockingProtectedMethodsTest.php
@@ -17,42 +17,42 @@ final class MockingProtectedMethodsTest extends MockeryTestCase
 {
     public function testShouldAllowMockingAbstractProtectedMethods(): void
     {
-        $mock = mock(TestWithProtectedMethods::class)
+        $mock = \mock(TestWithProtectedMethods::class)
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
 
         $mock->shouldReceive('abstractProtected')
             ->andReturn('abstractProtected');
-        self::assertEquals('abstractProtected', $mock->foo());
+        self::assertSame('abstractProtected', $mock->foo());
     }
 
     public function testShouldAllowMockingIncreasedVisabilityMethods(): void
     {
-        $mock = mock(TestIncreasedVisibilityChild::class);
+        $mock = \mock(TestIncreasedVisibilityChild::class);
         $mock->shouldReceive('foobar')
             ->andReturn('foobar');
-        self::assertEquals('foobar', $mock->foobar());
+        self::assertSame('foobar', $mock->foobar());
     }
 
     public function testShouldAllowMockingProtectedMethodOnDefinitionTimePartial(): void
     {
-        $mock = mock(TestWithProtectedMethods::class . '[protectedBar]')
+        $mock = \mock(TestWithProtectedMethods::class . '[protectedBar]')
             ->shouldAllowMockingProtectedMethods();
 
         $mock->shouldReceive('protectedBar')
             ->andReturn('notbar');
-        self::assertEquals('notbar', $mock->bar());
+        self::assertSame('notbar', $mock->bar());
     }
 
     public function testShouldAllowMockingProtectedMethods(): void
     {
-        $mock = mock(TestWithProtectedMethods::class)
+        $mock = \mock(TestWithProtectedMethods::class)
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
 
         $mock->shouldReceive('protectedBar')
             ->andReturn('notbar');
-        self::assertEquals('notbar', $mock->bar());
+        self::assertSame('notbar', $mock->bar());
     }
 
     /**
@@ -61,9 +61,9 @@ final class MockingProtectedMethodsTest extends MockeryTestCase
      */
     public function testShouldAutomaticallyDeferCallsToProtectedMethodsForPartials(): void
     {
-        $mock = mock(TestWithProtectedMethods::class . '[foo]');
+        $mock = \mock(TestWithProtectedMethods::class . '[foo]');
 
-        self::assertEquals('bar', $mock->bar());
+        self::assertSame('bar', $mock->bar());
     }
 
     /**
@@ -72,13 +72,13 @@ final class MockingProtectedMethodsTest extends MockeryTestCase
      */
     public function testShouldAutomaticallyDeferCallsToProtectedMethodsForRuntimePartials(): void
     {
-        $mock = mock(TestWithProtectedMethods::class)->makePartial();
-        self::assertEquals('bar', $mock->bar());
+        $mock = \mock(TestWithProtectedMethods::class)->makePartial();
+        self::assertSame('bar', $mock->bar());
     }
 
     public function testShouldAutomaticallyIgnoreAbstractProtectedMethods(): void
     {
-        $mock = mock(TestWithProtectedMethods::class)->makePartial();
+        $mock = \mock(TestWithProtectedMethods::class)->makePartial();
         self::assertNull($mock->foo());
     }
 }

--- a/tests/Unit/Mockery/MockingStaticMethodsCalledObjectStyleTest.php
+++ b/tests/Unit/Mockery/MockingStaticMethodsCalledObjectStyleTest.php
@@ -8,8 +8,6 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\ClassWithStaticMethods;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -18,7 +16,7 @@ final class MockingStaticMethodsCalledObjectStyleTest extends MockeryTestCase
     public function testProtectedStaticMethodCalledObjectStyleMockWithNotAllowingMockingOfNonExistentMethods(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(ClassWithStaticMethods::class);
+        $mock = \mock(ClassWithStaticMethods::class);
         $mock->shouldAllowMockingProtectedMethods();
         $mock->shouldReceive('protectedBar')
             ->andReturn(true);
@@ -28,7 +26,7 @@ final class MockingStaticMethodsCalledObjectStyleTest extends MockeryTestCase
 
     public function testStaticMethodCalledObjectStyleMock(): void
     {
-        $mock = mock(ClassWithStaticMethods::class);
+        $mock = \mock(ClassWithStaticMethods::class);
         $mock->shouldReceive('foo')
             ->andReturn(true);
         self::assertTrue($mock->foo());
@@ -37,7 +35,7 @@ final class MockingStaticMethodsCalledObjectStyleTest extends MockeryTestCase
     public function testStaticMethodCalledObjectStyleMockWithNotAllowingMockingOfNonExistentMethods(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
-        $mock = mock(ClassWithStaticMethods::class);
+        $mock = \mock(ClassWithStaticMethods::class);
         $mock->shouldReceive('foo')
             ->andReturn(true);
         self::assertTrue($mock->foo());

--- a/tests/Unit/Mockery/MockingVariadicArgumentsTest.php
+++ b/tests/Unit/Mockery/MockingVariadicArgumentsTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\TestWithVariadicArguments;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,10 +14,10 @@ final class MockingVariadicArgumentsTest extends MockeryTestCase
 {
     public function testShouldAllowMockingVariadicArguments(): void
     {
-        $mock = mock(TestWithVariadicArguments::class);
+        $mock = \mock(TestWithVariadicArguments::class);
 
         $mock->shouldReceive('foo')
             ->andReturn('notbar');
-        self::assertEquals('notbar', $mock->foo());
+        self::assertSame('notbar', $mock->foo());
     }
 }

--- a/tests/Unit/Mockery/NamedMockTest.php
+++ b/tests/Unit/Mockery/NamedMockTest.php
@@ -11,8 +11,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Stubs\Animal;
 use Stubs\Habitat;
 
-use function uniqid;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -40,12 +38,12 @@ final class NamedMockTest extends MockeryTestCase
         ]);
 
         self::assertInstanceOf(DateTime::class, $mock);
-        self::assertEquals('dave', $mock->getDave());
+        self::assertSame('dave', $mock->getDave());
     }
 
     public function testItGracefullyHandlesNamespacing(): void
     {
-        $animal = Mockery::namedMock(uniqid(Animal::class, false), Animal::class);
+        $animal = Mockery::namedMock(\uniqid(Animal::class, false), Animal::class);
 
         $animal->shouldReceive('habitat')
             ->andReturn(new Habitat());

--- a/tests/Unit/Mockery/ProxyMockingTest.php
+++ b/tests/Unit/Mockery/ProxyMockingTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception;
 use PHP73\UnmockableClass;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -19,19 +17,19 @@ final class ProxyMockingTest extends MockeryTestCase
     {
         $this->expectException(Exception::class);
 
-        mock(UnmockableClass::class);
+        \mock(UnmockableClass::class);
     }
 
     public function testPassesThruAnyMethod(): void
     {
-        $mock = mock(new UnmockableClass());
+        $mock = \mock(new UnmockableClass());
 
         self::assertSame(1, $mock->anyMethod());
     }
 
     public function testPassesThruVirtualMethods(): void
     {
-        $mock = mock(new UnmockableClass());
+        $mock = \mock(new UnmockableClass());
 
         self::assertSame(42, $mock->theAnswer());
     }

--- a/tests/Unit/Mockery/ReflectorTest.php
+++ b/tests/Unit/Mockery/ReflectorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Mockery;
 
-use Generator;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Reflector;
 use PHP73\ChildClass;
@@ -19,7 +18,18 @@ use const PHP_VERSION_ID;
  */
 final class ReflectorTest extends MockeryTestCase
 {
-    public static function provideReservedWords(): Generator
+    public static function provideGetTypeHintCases(): iterable
+    {
+        $isPHPLessThan8 = PHP_VERSION_ID < 80000;
+
+        yield from [
+            [ParentClass::class, '\\' . ParentClass::class],
+            [ChildClass::class, '\\' . ParentClass::class],
+            NullableObject::class => [NullableObject::class, $isPHPLessThan8 ? '?object' : 'object|null'],
+        ];
+    }
+
+    public static function provideIsReservedWordCases(): iterable
     {
         foreach ([
             'bool',
@@ -40,7 +50,7 @@ final class ReflectorTest extends MockeryTestCase
     }
 
     /**
-     * @dataProvider typeHintDataProvider
+     * @dataProvider provideGetTypeHintCases
      */
     public function testGetTypeHint(string $class, string $expectedTypeHint): void
     {
@@ -52,21 +62,10 @@ final class ReflectorTest extends MockeryTestCase
     }
 
     /**
-     * @dataProvider provideReservedWords
+     * @dataProvider provideIsReservedWordCases
      */
     public function testIsReservedWord(string $type): void
     {
         self::assertTrue(Reflector::isReservedWord($type));
-    }
-
-    public static function typeHintDataProvider(): Generator
-    {
-        $isPHPLessThan8 = PHP_VERSION_ID < 80000;
-
-        yield from [
-            [ParentClass::class, '\\' . ParentClass::class],
-            [ChildClass::class, '\\' . ParentClass::class],
-            NullableObject::class => [NullableObject::class, $isPHPLessThan8 ? '?object' : 'object|null'],
-        ];
     }
 }

--- a/tests/Unit/Mockery/SpyTest.php
+++ b/tests/Unit/Mockery/SpyTest.php
@@ -8,8 +8,6 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception\InvalidCountException;
 
-use function anyArgs;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -21,7 +19,7 @@ final class SpyTest extends MockeryTestCase
         $spy->foo(123, 456);
 
         $spy->shouldHaveReceived()
-            ->foo(anyArgs());
+            ->foo(\anyArgs());
     }
 
     public function testItIncrementsExpectationCountWhenShouldHaveReceivedIsUsed(): void
@@ -30,14 +28,14 @@ final class SpyTest extends MockeryTestCase
         $spy->myMethod('param1', 'param2');
         $spy->shouldHaveReceived('myMethod')
             ->with('param1', 'param2');
-        self::assertEquals(1, $spy->mockery_getExpectationCount());
+        self::assertSame(1, $spy->mockery_getExpectationCount());
     }
 
     public function testItIncrementsExpectationCountWhenShouldNotHaveReceivedIsUsed(): void
     {
         $spy = Mockery::spy();
         $spy->shouldNotHaveReceived('method');
-        self::assertEquals(1, $spy->mockery_getExpectationCount());
+        self::assertSame(1, $spy->mockery_getExpectationCount());
     }
 
     public function testItVerifiesAMethodWasCalled(): void

--- a/tests/Unit/Mockery/TraitsTest.php
+++ b/tests/Unit/Mockery/TraitsTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\SimpleTrait;
 use PHP73\TraitWithAbstractMethod;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -17,27 +15,27 @@ final class TraitsTest extends MockeryTestCase
 {
     public function testItCanCreateAnObjectForASimpleTrait(): void
     {
-        $trait = mock(SimpleTrait::class);
+        $trait = \mock(SimpleTrait::class);
 
-        self::assertEquals('bar', $trait->foo());
+        self::assertSame('bar', $trait->foo());
     }
 
     public function testItCanCreateAnObjectUsingMultipleTraits(): void
     {
-        $trait = mock(SimpleTrait::class, TraitWithAbstractMethod::class, [
+        $trait = \mock(SimpleTrait::class, TraitWithAbstractMethod::class, [
             'doBaz' => 123,
         ]);
 
-        self::assertEquals('bar', $trait->foo());
-        self::assertEquals(123, $trait->baz());
+        self::assertSame('bar', $trait->foo());
+        self::assertSame(123, $trait->baz());
     }
 
     public function testItCreatesAbstractMethodsAsNecessary(): void
     {
-        $trait = mock(TraitWithAbstractMethod::class, [
+        $trait = \mock(TraitWithAbstractMethod::class, [
             'doBaz' => 'baz',
         ]);
 
-        self::assertEquals('baz', $trait->baz());
+        self::assertSame('baz', $trait->baz());
     }
 }

--- a/tests/Unit/PHP73/MockClassWithFinalWakeupTest.php
+++ b/tests/Unit/PHP73/MockClassWithFinalWakeupTest.php
@@ -35,11 +35,11 @@ final class MockClassWithFinalWakeupTest extends MockeryTestCase
     {
         $mock = $this->container->mock(TestWithFinalWakeup::class);
         self::assertInstanceOf(TestWithFinalWakeup::class, $mock);
-        self::assertEquals(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup());
+        self::assertSame(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup());
 
         $mock = $this->container->mock(SubclassWithFinalWakeup::class);
         self::assertInstanceOf(SubclassWithFinalWakeup::class, $mock);
-        self::assertEquals(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup());
+        self::assertSame(TestWithFinalWakeup::class . '::__wakeup', $mock->__wakeup());
     }
 
     public function testCreateMockForClassWithNonFinalWakeup(): void

--- a/tests/Unit/PHP73/MockingOldStyleConstructorTest.php
+++ b/tests/Unit/PHP73/MockingOldStyleConstructorTest.php
@@ -8,8 +8,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use PHP73\OldStyleConstructor;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -17,7 +15,7 @@ class MockingOldStyleConstructorTest extends MockeryTestCase
 {
     public function testMockClassWithOldStyleConstructorAndArguments(): void
     {
-        $double = mock(OldStyleConstructor::class);
+        $double = \mock(OldStyleConstructor::class);
 
         self::assertInstanceOf(MockInterface::class, $double);
         self::assertInstanceOf(OldStyleConstructor::class, $double);

--- a/tests/Unit/PHP73/MockingVoidMethodsTest.php
+++ b/tests/Unit/PHP73/MockingVoidMethodsTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\PHP73;
 use PHP73\MethodWithVoidReturnType;
 use Tests\Unit\AbstractTestCase;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,7 +14,7 @@ final class MockingVoidMethodsTest extends AbstractTestCase
 {
     public function testItCanStubAndMockVoidMethods(): void
     {
-        $mock = mock(MethodWithVoidReturnType::class);
+        $mock = \mock(MethodWithVoidReturnType::class);
 
         $mock->expects('foo');
 
@@ -25,6 +23,6 @@ final class MockingVoidMethodsTest extends AbstractTestCase
 
     public function testItShouldSuccessfullyBuildTheMock(): void
     {
-        self::assertInstanceOf(MethodWithVoidReturnType::class, mock(MethodWithVoidReturnType::class));
+        self::assertInstanceOf(MethodWithVoidReturnType::class, \mock(MethodWithVoidReturnType::class));
     }
 }

--- a/tests/Unit/PHP73/TestCase1328Test.php
+++ b/tests/Unit/PHP73/TestCase1328Test.php
@@ -11,11 +11,8 @@ use Mockery\Exception\InvalidCountException;
 use Mockery\Expectation;
 use PHPUnit\Framework\TestCase;
 
-use function restore_error_handler;
-use function set_error_handler;
-
 /**
- * @coversDefaultClass Mockery
+ * @coversDefaultClass \Mockery
  * @requires PHP 7.3
  * @see https://github.com/mockery/mockery/issues/1328
  */
@@ -36,9 +33,9 @@ final class TestCase1328Test extends TestCase
 
     public function testThrowsInvalidArgumentExceptionForChainingAdditionalInvocationCountMethod(): void
     {
-        set_error_handler(
+        \set_error_handler(
             static function (int $errorCode, string $errorMessage): void {
-                restore_error_handler();
+                \restore_error_handler();
                 throw new InvalidArgumentException($errorMessage, $errorCode);
             },
             E_ALL
@@ -59,9 +56,9 @@ final class TestCase1328Test extends TestCase
 
     public function testThrowsInvalidArgumentExceptionWhenInvocationCountChanges(): void
     {
-        set_error_handler(
+        \set_error_handler(
             static function (int $errorCode, string $errorMessage): void {
-                restore_error_handler();
+                \restore_error_handler();
                 throw new InvalidArgumentException($errorMessage, $errorCode);
             },
             E_ALL

--- a/tests/Unit/PHP73/TestCase1404Test.php
+++ b/tests/Unit/PHP73/TestCase1404Test.php
@@ -11,7 +11,7 @@ use PDOStatement;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass Mockery
+ * @coversDefaultClass \Mockery
  * @requires PHP 7.3
  * @see https://github.com/mockery/mockery/issues/1404
  */
@@ -20,7 +20,7 @@ final class TestCase1404Test extends TestCase
     /**
      * @return Generator<string,list<string>>
      */
-    public static function provideResult(): Generator
+    public static function provideResult(): iterable
     {
         yield from [
             'empty' => [[]],

--- a/tests/Unit/PHP73/WithCustomFormatterExpectationTest.php
+++ b/tests/Unit/PHP73/WithCustomFormatterExpectationTest.php
@@ -13,8 +13,6 @@ use PHP73\InterfaceWithCustomFormatter;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function get_class;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -52,7 +50,7 @@ final class WithCustomFormatterExpectationTest extends TestCase
         );
     }
 
-    public static function formatObjectsDataProvider(): array
+    public static function provideFormatObjectsCases(): iterable
     {
         return [
             [
@@ -73,7 +71,7 @@ final class WithCustomFormatterExpectationTest extends TestCase
         ];
     }
 
-    public static function getObjectFormatterDataProvider(): array
+    public static function provideGetObjectFormatterCases(): iterable
     {
         return [
             [new stdClass(), null],
@@ -85,7 +83,7 @@ final class WithCustomFormatterExpectationTest extends TestCase
     }
 
     /**
-     * @dataProvider formatObjectsDataProvider
+     * @dataProvider provideFormatObjectsCases
      */
     public function testFormatObjects($obj, $shouldContains, $shouldNotContains): void
     {
@@ -99,7 +97,7 @@ final class WithCustomFormatterExpectationTest extends TestCase
     }
 
     /**
-     * @dataProvider getObjectFormatterDataProvider
+     * @dataProvider provideGetObjectFormatterCases
      */
     public function testGetObjectFormatter($object, $expected): void
     {
@@ -107,9 +105,9 @@ final class WithCustomFormatterExpectationTest extends TestCase
             return null;
         };
 
-        $formatter = Mockery::getConfiguration()->getObjectFormatter(get_class($object), $defaultFormatter);
+        $formatter = Mockery::getConfiguration()->getObjectFormatter(\get_class($object), $defaultFormatter);
         $formatted = $formatter($object, 1);
 
-        self::assertEquals($expected, $formatted ? $formatted['formatter'] : null);
+        self::assertSame($expected, $formatted ? $formatted['formatter'] : null);
     }
 }

--- a/tests/Unit/PHP73/WithFormatterExpectationTest.php
+++ b/tests/Unit/PHP73/WithFormatterExpectationTest.php
@@ -13,24 +13,22 @@ use PHP73\ClassWithPublicStaticProperty;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function mb_strpos;
-
 /**
  * @coversDefaultClass \Mockery
  */
 final class WithFormatterExpectationTest extends TestCase
 {
-    public static function formatObjectsDataProvider(): array
+    public static function provideFormatObjectsCases(): iterable
     {
         return [[[null], ''], [['a string', 98768, ['a', 'nother', 'array']], '']];
     }
 
     /**
-     * @dataProvider formatObjectsDataProvider
+     * @dataProvider provideFormatObjectsCases
      */
     public function testFormatObjects($args, $expected): void
     {
-        self::assertEquals($expected, Mockery::formatObjects($args));
+        self::assertSame($expected, Mockery::formatObjects($args));
     }
 
     public function testFormatObjectsExcludesStaticGetters(): void
@@ -38,7 +36,7 @@ final class WithFormatterExpectationTest extends TestCase
         $obj = new ClassWithPublicStaticGetter();
         $string = Mockery::formatObjects([$obj]);
 
-        self::assertSame(mb_strpos($string, 'getExcluded'), false);
+        self::assertSame(\mb_strpos($string, 'getExcluded'), false);
     }
 
     public function testFormatObjectsExcludesStaticProperties(): void
@@ -46,7 +44,7 @@ final class WithFormatterExpectationTest extends TestCase
         $obj = new ClassWithPublicStaticProperty();
         $string = Mockery::formatObjects([$obj]);
 
-        self::assertSame(mb_strpos($string, 'excludedProperty'), false);
+        self::assertSame(\mb_strpos($string, 'excludedProperty'), false);
     }
 
     public function testFormatObjectsShouldNotCallGettersWithParams(): void
@@ -54,7 +52,7 @@ final class WithFormatterExpectationTest extends TestCase
         $obj = new ClassWithGetterWithParam();
         $string = Mockery::formatObjects([$obj]);
 
-        self::assertSame(mb_strpos($string, 'Missing argument 1 for'), false);
+        self::assertSame(\mb_strpos($string, 'Missing argument 1 for'), false);
     }
 
     /**

--- a/tests/Unit/PHP74/TestCase1132Test.php
+++ b/tests/Unit/PHP74/TestCase1132Test.php
@@ -10,7 +10,7 @@ use PHP74\DummyClass;
 use Tests\Unit\AbstractTestCase;
 
 /**
- * @coversDefaultClass Mockery
+ * @coversDefaultClass \Mockery
  * @requires PHP 7.4
  * @see https://github.com/mockery/mockery/issues/1132
  */

--- a/tests/Unit/PHP74/TestCase1402Test.php
+++ b/tests/Unit/PHP74/TestCase1402Test.php
@@ -9,7 +9,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP74\Regression\Issue1402\Service;
 
 /**
- * @coversDefaultClass Mockery
+ * @coversDefaultClass \Mockery
  * @requires PHP 7.4
  * @see https://github.com/mockery/mockery/issues/1402
  */
@@ -22,6 +22,6 @@ final class TestCase1402Test extends MockeryTestCase
         $banana->allows('test')
             ->andReturns(2);
 
-        self::assertEquals(2, $banana->test());
+        self::assertSame(2, $banana->test());
     }
 }

--- a/tests/Unit/PHP80/MockingMethodsWithStaticReturnTypeTest.php
+++ b/tests/Unit/PHP80/MockingMethodsWithStaticReturnTypeTest.php
@@ -7,8 +7,6 @@ namespace Tests\Unit\PHP80;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP80\MethodWithStaticReturnType;
 
-use function mock;
-
 /**
  * @coversDefaultClass \Mockery
  */
@@ -16,7 +14,7 @@ final class MockingMethodsWithStaticReturnTypeTest extends MockeryTestCase
 {
     public function testMockingStaticReturnType(): void
     {
-        $mock = mock(MethodWithStaticReturnType::class);
+        $mock = \mock(MethodWithStaticReturnType::class);
 
         $mock->shouldReceive('returnType');
 

--- a/tests/Unit/PHP80/Php80LanguageFeaturesTest.php
+++ b/tests/Unit/PHP80/Php80LanguageFeaturesTest.php
@@ -19,9 +19,6 @@ use PHP80\ReturnTypeUnionTypeHint;
 use stdClass;
 use Traversable;
 
-use function mock;
-use function spy;
-
 /**
  * @requires PHP 8.0.0-dev
  * @coversDefaultClass \Mockery
@@ -30,7 +27,7 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 {
     public function testItCanMockAClassWithAMixedArgumentTypeHint(): void
     {
-        $mock = mock(ArgumentMixedTypeHint::class);
+        $mock = \mock(ArgumentMixedTypeHint::class);
         $object = new stdClass();
         $mock->allows()
             ->foo($object)
@@ -41,14 +38,14 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 
     public function testItCanMockAClassWithAMixedReturnTypeHint(): void
     {
-        $mock = spy(ReturnTypeMixedTypeHint::class);
+        $mock = \spy(ReturnTypeMixedTypeHint::class);
 
         self::assertNull($mock->foo());
     }
 
     public function testItCanMockAClassWithAParentArgumentTypeHint(): void
     {
-        $mock = mock(ArgumentParentTypeHint::class);
+        $mock = \mock(ArgumentParentTypeHint::class);
         $object = new ArgumentParentTypeHint();
         $mock->allows()
             ->foo($object)
@@ -59,14 +56,14 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 
     public function testItCanMockAClassWithAParentReturnTypeHint(): void
     {
-        $mock = spy(ReturnTypeParentTypeHint::class);
+        $mock = \spy(ReturnTypeParentTypeHint::class);
 
         self::assertInstanceOf(stdClass::class, $mock->foo());
     }
 
     public function testItCanMockAClassWithAUnionArgumentTypeHint(): void
     {
-        $mock = mock(ArgumentUnionTypeHint::class);
+        $mock = \mock(ArgumentUnionTypeHint::class);
         $object = new ArgumentUnionTypeHint();
         $mock->allows()
             ->foo($object)
@@ -77,7 +74,7 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 
     public function testItCanMockAClassWithAUnionArgumentTypeHintIncludingNull(): void
     {
-        $mock = mock(ArgumentUnionTypeHintWithNull::class);
+        $mock = \mock(ArgumentUnionTypeHintWithNull::class);
         $mock->allows()
             ->foo(null)
             ->once();
@@ -87,14 +84,14 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 
     public function testItCanMockAClassWithAUnionReturnTypeHint(): void
     {
-        $mock = spy(ReturnTypeUnionTypeHint::class);
+        $mock = \spy(ReturnTypeUnionTypeHint::class);
 
         self::assertIsObject($mock->foo());
     }
 
     public function testMockingIteratorAggregateDoesNotImplementIterator(): void
     {
-        $mock = mock(ImplementsIteratorAggregate::class);
+        $mock = \mock(ImplementsIteratorAggregate::class);
         self::assertInstanceOf(IteratorAggregate::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
         self::assertNotInstanceOf(Iterator::class, $mock);
@@ -102,7 +99,7 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 
     public function testMockingIteratorDoesNotImplementIterator(): void
     {
-        $mock = mock(ImplementsIterator::class);
+        $mock = \mock(ImplementsIterator::class);
         self::assertInstanceOf(Iterator::class, $mock);
         self::assertInstanceOf(Traversable::class, $mock);
     }

--- a/tests/Unit/PHP80/TestCase1414Test.php
+++ b/tests/Unit/PHP80/TestCase1414Test.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
- * @coversDefaultClass Mockery
+ * @coversDefaultClass \Mockery
  * @requires PHP 8.0
  * @see https://github.com/mockery/mockery/issues/1414
  */

--- a/tests/Unit/PHP81/Php81LanguageFeaturesTest.php
+++ b/tests/Unit/PHP81/Php81LanguageFeaturesTest.php
@@ -24,11 +24,7 @@ use RuntimeException;
 use Serializable;
 use TypeError;
 
-use function pcntl_fork;
-use function pcntl_waitpid;
-use function pcntl_wexitstatus;
 use function mock;
-use function spy;
 
 /**
  * @requires PHP 8.1.0-dev
@@ -38,7 +34,7 @@ final class Php81LanguageFeaturesTest extends MockeryTestCase
 {
     public function testCanMockClassesThatImplementSerializable(): void
     {
-        $mock = mock(ClassThatImplementsSerializable::class);
+        $mock = \mock(ClassThatImplementsSerializable::class);
 
         self::assertInstanceOf(Serializable::class, $mock);
     }
@@ -58,7 +54,7 @@ final class Php81LanguageFeaturesTest extends MockeryTestCase
     {
         $mock = Mockery::mock(NeverReturningTypehintClass::class)->makePartial();
 
-        $pid = pcntl_fork();
+        $pid = \pcntl_fork();
 
         if ($pid === -1) {
             self::markTestSkipped("Couldn't fork for exit test");
@@ -67,8 +63,8 @@ final class Php81LanguageFeaturesTest extends MockeryTestCase
         }
 
         if ($pid) {
-            pcntl_waitpid($pid, $status);
-            self::assertEquals(123, pcntl_wexitstatus($status));
+            \pcntl_waitpid($pid, $status);
+            self::assertSame(123, \pcntl_wexitstatus($status));
 
             return;
         }
@@ -91,21 +87,21 @@ final class Php81LanguageFeaturesTest extends MockeryTestCase
 
     public function testItCanMockAClassWithReturnTypeWillChangeAttributeAndNoReturnType(): void
     {
-        $mock = spy(ReturnTypeWillChangeAttributeNoReturnType::class);
+        $mock = \spy(ReturnTypeWillChangeAttributeNoReturnType::class);
 
         self::assertNull($mock->getTimestamp());
     }
 
     public function testItCanMockAClassWithReturnTypeWillChangeAttributeAndWrongReturnType(): void
     {
-        $mock = spy(ReturnTypeWillChangeAttributeWrongReturnType::class);
+        $mock = \spy(ReturnTypeWillChangeAttributeWrongReturnType::class);
 
         self::assertSame(0.0, $mock->getTimestamp());
     }
 
     public function testItCanMockAnInternalClassWithTentativeReturnTypes(): void
     {
-        $mock = spy(DateTime::class);
+        $mock = \spy(DateTime::class);
 
         self::assertSame(0, $mock->getTimestamp());
     }
@@ -132,7 +128,7 @@ final class Php81LanguageFeaturesTest extends MockeryTestCase
         $mock->shouldReceive('set')
             ->once();
         $mock->set();
-        self::assertEquals(SimpleEnum::first, $mock->enum); // check that mock did not set internal variable
+        self::assertSame(SimpleEnum::first, $mock->enum); // check that mock did not set internal variable
     }
 
     public function testMockingClassWithNewInInitializer(): void
@@ -144,7 +140,7 @@ final class Php81LanguageFeaturesTest extends MockeryTestCase
 
     public function testNewInitializerExpression(): void
     {
-        $class = mock(MockClass::class)
+        $class = \mock(MockClass::class)
             ->expects('test')
             ->with('test')
             ->andReturn('it works')

--- a/tests/Unit/PHP82/Php82LanguageFeaturesTest.php
+++ b/tests/Unit/PHP82/Php82LanguageFeaturesTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\PHP82;
 
-use Generator;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Reflector;
@@ -24,15 +23,13 @@ use PHP82\TestTwo;
 use ReflectionClass;
 use ReflectionType;
 
-use function mock;
-
 /**
  * @requires PHP 8.2.0-dev
  * @coversDefaultClass \Mockery
  */
 final class Php82LanguageFeaturesTest extends MockeryTestCase
 {
-    public static function parameterContraVarianceDataProvider(): Generator
+    public static function provideMockParameterDisjunctiveNormalFormTypesCases(): iterable
     {
         $fixtures = [Sut::class, TestOne::class, TestTwo::class, TestThree::class];
 
@@ -41,7 +38,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
         }
     }
 
-    public static function returnCoVarianceDataProvider(): Generator
+    public static function provideMockReturnDisjunctiveNormalFormTypesCases(): iterable
     {
         $fixtures = [
             TestReturnCoVarianceOne::class,
@@ -56,7 +53,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
 
     public function testCanMockReservedWordFalse(): void
     {
-        $mock = mock(HasReservedWordFalse::class);
+        $mock = \mock(HasReservedWordFalse::class);
 
         $mock->expects('testFalseMethod')
             ->once();
@@ -67,7 +64,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
 
     public function testCanMockReservedWordTrue(): void
     {
-        $mock = mock(HasReservedWordTrue::class);
+        $mock = \mock(HasReservedWordTrue::class);
 
         $mock->expects('testTrueMethod')
             ->once();
@@ -78,7 +75,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
 
     public function testCanMockUndefinedClasses(): void
     {
-        $class = mock('MockUnDefinedClass');
+        $class = \mock('MockUnDefinedClass');
 
         $class->foo = 'bar';
 
@@ -94,7 +91,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
 
     /**
      * @param class-string $fullyQualifiedClassName
-     * @dataProvider parameterContraVarianceDataProvider
+     * @dataProvider provideMockParameterDisjunctiveNormalFormTypesCases
      */
     public function testMockParameterDisjunctiveNormalFormTypes(string $fullyQualifiedClassName): void
     {
@@ -104,7 +101,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
             ->getParameters()[0]
             ->getType();
 
-        $mock = mock($fullyQualifiedClassName);
+        $mock = \mock($fullyQualifiedClassName);
 
         $reflectionClass = new ReflectionClass($mock);
         $type = $reflectionClass->getMethod($expectedMethod->getName())
@@ -116,7 +113,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
 
     /**
      * @param class-string $fullyQualifiedClassName
-     * @dataProvider returnCoVarianceDataProvider
+     * @dataProvider provideMockReturnDisjunctiveNormalFormTypesCases
      */
     public function testMockReturnDisjunctiveNormalFormTypes(string $fullyQualifiedClassName): void
     {
@@ -126,7 +123,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
 
         self::assertInstanceOf(ReflectionType::class, $expectedType);
 
-        $mock = mock($fullyQualifiedClassName);
+        $mock = \mock($fullyQualifiedClassName);
 
         $reflectionClass = new ReflectionClass($mock);
 

--- a/tests/Unit/PHP82/TestCase1439Test.php
+++ b/tests/Unit/PHP82/TestCase1439Test.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\PHP82;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use SoapClient;
+use Throwable;
 
 /**
  * @coversDefaultClass \Mockery\Expectation
@@ -14,11 +16,13 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 final class TestCase1439Test extends MockeryTestCase
 {
-    /** @throws \Throwable */
+    /**
+     * @throws Throwable
+     */
     public function testDescription(): void
     {
         // Mock the SOAP client
-        $soapClientMock = Mockery::mock(\SoapClient::class);
+        $soapClientMock = Mockery::mock(SoapClient::class);
 
         // Method we will be calling
         $methodName = 'testMethod';
@@ -39,7 +43,7 @@ final class TestCase1439Test extends MockeryTestCase
             ->andReturn($expectedResult);
 
         // Simulate the call
-        $response = call_user_func_array([$soapClientMock, $methodName], $params);
+        $response = \call_user_func_array([$soapClientMock, $methodName], $params);
 
         self::assertSame($expectedResult, $response);
     }

--- a/tests/Unit/PHP83/Php83LanguageFeaturesTest.php
+++ b/tests/Unit/PHP83/Php83LanguageFeaturesTest.php
@@ -12,8 +12,6 @@ use PHP83\Enums;
 use PHP83\Interfaces;
 use PHP83\Traits;
 
-use function mock;
-
 /**
  * @requires PHP 8.3.0-dev
  * @coversDefaultClass \Mockery
@@ -22,7 +20,7 @@ final class Php83LanguageFeaturesTest extends MockeryTestCase
 {
     public function testCanMockClassTypedClassConstants(): void
     {
-        $mock = mock(Classes::class);
+        $mock = \mock(Classes::class);
 
         self::assertInstanceOf(Classes::class, $mock);
         self::assertSame(Enums::FOO, $mock::BAR);
@@ -30,7 +28,7 @@ final class Php83LanguageFeaturesTest extends MockeryTestCase
 
     public function testCanMockInterfaceTypedClassConstants(): void
     {
-        $mock = mock(Interfaces::class);
+        $mock = \mock(Interfaces::class);
 
         self::assertInstanceOf(Interfaces::class, $mock);
         self::assertSame(Enums::FOO, $mock::BAR);
@@ -38,7 +36,7 @@ final class Php83LanguageFeaturesTest extends MockeryTestCase
 
     public function testCanMockTraitTypedClassConstants(): void
     {
-        $mock = mock(Traits::class);
+        $mock = \mock(Traits::class);
 
         self::assertSame(Enums::FOO, $mock->foo());
         self::assertSame(Enums::FOO, $mock::BAR);
@@ -46,7 +44,7 @@ final class Php83LanguageFeaturesTest extends MockeryTestCase
 
     public function testCanMockWithDynamicClassConstantFetch(): void
     {
-        $mock = mock(ClassName::class);
+        $mock = \mock(ClassName::class);
 
         $constant = 'CONSTANT';
 
@@ -63,6 +61,6 @@ final class Php83LanguageFeaturesTest extends MockeryTestCase
     {
         $this->expectException(Exception::class);
 
-        mock(Enums::class);
+        \mock(Enums::class);
     }
 }


### PR DESCRIPTION
Bumps symplify/easy-coding-standard from 12.1.14 to 12.3.5.

- Update `composer.json`
- Update `composer.lock`