### PR TITLE
Update wheel version requirement for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,5 +21,5 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
-urllib3>=2.6.3
-wheel==0.43.0
+urllib3==2.6.3
+wheel==0.46.2


### PR DESCRIPTION
Bumps `wheel` dependency from version `0.43.0` to version `0.46.2` in `docs/requirements.txt`.

https://github.com/advisories/GHSA-8rrh-rw8j-w5fx