### PR TITLE
Mock demeter chains and fluent interface methods with `static` return type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "security": "https://github.com/mockery/mockery/security/advisories"
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.3|>=8.0",
         "lib-pcre": ">=7.0",
         "hamcrest/hamcrest-php": "^2.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "security": "https://github.com/mockery/mockery/security/advisories"
     },
     "require": {
-        "php": ">=7.3|>=8.0",
+        "php": ">=7.3",
         "lib-pcre": ">=7.0",
         "hamcrest/hamcrest-php": "^2.0.1"
     },

--- a/library/Mockery.php
+++ b/library/Mockery.php
@@ -13,6 +13,7 @@ use Mockery\CompositeExpectation;
 use Mockery\Configuration;
 use Mockery\Container;
 use Mockery\Exception as MockeryException;
+use Mockery\ExpectationDirector;
 use Mockery\ExpectationInterface;
 use Mockery\Generator\CachingGenerator;
 use Mockery\Generator\Generator;
@@ -670,7 +671,7 @@ class Mockery
      *
      * @param class-string<TSpy>|TSpy|Closure(LegacyMockInterface&MockInterface&TSpy):LegacyMockInterface&MockInterface&TSpy|array<TSpy> ...$args
      *
-     * @return LegacyMockInterface&MockInterface&TSpy
+     * @return (LegacyMockInterface&TSpy)|(MockInterface&TSpy)
      */
     public static function spy(...$args)
     {
@@ -723,8 +724,6 @@ class Mockery
         $container = $mock->mockery_getContainer();
         $methodNames = \explode('->', $arg);
 
-        \reset($methodNames);
-
         if (
             ! $mock->mockery_isAnonymous()
             && ! self::getConfiguration()->mockingNonExistentMethodsAllowed()
@@ -737,37 +736,36 @@ class Mockery
             );
         }
 
