### PR TITLE
Fix readonly class mock handling

### DIFF
--- a/library/Mockery/Generator/DefinedTargetClass.php
+++ b/library/Mockery/Generator/DefinedTargetClass.php
@@ -185,4 +185,12 @@ class DefinedTargetClass implements TargetClassInterface
     {
         return $this->rfc->isFinal();
     }
+
+    /**
+     * @return bool
+     */
+    public function isReadOnly()
+    {
+        return PHP_VERSION_ID >= 80200 && $this->rfc->isReadOnly();
+    }
 }

--- a/library/Mockery/Generator/MockConfiguration.php
+++ b/library/Mockery/Generator/MockConfiguration.php
@@ -373,6 +373,16 @@ class MockConfiguration
                 );
             }
 
+            if ($this->getTargetObject() === null && $dtc->isReadOnly()) {
+                throw new Exception(
+                    'The class ' . $this->targetClassName . ' is marked readonly and its methods'
+                    . ' cannot be replaced. Classes marked readonly can be passed in'
+                    . ' to \Mockery::mock() as instantiated objects to create a'
+                    . ' partial mock, but only if the mock is not subject to type'
+                    . ' hinting checks.'
+                );
+            }
+
             $this->targetClass = $dtc;
         } else {
             $this->targetClass = UndefinedTargetClass::factory($this->targetClassName);

--- a/tests/Fixture/PHP83/Classes.php
+++ b/tests/Fixture/PHP83/Classes.php
@@ -7,3 +7,10 @@ namespace PHP83;
 class Classes implements Interfaces {
     use Traits;
 }
+
+readonly class ReadonlyClass {
+    public function foo(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Unit/PHP83/Php83LanguageFeaturesTest.php
+++ b/tests/Unit/PHP83/Php83LanguageFeaturesTest.php
@@ -10,6 +10,7 @@ use PHP83\Classes;
 use PHP83\ClassName;
 use PHP83\Enums;
 use PHP83\Interfaces;
+use PHP83\ReadonlyClass;
 use PHP83\Traits;
 
 /**
@@ -62,5 +63,13 @@ final class Php83LanguageFeaturesTest extends MockeryTestCase
         $this->expectException(Exception::class);
 
         \mock(Enums::class);
+    }
+
+    public function testCanNotMockReadonlyClasses(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('is marked readonly');
+
+        \mock(ReadonlyClass::class);
     }
 }


### PR DESCRIPTION
Fixes #1490.

Readonly classes cannot be extended by generated mocks on PHP 8.2+, so this
detects readonly targets before code generation and raises a Mockery exception
instead of allowing invalid generated PHP to be evaluated.

Validation:

```bash
docker run --rm -v "$PWD:/app" -w /app php:8.3-cli sh -lc 'vendor/bin/phpunit tests/Unit/PHP83/Php83LanguageFeaturesTest.php'
# OK (6 tests, 13 assertions)

docker run --rm -v "$PWD:/app" -w /app php:8.3-cli sh -lc 'vendor/bin/phpunit tests/Unit/Mockery/MockConfigurationTest.php tests/Unit/Mockery/Generator/DefinedTargetClassTest.php'
# OK (12 tests, 25 assertions)

docker run --rm -v "$PWD:/app" -w /app php:8.3-cli sh -lc 'timeout 5s php .oss-factory/repro-readonly.php; code=$?; echo EXIT:$code'
# Prints A, then Mockery\Exception containing "is marked readonly"; EXIT:255

docker run --rm -v "$PWD:/app" -w /app php:8.3-cli sh -lc 'timeout 5s php .oss-factory/repro-non-readonly.php; code=$?; echo EXIT:$code'
# A / B / EXIT:0
```
