### PR TITLE
Bump `requests` from `2.32.4` to `2.33.0`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ Jinja2==3.1.6
 MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.17.2
-requests==2.32.4
+requests==2.33.0
 setuptools==78.1.1
 snowballstemmer==2.2.0
 Sphinx==7.3.7


### PR DESCRIPTION
Fixes [CVE-2026-25645](https://github.com/advisories/GHSA-gc5v-m9x4-r6x2)