### PR TITLE
Fixed invalid variadic $args parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [1453: Misleading, possibly invalid, mock @param phpdoc signature for the variadic param $args](https://github.com/mockery/mockery/issues/1453)
+
 ## [1.6.12] - 2024-05-15
 
 ### Changed

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -418,7 +418,7 @@ class Mockery
      *
      * @template TInstanceMock
      *
-     * @param array<class-string<TInstanceMock>|TInstanceMock|array<mixed>> $args
+     * @param class-string<TInstanceMock>|TInstanceMock|array<mixed> ...$args
      *
      * @return LegacyMockInterface&MockInterface&TInstanceMock
      */
@@ -468,7 +468,7 @@ class Mockery
      *
      * @template TMock of object
      *
-     * @param array<class-string<TMock>|TMock|Closure(LegacyMockInterface&MockInterface&TMock):LegacyMockInterface&MockInterface&TMock|array<TMock>> $args
+     * @param class-string<TMock>|TMock|Closure(LegacyMockInterface&MockInterface&TMock):LegacyMockInterface&MockInterface&TMock|array<TMock> ...$args
      *
      * @return LegacyMockInterface&MockInterface&TMock
      */
@@ -496,7 +496,7 @@ class Mockery
      *
      * @template TNamedMock
      *
-     * @param array<class-string<TNamedMock>|TNamedMock|array<mixed>> $args
+     * @param class-string<TNamedMock>|TNamedMock|array<mixed> ...$args
      *
      * @return LegacyMockInterface&MockInterface&TNamedMock
      */
@@ -668,7 +668,7 @@ class Mockery
      *
      * @template TSpy
      *
-     * @param array<class-string<TSpy>|TSpy|Closure(LegacyMockInterface&MockInterface&TSpy):LegacyMockInterface&MockInterface&TSpy|array<TSpy>> $args
+     * @param class-string<TSpy>|TSpy|Closure(LegacyMockInterface&MockInterface&TSpy):LegacyMockInterface&MockInterface&TSpy|array<TSpy> ...$args
      *
      * @return LegacyMockInterface&MockInterface&TSpy
      */


### PR DESCRIPTION
The given phpdoc for:
- `\Mockery::mock`
- `\Mockery::spy`
- `\Mockery::namedMock`
- `\Mockery::instanceMock`

contained an invalid syntax for variadic types:
`@param array<class-string<TInstanceMock>|TInstanceMock|array<mixed>> $args`

correct syntax:
`@param class-string<TInstanceMock>|TInstanceMock|array<mixed> ...$args`

Closes #1453 