### PR TITLE
Do not return from constructors/destructors

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -24,9 +24,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: none
-          php-version: 8.4
+          php-version: 8.5
           ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
-          tools: psalm:6.7.1
+          tools: psalm:6.16.1
 
       - name: Get composer cache directory
         id: composer-cache

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -72,11 +72,13 @@ class MethodDefinitionPass implements Pass
     protected function renderParams(Method $method, $config)
     {
         $class = $method->getDeclaringClass();
+        $className = strtolower($class->getName());
+        $methodName = $method->getName();
         if ($class->isInternal()) {
             $overrides = $config->getParameterOverrides();
 
-            if (isset($overrides[strtolower($class->getName())][$method->getName()])) {
-                return '(' . implode(',', $overrides[strtolower($class->getName())][$method->getName()]) . ')';
+            if (isset($overrides[$className][$methodName])) {
+                return '(' . implode(',', $overrides[$className][$methodName]) . ')';
             }
         }
 
@@ -140,8 +142,9 @@ class MethodDefinitionPass implements Pass
         return $typeHint === null ? '' : sprintf('%s ', $typeHint);
     }
 
-    private function renderMethodBody($method, $config)
+    private function renderMethodBody(Method $method, MockConfiguration $config)
     {
+        $methodName = $method->getName();
         $invoke = $method->isStatic() ? 'static::_mockery_handleStaticMethodCall' : '$this->_mockery_handleMethodCall';
         $body = <<<BODY
 {
@@ -154,10 +157,10 @@ BODY;
         // in case more parameters are passed in than the function definition
         // says - eg varargs.
         $class = $method->getDeclaringClass();
-        $class_name = strtolower($class->getName());
+        $className = strtolower($class->getName());
         $overrides = $config->getParameterOverrides();
-        if (isset($overrides[$class_name][$method->getName()])) {
-            $params = array_values($overrides[$class_name][$method->getName()]);
+        if (isset($overrides[$className][$methodName])) {
+            $params = array_values($overrides[$className][$methodName]);
             $paramCount = count($params);
             for ($i = 0; $i < $paramCount; ++$i) {
                 $param = $params[$i];

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -188,13 +188,34 @@ BODY;
             }
         }
 
-        $body .= "\$ret = {$invoke}(__FUNCTION__, \$argv);\n";
+        if ($this->shouldReturnValue($method)) {
+            $body .= "\$ret = {$invoke}(__FUNCTION__, \$argv);\n";
 
-        // Returning a value from a constructor is deprecated as of PHP 8.6.
-        if ($method->getName() !== '__construct' && ! in_array($method->getReturnType(), ['never', 'void'], true)) {
             $body .= "return \$ret;\n";
+
+            return $body . "}\n";
         }
 
+        $body .= "{$invoke}(__FUNCTION__, \$argv);\n";
+
         return $body . "}\n";
+    }
+
+    private function shouldReturnValue(Method $method): bool
+    {
+        $returnType = $method->getReturnType();
+        if ($returnType === 'void' || $returnType === 'never') {
+            return false;
+        }
+
+        /**
+         * @see https://wiki.php.net/rfc/deprecate-return-value-from-construct
+         */
+        $methodName = strtolower($method->getName());
+        if ($methodName === '__construct' || $methodName === '__destruct') {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
+++ b/library/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPass.php
@@ -190,7 +190,8 @@ BODY;
 
         $body .= "\$ret = {$invoke}(__FUNCTION__, \$argv);\n";
 
-        if (! in_array($method->getReturnType(), ['never', 'void'], true)) {
+        // Returning a value from a constructor is deprecated as of PHP 8.6.
+        if ($method->getName() !== '__construct' && ! in_array($method->getReturnType(), ['never', 'void'], true)) {
             $body .= "return \$ret;\n";
         }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1385,6 +1385,7 @@ MOCK]]></code>
       <code><![CDATA[getName]]></code>
       <code><![CDATA[getName]]></code>
       <code><![CDATA[getName]]></code>
+      <code><![CDATA[getName]]></code>
       <code><![CDATA[getParameterOverrides]]></code>
       <code><![CDATA[getParameterOverrides]]></code>
       <code><![CDATA[getParameters]]></code>
@@ -4892,6 +4893,21 @@ MOCK]]></code>
     </MissingThrowsDocblock>
     <UnusedClass>
       <code><![CDATA[InterfacePassTest]]></code>
+    </UnusedClass>
+  </file>
+  <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[self::assertFalse(\mb_strpos($constructor, 'return $ret;'))]]></code>
+      <code><![CDATA[self::assertFalse(\mb_strpos($constructor, 'return $ret;'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, '_mockery_handleMethodCall'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, '_mockery_handleMethodCall'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, 'public function __construct'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, 'public function __construct'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($method, 'return $ret;'))]]></code>
+      <code><![CDATA[self::assertNotFalse(\mb_strpos($method, 'return $ret;'))]]></code>
+    </MissingThrowsDocblock>
+    <UnusedClass>
+      <code><![CDATA[MethodDefinitionPassTest]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/GlobalHelpersTest.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.7.1@a2f190972555ea01b0cfcc1913924d6c5fc1a64e">
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
   <file src="library/Mockery.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$demeterMockKey]]></code>
@@ -485,10 +485,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AtLeast]]></code>
     </ClassMustBeFinal>
-    <InvalidOperand>
-      <code><![CDATA[$n]]></code>
-      <code><![CDATA[$this->_limit]]></code>
-    </InvalidOperand>
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
@@ -501,10 +497,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[AtMost]]></code>
     </ClassMustBeFinal>
-    <InvalidOperand>
-      <code><![CDATA[$n]]></code>
-      <code><![CDATA[$this->_limit]]></code>
-    </InvalidOperand>
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
@@ -535,10 +527,6 @@
     <ClassMustBeFinal>
       <code><![CDATA[Exact]]></code>
     </ClassMustBeFinal>
-    <InvalidOperand>
-      <code><![CDATA[$n]]></code>
-      <code><![CDATA[$this->_limit]]></code>
-    </InvalidOperand>
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
@@ -622,9 +610,6 @@
     <InvalidArgument>
       <code><![CDATA[$argsOrClosure]]></code>
     </InvalidArgument>
-    <InvalidOperand>
-      <code><![CDATA[$index]]></code>
-    </InvalidOperand>
     <InvalidStringClass>
       <code><![CDATA[new $exception($message, $code, $previous)]]></code>
       <code><![CDATA[new $this->_countValidatorClass($this, $limit)]]></code>
@@ -1024,9 +1009,6 @@
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$params[1]]]></code>
     </PossiblyUndefinedIntArrayOffset>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getParameterOverrides]]></code>
