### PR TITLE
Bump `Pygments` from `2.17.2` to `2.20.0`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ imagesize==1.4.1
 Jinja2==3.1.6
 MarkupSafe==2.1.5
 packaging==24.0
-Pygments==2.17.2
+Pygments==2.20.0
 requests==2.32.4
 setuptools==78.1.1
 snowballstemmer==2.2.0


### PR DESCRIPTION
Fixes [CVE-2026-4539](https://github.com/advisories/GHSA-5239-wwwm-4pmq)