### PR TITLE
Update urllib3 version requirement in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,5 +21,5 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
-urllib3==2.5.0
+urllib3>=2.6.3
 wheel==0.43.0


### PR DESCRIPTION
Changed `urllib3` dependency from an exact version (`2.5.0`) to a minimum version (`>=2.6.3`) in `docs/requirements.txt`.