### PR TITLE
Bump `idna` from `3.7` to `3.15`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ Babel==2.14.0
 certifi==2024.07.04
 charset-normalizer==3.3.2
 docutils==0.20.1
-idna==3.7
+idna==3.15
 imagesize==1.4.1
 Jinja2==3.1.6
 MarkupSafe==2.1.5


### PR DESCRIPTION
Fixes [CVE-2026-45409](https://github.com/advisories/GHSA-65pc-fj4g-8rjx)