### PR TITLE
Phpunit integration test listener false positive

### DIFF
--- a/library/Mockery/Adapter/Phpunit/TestListenerTrait.php
+++ b/library/Mockery/Adapter/Phpunit/TestListenerTrait.php
@@ -80,5 +80,6 @@ class TestListenerTrait
         } else {
             Blacklist::$blacklistedClassNames[Mockery::class] = 1;
         }
+        Mockery::resetContainer();
     }
 }

--- a/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -43,7 +43,7 @@ final class TestListenerTest extends MockeryTestCase
     {
         $this->listener->startTestSuite(new TestSuite());
 
-        $mock = Mockery::getContainer()->mock();
+        $mock = Mockery::mock();
         $mock->shouldReceive('bar')
             ->once();
 
@@ -58,8 +58,7 @@ final class TestListenerTest extends MockeryTestCase
 
     public function testSuccessWhenMockIsUsedBeforeStartingTests(): void
     {
-        $container = Mockery::getContainer();
-        $mock = $container->mock();
+        $mock = Mockery::mock();
         $mock->shouldReceive('bar')
             ->once();
 

--- a/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -18,8 +18,6 @@ use ReflectionClass;
  */
 final class TestListenerTest extends MockeryTestCase
 {
-    protected $container;
-
     protected $listener;
 
     protected $test;
@@ -28,9 +26,6 @@ final class TestListenerTest extends MockeryTestCase
 
     protected function mockeryTestSetUp(): void
     {
-        // We intentionally test the static container here. That is what the
-        // listener will check.
-        $this->container = Mockery::getContainer();
         $this->listener = new TestListener();
         $this->testResult = new TestResult();
         $this->test = new EmptyTestCase();
@@ -40,13 +35,15 @@ final class TestListenerTest extends MockeryTestCase
 
         self::assertTrue(
             $this->testResult->wasSuccessful(),
-            'sanity check: empty test results should be considered successful'
+            'sanity check: empty test results should be considered successful',
         );
     }
 
     public function testFailureOnMissingClose(): void
     {
-        $mock = $this->container->mock();
+        $this->listener->startTestSuite(new TestSuite());
+
+        $mock = Mockery::getContainer()->mock();
         $mock->shouldReceive('bar')
             ->once();
 
@@ -59,37 +56,54 @@ final class TestListenerTest extends MockeryTestCase
         Mockery::close();
     }
 
+    public function testSuccessWhenMockIsUsedBeforeStartingTests(): void
+    {
+        $container = Mockery::getContainer();
+        $mock = $container->mock();
+        $mock->shouldReceive('bar')
+            ->once();
+
+        $this->listener->startTestSuite(new TestSuite());
+
+        $this->listener->endTest($this->test, 0);
+
+        self::assertTrue($this->testResult->wasSuccessful(), 'expected test result to indicate success');
+    }
+
     public function testMockeryIsAddedToBlacklist(): void
     {
         $suite = Mockery::mock(TestSuite::class);
 
         if (\method_exists(Blacklist::class, 'addDirectory')) {
-            self::assertFalse(
-                (new Blacklist())->isBlacklisted((new ReflectionClass(Mockery::class))->getFileName())
-            );
-
             $this->listener->startTestSuite($suite);
 
             self::assertTrue(
-                (new Blacklist())->isBlacklisted((new ReflectionClass(Mockery::class))->getFileName())
+                (new Blacklist())->isBlacklisted((new ReflectionClass(Mockery::class))->getFileName()),
+                'expected blacklist to contain the Mockery reflection',
             );
         } else {
-            self::assertArrayNotHasKey(Mockery::class, Blacklist::$blacklistedClassNames);
             $this->listener->startTestSuite($suite);
-            self::assertSame(1, Blacklist::$blacklistedClassNames[Mockery::class]);
+            self::assertSame(
+                1,
+                Blacklist::$blacklistedClassNames[Mockery::class],
+                'expected blacklist to contain the Mockery reflection',
+            );
         }
     }
 
     public function testSuccessOnClose(): void
     {
-        $mock = $this->container->mock();
+        $this->listener->startTestSuite(new TestSuite());
+
+        $container = Mockery::getContainer();
+        $mock = $container->mock();
         $mock->shouldReceive('bar')
             ->once();
         $mock->bar();
 
         // This is what MockeryPHPUnitIntegration and MockeryTestCase trait
         // will do. We intentionally call the static close method.
-        $this->test->addToAssertionCount($this->container->mockery_getExpectationCount());
+        $this->test->addToAssertionCount($container->mockery_getExpectationCount());
 
         Mockery::close();
 


### PR DESCRIPTION
This change proposes resetting the container when the testSuite is started. This fixes a false positive that is thrown by the TestListener when a mock is created before running the actual tests. 

This might require some context: We sometimes create mocks in PHPunit's dataproviders. This might not be intended, but for some of our tests it makes sense. When PHPunit runs, it will execute all dataproviders to determine all the test cases to run (for progress counts and filtering test cases). When mocks are created in the dataprovider, the mockery container is initialized before the actual tests are run. Afterward the test listener will assert that the container is closed on end of a test. If the first test that is executed is a test that does not use Mockery and thus does not close it, the testListener will issue a false possitive failure that Mockery's expectations are not verified. 

It can be summarized: 
- phpunit is started
- phpunit runs dataproviders
- dataprovider creates a mock
- Mockery container is created
- phpunit starts suite
- phpunit runs non-mockery test
- non-mockery test does not close Mockery
- non-mockery test ends
- phpunit triggers listener
- listener detects Mockery is not closed
- listener falsely reports failure

This change fixes it by resetting the container between creating mocks in data providers and running initial test

notes: 
- I had to remove some pre-condition checks in `\Tests\Unit\Mockery\Adapter\Phpunit\TestListenerTest::testMockeryIsAddedToBlacklist` as `\Mockery\Adapter\Phpunit\TestListener::startTestSuite` is now called multiple times in tests. It sets a singleton in PHPUnit, thus to keep tests independent I had to remove it. (other option would be to reset the internals of `\PHPUnit\Util\ExcludeList` using reflection, but that seems unwanted as it might change unexpectedly)