### PR TITLE
Handle `ReflectionException` when resolving named arguments

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -645,6 +645,7 @@
       <code><![CDATA[$groups]]></code>
       <code><![CDATA[$message]]></code>
       <code><![CDATA[$return]]></code>
+      <code><![CDATA[$this->getName()]]></code>
       <code><![CDATA[$values]]></code>
       <code><![CDATA[func_get_args()]]></code>
       <code><![CDATA[func_get_args()]]></code>
@@ -656,6 +657,8 @@
       <code><![CDATA[$groups[$group]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
+      <code><![CDATA[$_arguments[$position]]]></code>
+      <code><![CDATA[$_arguments[$position]]]></code>
       <code><![CDATA[$arg]]></code>
       <code><![CDATA[$expectedArg]]></code>
       <code><![CDATA[$expectedArg]]></code>
@@ -5844,10 +5847,18 @@ MOCK]]></code>
       <code><![CDATA[foo]]></code>
       <code><![CDATA[foo]]></code>
       <code><![CDATA[foo]]></code>
+      <code><![CDATA[foo]]></code>
+      <code><![CDATA[foo]]></code>
+      <code><![CDATA[foo]]></code>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
       <code><![CDATA[once]]></code>
+      <code><![CDATA[times]]></code>
+      <code><![CDATA[times]]></code>
+      <code><![CDATA[times]]></code>
+      <code><![CDATA[times]]></code>
+      <code><![CDATA[with]]></code>
     </MixedMethodCall>
     <RedundantCondition>
       <code><![CDATA[assertIsObject]]></code>
@@ -5857,6 +5868,18 @@ MOCK]]></code>
       <code><![CDATA[allows]]></code>
       <code><![CDATA[allows]]></code>
       <code><![CDATA[allows]]></code>
+      <code><![CDATA[allows]]></code>
+      <code><![CDATA[allows]]></code>
+      <code><![CDATA[allows]]></code>
+      <code><![CDATA[expects]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
+      <code><![CDATA[shouldHaveReceived]]></code>
     </UndefinedMethod>
     <UnusedClass>
       <code><![CDATA[Php80LanguageFeaturesTest]]></code>

--- a/tests/Fixture/PHP80/MultiArgument.php
+++ b/tests/Fixture/PHP80/MultiArgument.php
@@ -9,4 +9,8 @@ class MultiArgument
     public function foo(int $bar = 0, string $bee = '', string $dol = '')
     {
     }
+
+    public function bar(int $int, string $string, bool $bool)
+    {
+    }
 }

--- a/tests/Unit/PHP80/Php80LanguageFeaturesTest.php
+++ b/tests/Unit/PHP80/Php80LanguageFeaturesTest.php
@@ -73,7 +73,7 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
         $mock->foo($object);
     }
 
-    public function testItCanMockAClassWithANamedArgumentList()
+    public function testItCanMockAClassWithANamedArgumentList(): void
     {
         $mock = \mock(MultiArgument::class);
 
@@ -93,7 +93,23 @@ final class Php80LanguageFeaturesTest extends MockeryTestCase
 
         $mock->foo(bar: 1);
         $mock->foo(1);
+    }
 
+    public function testItCanMockAClassWithANamedArgumentListWithoutDefaultValue(): void
+    {
+        $mock = \mock(MultiArgument::class);
+
+        $mock->expects('bar')->with(bool: true, int: 1, string: '')->times(3);
+
+        $mock->bar(1, '', true);
+
+        $mock->bar(bool: true, int: 1, string: '');
+
+        $mock->bar(string: '', bool: true, int: 1);
+    }
+
+    public function testItCanSpyAClassWithANamedArgumentList(): void
+    {
         $spy = \spy(MultiArgument::class);
 
         $param = ['bar' => 2, 'dol' => '2'];


### PR DESCRIPTION
Following #1448,

- Handle `ReflectionException` when method does not exist.
- Retrieve default values when available using `isDefaultValueAvailable` and `getDefaultValue`.


---
had an issue with pushing changes to the original PR.

<img width="770" alt="image" src="https://github.com/user-attachments/assets/ac684516-7b6f-4038-a0d5-e0ec8f726559" />