### PR TITLE
Fixes CVE-2025-27516

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.3.2
 docutils==0.20.1
 idna==3.7
 imagesize==1.4.1
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2025-27516 which show up because of the python dependencies in the docs.
We may end up whitelisting since we don't use python personally, but figured this would reduce some pain.