-    </PossiblyUnusedMethod>
     <PropertyTypeCoercion>
       <code><![CDATA[$methods]]></code>
     </PropertyTypeCoercion>
@@ -1102,9 +1084,6 @@
     <InvalidArgument>
       <code><![CDATA[false]]></code>
     </InvalidArgument>
-    <InvalidOperand>
-      <code><![CDATA[self::$parameterCounter++]]></code>
-    </InvalidOperand>
     <InvalidReturnStatement>
       <code><![CDATA[class_exists($typeHint) ? DefinedTargetClass::factory($typeHint, false) : null]]></code>
     </InvalidReturnStatement>
@@ -1330,10 +1309,6 @@ MOCK]]></code>
     <InvalidCast>
       <code><![CDATA[$param]]></code>
     </InvalidCast>
-    <InvalidMethodCall>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[isPassedByReference]]></code>
-    </InvalidMethodCall>
     <MissingOverrideAttribute>
       <code><![CDATA[public function apply($code, MockConfiguration $config)]]></code>
     </MissingOverrideAttribute>
@@ -1341,8 +1316,6 @@ MOCK]]></code>
       <code><![CDATA[$class]]></code>
       <code><![CDATA[$code]]></code>
       <code><![CDATA[$config]]></code>
-      <code><![CDATA[$config]]></code>
-      <code><![CDATA[$method]]></code>
     </MissingParamType>
     <MissingReturnType>
       <code><![CDATA[appendToClass]]></code>
@@ -1354,43 +1327,24 @@ MOCK]]></code>
     <MixedArgument>
       <code><![CDATA[$class]]></code>
       <code><![CDATA[$class]]></code>
-      <code><![CDATA[$class->getName()]]></code>
-      <code><![CDATA[$method->getParameters()]]></code>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
+      <code><![CDATA[$overrides[$className][$methodName]]]></code>
+      <code><![CDATA[$overrides[$className][$methodName]]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$param]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code><![CDATA[$overrides[$class_name]]]></code>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())]]]></code>
-      <code><![CDATA[$overrides[strtolower($class->getName())][$method->getName()]]]></code>
+      <code><![CDATA[$overrides[$className]]]></code>
+      <code><![CDATA[$overrides[$className][$methodName]]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-      <code><![CDATA[$overrides[$class_name][$method->getName()]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$class]]></code>
       <code><![CDATA[$code]]></code>
       <code><![CDATA[$defaultValue]]></code>
-      <code><![CDATA[$overrides]]></code>
       <code><![CDATA[$overrides]]></code>
       <code><![CDATA[$paramDef]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code><![CDATA[getDeclaringClass]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getName]]></code>
       <code><![CDATA[getParameterOverrides]]></code>
-      <code><![CDATA[getParameterOverrides]]></code>
-      <code><![CDATA[getParameters]]></code>
-      <code><![CDATA[getReturnType]]></code>
-      <code><![CDATA[isStatic]]></code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$code]]></code>
@@ -1408,6 +1362,9 @@ MOCK]]></code>
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$matches[1]]]></code>
     </PossiblyUndefinedIntArrayOffset>
