### PR TITLE
Add `__unserialize`

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -717,6 +717,16 @@ class Mock implements MockInterface
          */
     }
 
+    public function __unserialize(array $data)
+    {
+        /**
+         * This does not add __unserialize method support. It's a blind method and any
+         * expected __unserialize work will NOT be performed. It merely cuts off
+         * annoying errors where a __unserialize exists but is not essential when
+         * mocking
+         */
+    }
+
     public function __destruct()
     {
         /**


### PR DESCRIPTION
Prevent deprecation warnings for `__wakeup` on PHP 8.5. See https://wiki.php.net/rfc/deprecations_php_8_5

Untested because I couldn't get tests to run locally. But this should hopefully get the discussion started.

Fixes #1471