### PR TITLE
Bump `setuptools` from `70.0.0` to `78.1.1`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2
 requests==2.32.0
-setuptools==70.0.0
+setuptools==78.1.1
 snowballstemmer==2.2.0
 Sphinx==7.3.7
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
Upgrades `setuptools` to version `78.1.1`.

https://github.com/advisories/GHSA-5rjg-fvgr-3xxf


Closes #1464