+    <RedundantFunctionCallGivenDocblockType>
+      <code><![CDATA[array_values]]></code>
+    </RedundantFunctionCallGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$type]]></code>
     </RiskyTruthyFalsyComparison>
@@ -1916,9 +1873,6 @@ MOCK]]></code>
     <DeprecatedClass>
       <code><![CDATA[MatcherAbstract]]></code>
     </DeprecatedClass>
-    <InvalidOperand>
-      <code><![CDATA[$k]]></code>
-    </InvalidOperand>
     <MissingOverrideAttribute>
       <code><![CDATA[public function match(&$actual)]]></code>
     </MissingOverrideAttribute>
@@ -1995,10 +1949,6 @@ MOCK]]></code>
       <code><![CDATA[$method === null]]></code>
       <code><![CDATA[$method === null]]></code>
     </DocblockTypeContradiction>
-    <InvalidOperand>
-      <code><![CDATA[$order]]></code>
-      <code><![CDATA[$this->_mockery_currentOrder]]></code>
-    </InvalidOperand>
     <InvalidReturnStatement>
       <code><![CDATA[$director]]></code>
       <code><![CDATA[new HigherOrderMessage($this, 'shouldHaveReceived')]]></code>
@@ -4896,16 +4846,6 @@ MOCK]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php">
-    <MissingThrowsDocblock>
-      <code><![CDATA[self::assertFalse(\mb_strpos($constructor, 'return $ret;'))]]></code>
-      <code><![CDATA[self::assertFalse(\mb_strpos($constructor, 'return $ret;'))]]></code>
-      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, '_mockery_handleMethodCall'))]]></code>
-      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, '_mockery_handleMethodCall'))]]></code>
-      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, 'public function __construct'))]]></code>
-      <code><![CDATA[self::assertNotFalse(\mb_strpos($constructor, 'public function __construct'))]]></code>
-      <code><![CDATA[self::assertNotFalse(\mb_strpos($method, 'return $ret;'))]]></code>
-      <code><![CDATA[self::assertNotFalse(\mb_strpos($method, 'return $ret;'))]]></code>
-    </MissingThrowsDocblock>
     <UnusedClass>
       <code><![CDATA[MethodDefinitionPassTest]]></code>
     </UnusedClass>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -27,7 +27,7 @@
     useDocblockPropertyTypes="true"
     usePhpDocMethodsWithoutMagicCall="true"
     usePhpDocPropertiesWithoutMagicCall="true"
-    phpVersion="8.4"
+    phpVersion="8.5"
 >
     <projectFiles>
         <directory name="library"/>

--- a/tests/Fixture/PHP85/Temp.php
+++ b/tests/Fixture/PHP85/Temp.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHP85;
+
+readonly class Temp
+{
+
+}

--- a/tests/Fixture/PHP86/ClassWithConstructorAndDestructor.php
+++ b/tests/Fixture/PHP86/ClassWithConstructorAndDestructor.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHP86;
+
+class ClassWithConstructorAndDestructor
+{
+    public function __construct(public int $number) {}
+
+    public function __destruct() {}
+
+    public function number(): int
+    {
+        return $this->number;
+    }
+
+    public function voidMethod(): void
+    {
+    }
+
+    public function neverMethod(): never
+    {
+        throw new \RuntimeException('This method never returns.');
+    }
+}

