### PR TITLE
Docs: add alternative approaches for mocking final classes

### DIFF
--- a/docs/reference/creating_test_doubles.rst
+++ b/docs/reference/creating_test_doubles.rst
@@ -81,6 +81,7 @@ This stub or mock object will implement the ``MyInterface`` interface.
     Classes marked final, or classes that have methods marked final cannot be
     mocked fully. Mockery supports creating partial mocks for these cases.
     Partial mocks will be explained later in the documentation.
+    For more robust solutions to this issue, see :doc:`final_methods_classes`.
 
 Mockery also supports creating stub or mock objects based on a single existing
 class, which must implement one or more interfaces. We can do this by providing
@@ -287,6 +288,10 @@ marked final since the Proxy is not subject to those limitations. The tradeoff
 should be obvious - a proxied partial will fail any typehint checks for the
 class being mocked since it cannot extend that class.
 
+.. note::
+
+     For more robust solutions for final classes, see :doc:`final_methods_classes`.
+     
 .. _creating-test-doubles-aliasing:
 
 Aliasing

--- a/docs/reference/final_methods_classes.rst
+++ b/docs/reference/final_methods_classes.rst
@@ -9,7 +9,7 @@ classes or methods marked final is hard. The final keyword prevents methods so
 marked from being replaced in subclasses (subclassing is how mock objects can
 inherit the type of the class or object being mocked).
 
-The simplest solution is to implement an interface in your final class and 
+The simplest solution is to implement an interface in your final class and
 typehint against / mock this.
 
 However this may not be possible in some third party libraries.
@@ -32,6 +32,5 @@ about proxied partial test doubles.
 
     Some packages can bypass the ``final`` keyword at runtime, allowing you to use
     ``\Mockery::mock()`` without additional configuration. Consider these options:
-    
+
     * `dg/bypass-finals <https://github.com/dg/bypass-finals>`_
-    * `nunomaduro/mock-final-classes <https://github.com/nunomaduro/mock-final-classes>`_

--- a/docs/reference/final_methods_classes.rst
+++ b/docs/reference/final_methods_classes.rst
@@ -27,3 +27,11 @@ and meeting expectations.
 
 See the :ref:`creating-test-doubles-partial-test-doubles` chapter, the subsection
 about proxied partial test doubles.
+
+.. note::
+
+    Some packages can bypass the ``final`` keyword at runtime, allowing you to use
+    ``\Mockery::mock()`` without additional configuration. Consider these options:
+    
+    * `dg/bypass-finals <https://github.com/dg/bypass-finals>`_
+    * `nunomaduro/mock-final-classes <https://github.com/nunomaduro/mock-final-classes>`_

--- a/docs/reference/partial_mocks.rst
+++ b/docs/reference/partial_mocks.rst
@@ -90,6 +90,10 @@ marked final since the Proxy is not subject to those limitations. The tradeoff
 should be obvious - a proxied partial will fail any typehint checks for the
 class being mocked since it cannot extend that class.
 
+.. note::
+
+     For more robust solutions for final classes, see :doc:`final_methods_classes`.
+
 Special Internal Cases
 ----------------------
 


### PR DESCRIPTION
I know mentioning other packages in Mockery's documentation might not be appropriate, but in this case, I think it's a generous and helpful gesture for users.

Since Mockery is the most popular mocking library in PHP, many developers treat its documentation as the single source of truth for mocking dependencies in tests. So when Mockery says that for final classes there's almost nothing that can be done and suggests changing the design, most users don’t look for other solutions.

But when developers want to write strict code—marking classes as `final`, type-hinting properly, and using the full features of their frameworks like Laravel’s service container—they often face tough decisions.

So I thought it might be a good idea to briefly introduce packages that can remove the final keyword on the fly. This way, users can stay strict, enjoy their framework’s features, and still use Mockery with ease.

Thank you for considering this.