### PR TITLE
Bump `requests` from `2.32.0` to `2.32.4`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ Jinja2==3.1.6
 MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2
-requests==2.32.0
+requests==2.32.4
 setuptools==70.0.0
 snowballstemmer==2.2.0
 Sphinx==7.3.7


### PR DESCRIPTION
Upgrades `requests` to version `2.32.4`.

https://github.com/advisories/GHSA-9hjg-9r4m-mvj7