### PR TITLE
Bump `urllib3` from `2.2.2` to `2.5.0`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,5 +21,5 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
-urllib3==2.2.2
+urllib3==2.5.0
 wheel==0.43.0


### PR DESCRIPTION
Upgrades `urllib3` to version `2.5.0`.

https://github.com/advisories/GHSA-pq67-6m6q-mj2v
https://github.com/advisories/GHSA-48p4-8xcf-vxj5