### PR TITLE
Update .gitattributes: add `docs/`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 /.github export-ignore
 /.gitignore export-ignore
 /docker export-ignore
+/docs export-ignore
 /e2e-test.sh export-ignore
 /ecs.php export-ignore
 /Makefile export-ignore


### PR DESCRIPTION
Hello,

I would like to propose to prevent docs/ from being packaged up and installed when installing this package.

Reasons:
- I believe in general it's not useful to have the _complete_ docs with every installation (in contrast to single files like CHANGELOG or so)
- This file contains python specific `requirements.txt` which, whilst being updated over time, even the latest Mockery release 1.6.12 contains a list of packages triggering security scanners.

Whilst I know there is no attack surface at all here and I know it's a dev dependency, security scanning tools don't know this and create alerts.

Thanks