### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,4 @@
 /tools export-ignore
 /composer.lock export-ignore
 /.readthedocs.yml export-ignore
+/CONTRIBUTING.md export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was daad681 (2026-05-05, #1483). The files below have been added or modified since, and are still included in the composer dist:
- `/CONTRIBUTING.md export-ignore` — last touched in 5ee21d6 2023-12-10

Background reading: https://blog.madewithlove.be/post/gitattributes/