-        /** @var Closure $nextExp */
-        $nextExp = static function ($method) use ($add) {
+        $nextExpectation = static function (string $method) use ($add): ExpectationInterface {
             return $add($method);
         };
 
         $parent = \get_class($mock);
 
-        /** @var null|ExpectationInterface $expectations */
-        $expectations = null;
         while (true) {
             $method = \array_shift($methodNames);
+
+            if (empty($methodNames)) {
+                $expectations = $nextExpectation($method);
+                break;
+            }
+
             $expectations = $mock->mockery_getExpectationsFor($method);
 
-            if ($expectations === null || self::noMoreElementsInChain($methodNames)) {
-                $expectations = $nextExp($method);
-                if (self::noMoreElementsInChain($methodNames)) {
-                    break;
-                }
-
-                $mock = self::getNewDemeterMock($container, $parent, $method, $expectations);
-            } else {
+            if ($expectations instanceof ExpectationDirector) {
                 $demeterMockKey = $container->getKeyOfDemeterMockFor($method, $parent);
-                if ($demeterMockKey !== null) {
+                if (\is_string($demeterMockKey)) {
                     $mock = self::getExistingDemeterMock($container, $demeterMockKey);
                 }
+            } else {
+                $expectations = $nextExpectation($method);
+                $mock = self::getNewDemeterMock($container, $parent, $method, $expectations);
             }
 
             $parent .= '->' . $method;
 
-            $nextExp = static function ($n) use ($mock) {
-                return $mock->allows($n);
+            $nextExpectation = static function (string $method) use ($mock) {
+                return $mock->allows($method);
             };
         }
 
@@ -956,7 +954,7 @@ class Mockery
      *
      * @param class-string<TMock> $demeterMockKey
      *
-     * @return null|(LegacyMockInterface&MockInterface&TMock)
+     * @return null|((LegacyMockInterface&TMock)|(MockInterface&TMock))
      */
     private static function getExistingDemeterMock(Container $container, $demeterMockKey)
     {
@@ -972,60 +970,53 @@ class Mockery
      *
      * @return LegacyMockInterface&MockInterface
      */
-    private static function getNewDemeterMock(Container $container, $parent, $method, ExpectationInterface $exp)
+    private static function getNewDemeterMock(Container $container, $parent, $method, ExpectationInterface $expectation)
     {
         $newMockName = 'demeter_' . \md5($parent) . '_' . $method;
+        $parentMock = $expectation->getMock();
 
-        $parRef = null;
+        if (! $parentMock instanceof LegacyMockInterface) {
+            $mock = $container->mock($newMockName);
+            $expectation->andReturn($mock);
 
-        $parentMock = $exp->getMock();
-        if ($parentMock !== null) {
-            $parRef = new ReflectionObject($parentMock);
+            return $mock;
         }
 
-        if ($parRef instanceof ReflectionObject && $parRef->hasMethod($method)) {
-            $parRefMethod = $parRef->getMethod($method);
-            $parRefMethodRetType = Reflector::getReturnType($parRefMethod, true);
+        $parentMockReflectionObject = new ReflectionObject($parentMock);
 
-            if ($parRefMethodRetType !== null) {
-                $returnTypes = \explode('|', $parRefMethodRetType);
+        if (! $parentMockReflectionObject->hasMethod($method)) {
+            $mock = $container->mock($newMockName);
+            $expectation->andReturn($mock);
 
-                $filteredReturnTypes = array_filter($returnTypes, static function (string $type): bool {
-                    return ! Reflector::isReservedWord($type);
-                });
-
-                if ($filteredReturnTypes !== []) {
-                    $nameBuilder = new MockNameBuilder();
-
-                    $nameBuilder->addPart('\\' . $newMockName);
-
-                    $mock = self::namedMock(
-                        $nameBuilder->build(),
-                        ...$filteredReturnTypes
-                    );
-
-                    $exp->andReturn($mock);
-
-                    return $mock;
-                }
-            }
+            return $mock;
         }
 
-        $mock = $container->mock($newMockName);
-        $exp->andReturn($mock);
+        $parRefMethodRetType = Reflector::getReturnType($parentMockReflectionObject->getMethod($method), true);
+        if (! \is_string($parRefMethodRetType)) {
+            $mock = $container->mock($newMockName);
+            $expectation->andReturn($mock);
+            return $mock;
+        }
+
+        if ($parRefMethodRetType === 'self' || $parRefMethodRetType === 'static') {
+            $expectation->andReturn($parentMock);
+            return $parentMock;
+        }
+
+        $nameBuilder = new MockNameBuilder();
+
+        $nameBuilder->addPart('\\' . $newMockName);
+
+        $mock = self::namedMock(
+            $nameBuilder->build(),
+            ...\array_filter(\explode('|', $parRefMethodRetType), static function (string $type): bool {
+                return ! Reflector::isReservedWord($type);
+            })
+        );
+
+        $expectation->andReturn($mock);
 
         return $mock;
-    }
-
-    /**
-     * Checks if the passed array representing a demeter
-     * chain with the method names is empty.
-     *
-     * @return bool
-     */
-    private static function noMoreElementsInChain(array $methodNames)
-    {
-        return $methodNames === [];
     }
 
     /**

--- a/tests/Fixture/PHP80/PHP80TestInterface.php
+++ b/tests/Fixture/PHP80/PHP80TestInterface.php
@@ -6,4 +6,7 @@ namespace PHP80;
 
 interface PHP80TestInterface
 {
+    public function do(): static;
+
+    public function thing(): static;
 }

--- a/tests/Unit/Mockery/DemeterChainTest.php
+++ b/tests/Unit/Mockery/DemeterChainTest.php
@@ -41,6 +41,18 @@ final class DemeterChainTest extends MockeryTestCase
         self::assertSame('somethingElse', $this->mock->getElement()->getFirst());
     }
 
+    /**
+     * @requires PHP >=8.0
+     */
+    public function testDemeterChainsOnInterfaceSubjects(): void
+    {
+        $mock = Mockery::mock(\PHP80\PHP80TestInterface::class);
+
+        $mock->shouldReceive('do->thing');
+
+        self::assertInstanceOf(\PHP80\PHP80TestInterface::class, $mock->do()->thing());
+    }
+
     public function testDemeterChainsWithClassReturnTypeHints(): void
     {
         $a = Mockery::mock(\DemeterChain\A::class);
@@ -178,16 +190,5 @@ final class DemeterChainTest extends MockeryTestCase
 
         self::assertSame('somethingElse', $this->mock->getOtherElement() ->getSecond());
         self::assertSame('something', $this->mock->getElement()->getFirst());
-    }
-
-    public function testDemeterChainsOnInterfaceSubjects()
-    {
-        $mock = Mockery::mock(\PHP80\PHP80TestInterface::class);
-        $mock->shouldReceive('do->thing')
-            ->andReturn(null);
-
-        $value = $mock->do()->thing();
-        
-        $this->assertNull($value);
     }
 }

--- a/tests/Unit/Mockery/DemeterChainTest.php
+++ b/tests/Unit/Mockery/DemeterChainTest.php
@@ -179,4 +179,15 @@ final class DemeterChainTest extends MockeryTestCase
         self::assertSame('somethingElse', $this->mock->getOtherElement() ->getSecond());
         self::assertSame('something', $this->mock->getElement()->getFirst());
     }
+
+    public function testDemeterChainsOnInterfaceSubjects()
+    {
+        $mock = Mockery::mock(\PHP80\PHP80TestInterface::class);
+        $mock->shouldReceive('do->thing')
+            ->andReturn(null);
+
+        $value = $mock->do()->thing();
+        
+        $this->assertNull($value);
+    }
 }


### PR DESCRIPTION
As per the title, this isn't a solution to #1447 but instead illustrates the bug with a new test case.

We use the static return type for interfaces, as self can result in child classes not being able to work with said interface.

In short, if you have an interface method signature which has a static return type, mockery fails:

```cli
ParseError: syntax error, unexpected token "static", expecting identifier
```

The test case added shows this aspect failing. I've tried solving this but honestly, I am struggling to follow the mockery code, so any guidance would be appreciated and I'll update this PR to solve the problem appropriately.

Note that this can still be done with a hacky utility method we wrote as a wrapper to help us still use demeter chain expectations on interfaces:

```php
protected function demeter(MockInterface $mock, string $chain): HigherOrderMessage|Expectation|ExpectationInterface
{
    $expectations = explode('->', $chain);
    $final = array_pop($expectations);

    $mock->shouldReceive(Arr::mapWithKeys($expectations, fn($expectation) => [$expectation => $mock]));

    return $mock->shouldReceive($final);
}
```

And it can also be done using array expectations:

```php
$mock->shouldReceive(['do' => $mock, 'thing' => $mock])->andReturn(...);
```

So it seems to me that something funky is going on specifically with interfaces deeper down in the mockery code. Ideally, we want to be able to support demeter chain mocks on interface methods with static return types.