### PR TITLE
Add `withAndOthers` expectation shorthand

### DIFF
--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -797,7 +797,7 @@ class Expectation implements ExpectationInterface
 
     public function withAndOthers(...$args)
     {
-        return $this->withArgs([...$args, new AndAnyOtherArgs()]);
+        return $this->withArgs(array_merge($args, [new AndAnyOtherArgs()]));
     }
 
     /**

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -788,6 +788,19 @@ class Expectation implements ExpectationInterface
     }
 
     /**
+     * Set expectation that the given arguments are acceptable plus variable other arguments
+     *
+     * @param mixed ...$args
+     *
+     * @return self
+     */
+
+    public function withAndOther(...$args)
+    {
+        return $this->withArgs([...$args, new AndAnyOtherArgs()]);
+    }
+
+    /**
      * Set expectation that any arguments are acceptable
      *
      * @return self

--- a/library/Mockery/Expectation.php
+++ b/library/Mockery/Expectation.php
@@ -795,7 +795,7 @@ class Expectation implements ExpectationInterface
      * @return self
      */
 
-    public function withAndOther(...$args)
+    public function withAndOthers(...$args)
     {
         return $this->withArgs([...$args, new AndAnyOtherArgs()]);
     }

--- a/tests/Unit/Mockery/ExpectationTest.php
+++ b/tests/Unit/Mockery/ExpectationTest.php
@@ -1055,6 +1055,15 @@ final class ExpectationTest extends MockeryTestCase
         $this->mock->foo(1, 'k', new stdClass());
     }
 
+    public function testExpectsAndOthers(): void
+    {
+        $this->mock->shouldReceive('foo')
+            ->withAndOthers(1, 2)
+            ->times(2);
+        $this->mock->foo(1, 2);
+        $this->mock->foo(1, 2, new stdClass(), 'a', 'b', 'c');
+    }
+
     public function testExpectsArgumentMatchingObjectType(): void
     {
         $this->mock->shouldReceive('foo')


### PR DESCRIPTION
I want to request to add the `withAndOthers` shorthand function so people can more easily write expectations for (changing) optional arguments.

Usage:
```php
public function foobar(string $foo, int $bar, array $args = []): void
{
    // ...
}

$mock->shouldReceive('foobar')->withAndOthers('str', 123);
```

Use case: when I add a new optional parameter to a function, some testcases that use `$mock->with(...)` will fail (since a new parameter might now be included), however by using `$mock->withAndOthers(...)` I can indicate that the optional parameters have no expectation and will be accepted in any form.

I don't know if this requires a test since there is one already which tests the underlying logic:

https://github.com/mockery/mockery/blob/dca1e95368d49db1613998c2c1dfd5311e3c8f75/tests/Unit/Mockery/ExpectationTest.php#L139-L145