### PR TITLE
Bump jinja2 from 3.1.4 to 3.1.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.3.2
 docutils==0.20.1
 idna==3.7
 imagesize==1.4.1
-Jinja2==3.1.4
+Jinja2==3.1.5
 MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2


### PR DESCRIPTION
Fixes [CVE-2024-56201](https://github.com/advisories/GHSA-gmj6-6f8f-6699)