--- a/tests/Fixture/PHP86/ClassWithConstructorAndDestructor.php
+++ b/tests/Fixture/PHP86/ClassWithConstructorAndDestructor.php
@@ -6,7 +6,11 @@ namespace PHP86;
 
 class ClassWithConstructorAndDestructor
 {
-    public function __construct(public int $number) {}
+    private $number;
+
+    public function __construct(int $number) {
+        $this->number = $number;
+    }
 
     public function __destruct() {}
 

--- a/tests/Fixture/autoload.php
+++ b/tests/Fixture/autoload.php
@@ -6,18 +6,28 @@ use Composer\Autoload\ClassLoader;
 
 $rootDir = dirname(__DIR__, 2);
 
-$loader = require $rootDir . '/vendor/autoload.php';
+$loader = require \implode(DIRECTORY_SEPARATOR, [$rootDir, 'vendor', 'autoload.php']);
 
-if (! $loader instanceof ClassLoader){
+if (! $loader instanceof ClassLoader) {
     throw new \RuntimeException('Unable to load ' . ClassLoader::class);
 }
 
-$loader->add('', $rootDir . '/tests/Fixture/Namespaced');
-$loader->addPsr4('PHP73\\', $rootDir . '/tests/Fixture/PHP73');
-$loader->addPsr4('PHP74\\', $rootDir . '/tests/Fixture/PHP74');
-$loader->addPsr4('PHP80\\', $rootDir . '/tests/Fixture/PHP80');
-$loader->addPsr4('PHP81\\', $rootDir . '/tests/Fixture/PHP81');
-$loader->addPsr4('PHP82\\', $rootDir . '/tests/Fixture/PHP82');
-$loader->addPsr4('PHP83\\', $rootDir . '/tests/Fixture/PHP83');
-$loader->addPsr4('PHP84\\', $rootDir . '/tests/Fixture/PHP84');
-$loader->addPsr4('Tests\\', $rootDir . '/tests');
+$testsDir = \implode(DIRECTORY_SEPARATOR, [$rootDir, 'tests']);
+if (! \is_dir($testsDir)) {
+    throw new \RuntimeException('Unable to find tests directory: ' . $testsDir);
+}
+
+$loader->addPsr4('Tests\\Unit\\', $testsDir . DIRECTORY_SEPARATOR . 'Unit');
+
+$fixtureDir = \implode(DIRECTORY_SEPARATOR, [$testsDir, 'Fixture']);
+if (! \is_dir($fixtureDir)) {
+    throw new \RuntimeException('Unable to find fixture directory: ' . $fixtureDir);
+}
+
+$loader->add('', $fixtureDir . DIRECTORY_SEPARATOR . 'Namespaced');
+
+$versions = ['PHP73', 'PHP74', 'PHP80', 'PHP81', 'PHP82', 'PHP83', 'PHP84', 'PHP85', 'PHP86'];
+
+foreach ($versions as $version) {
+    $loader->addPsr4($version . '\\', $fixtureDir . DIRECTORY_SEPARATOR . $version);
+}

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Mockery\Generator\StringManipulation\Pass;
+
+use Mockery\Generator\MockConfiguration;
+use Mockery\Generator\StringManipulation\Pass\MethodDefinitionPass;
+use PHP73\MockeryTest_ClassMultipleConstructorParams;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Mockery
+ */
+final class MethodDefinitionPassTest extends TestCase
+{
+    public function testConstructorDoesNotReturnAValue(): void
+    {
+        $config = new MockConfiguration([MockeryTest_ClassMultipleConstructorParams::class]);
+        $pass = new MethodDefinitionPass();
+        $code = $pass->apply('class Dave { }', $config);
+
+        $constructor = \mb_substr($code, 0, (int) \mb_strpos($code, 'public function dave'));
+
+        // Returning a value from a constructor is deprecated as of PHP 8.6.
+        self::assertNotFalse(\mb_strpos($constructor, 'public function __construct'));
+        self::assertNotFalse(\mb_strpos($constructor, '_mockery_handleMethodCall'));
+        self::assertFalse(\mb_strpos($constructor, 'return $ret;'));
+
+        // Regular methods still return the handled call value.
+        $method = \mb_substr($code, (int) \mb_strpos($code, 'public function dave'));
+        self::assertNotFalse(\mb_strpos($method, 'return $ret;'));
+    }
+}

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php
@@ -6,29 +6,123 @@ namespace Tests\Unit\Mockery\Generator\StringManipulation\Pass;
 
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\MethodDefinitionPass;
-use PHP73\MockeryTest_ClassMultipleConstructorParams;
-use PHPUnit\Framework\TestCase;
+use PHP86\ClassWithConstructorAndDestructor;
+use Tests\Unit\AbstractTestCase;
+use Throwable;
 
 /**
- * @coversDefaultClass \Mockery
+ * @coversDefaultClass \Mockery\Generator\StringManipulation\Pass\MethodDefinitionPass
  */
-final class MethodDefinitionPassTest extends TestCase
+final class MethodDefinitionPassTest extends AbstractTestCase
 {
-    public function testConstructorDoesNotReturnAValue(): void
+    /** @throws Throwable */
+    public function testConstructMethodDoesNotReturnAValue(): void
     {
-        $config = new MockConfiguration([MockeryTest_ClassMultipleConstructorParams::class]);
+        $config = new MockConfiguration([ClassWithConstructorAndDestructor::class]);
+
         $pass = new MethodDefinitionPass();
-        $code = $pass->apply('class Dave { }', $config);
 
-        $constructor = \mb_substr($code, 0, (int) \mb_strpos($code, 'public function dave'));
+        self::assertStringContainsString(
+            implode(
+                "\n",
+                [
+                    'public function __construct(int $number){',
+                    '$argc = func_num_args();',
+                    '$argv = func_get_args();',
+                    '$this->_mockery_handleMethodCall(__FUNCTION__, $argv);',
+                    '}',
+                ]
+            ),
+            $pass->apply('class Example {}', $config)
+        );
+    }
 
-        // Returning a value from a constructor is deprecated as of PHP 8.6.
-        self::assertNotFalse(\mb_strpos($constructor, 'public function __construct'));
-        self::assertNotFalse(\mb_strpos($constructor, '_mockery_handleMethodCall'));
-        self::assertFalse(\mb_strpos($constructor, 'return $ret;'));
+    /** @throws Throwable */
+    public function testDestructMethodDoesNotReturnAValue(): void
+    {
+        $config = new MockConfiguration([ClassWithConstructorAndDestructor::class]);
 
-        // Regular methods still return the handled call value.
-        $method = \mb_substr($code, (int) \mb_strpos($code, 'public function dave'));
-        self::assertNotFalse(\mb_strpos($method, 'return $ret;'));
+        $pass = new MethodDefinitionPass();
+
+        self::assertStringContainsString(
+            implode(
+                "\n",
+                [
+                    'public function __destruct(){',
+                    '$argc = func_num_args();',
+                    '$argv = func_get_args();',
+                    '$this->_mockery_handleMethodCall(__FUNCTION__, $argv);',
+                    '}',
+                ]
+            ),
+            $pass->apply('class Example {}', $config)
+        );
+    }
+
+    /** @throws Throwable */
+    public function testNumberMethodDoesNotReturnAValue(): void
+    {
+        $config = new MockConfiguration([ClassWithConstructorAndDestructor::class]);
+
+        $pass = new MethodDefinitionPass();
+
+        self::assertStringContainsString(
+            implode(
+                "\n",
+                [
+                    'public function number(): int{',
+                    '$argc = func_num_args();',
+                    '$argv = func_get_args();',
+                    '$ret = $this->_mockery_handleMethodCall(__FUNCTION__, $argv);',
+                    'return $ret;',
+                    '}',
+                ]
+            ),
+            $pass->apply('class Example {}', $config)
+        );
+    }
+
+    /** @throws Throwable */
+    public function testNeverMethodDoesNotReturnAValue(): void
+    {
+        $config = new MockConfiguration([ClassWithConstructorAndDestructor::class]);
+
+        $pass = new MethodDefinitionPass();
+
+        self::assertStringContainsString(
+            implode(
+                "\n",
+                [
+                    'public function neverMethod(): never{',
+                    '$argc = func_num_args();',
+                    '$argv = func_get_args();',
+                    '$this->_mockery_handleMethodCall(__FUNCTION__, $argv);',
+                    '}',
+                ]
+            ),
+            $pass->apply('class Example {}', $config)
+        );
+    }
+
+    /** @throws Throwable */
+    public function testVoidMethodDoesNotReturnAValue(): void
+    {
+        $config = new MockConfiguration([ClassWithConstructorAndDestructor::class]);
+
+        $pass = new MethodDefinitionPass();
+
+        self::assertStringContainsString(
+            implode(
+                "\n",
+                [
+                    'public function voidMethod(): void{',
+                    '$argc = func_num_args();',
+                    '$argv = func_get_args();',
+                    '$this->_mockery_handleMethodCall(__FUNCTION__, $argv);',
+                    '}',
+                ]
+            ),
+            $pass->apply('class Example {}', $config)
+        );
     }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/MethodDefinitionPassTest.php
@@ -82,7 +82,10 @@ final class MethodDefinitionPassTest extends AbstractTestCase
         );
     }
 
-    /** @throws Throwable */
+    /**
+     * @requires PHP 8.1.0-dev
+     * @throws Throwable
+     */
     public function testNeverMethodDoesNotReturnAValue(): void
     {
         $config = new MockConfiguration([ClassWithConstructorAndDestructor::class]);


### PR DESCRIPTION
Returning a value from a constructor is deprecated as of PHP 8.6, so the generated `__construct` no longer appends `return $ret;`. The handler is still called, so constructor expectations keep working.

Fixes #1494.
