### PR TITLE
Add export-ignore rules to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,6 @@
 /psalm.xml.dist export-ignore
 /tests export-ignore
 /tools export-ignore
+/composer.lock export-ignore
+/COPYRIGHT.md export-ignore
+/.readthedocs.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,5 +18,4 @@
 /tests export-ignore
 /tools export-ignore
 /composer.lock export-ignore
-/COPYRIGHT.md export-ignore
 /.readthedocs.yml export-ignore


### PR DESCRIPTION
Current archive targets other than library/ will be as follows:
```bash
gh api repos/mockery/mockery/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^library/' | sort
```

```
CHANGELOG.md
composer.json
composer.lock
CONTRIBUTING.md
COPYRIGHT.md
LICENSE
.phpstorm.meta.php
README.md
.readthedocs.yml
SECURITY.md
```

With this PR, the archive targets other than library/ will be as follows:
```bash
gh api repos/sasezaki/mockery/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^library/' | sort
```

```
CHANGELOG.md
composer.json
CONTRIBUTING.md
COPYRIGHT.md
LICENSE
.phpstorm.meta.php
README.md
SECURITY.md
```

Changes:
- Added `/composer.lock export-ignore`
- Added `/.readthedocs.yml export-ignore`
---
> **Note:** `composer.lock` is included in dist archives by default, but for libraries it is unnecessary — Composer ignores `composer.lock` from dependencies and resolves versions from `composer.json` alone. Excluding it keeps the dist archive clean.
> **Personal opinion:** `CONTRIBUTING.md` exists in this repository. I personally consider it unnecessary in the dist archive, but I have chosen not to add it to `export-ignore`.
