### PR TITLE
Bump `urllib3` from `2.6.3` to `2.7.0`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,5 +21,5 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
-urllib3==2.6.3
+urllib3==2.7.0
 wheel==0.46.2


### PR DESCRIPTION
Fixes [CVE-2026-44431](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) and [CVE-2026-44432](https://github.com/advisories/GHSA-mf9v-mfxr-j63j)