### PR TITLE
Bump `setuptools` from `78.1.1` to `83.0.0`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ MarkupSafe==2.1.5
 packaging==24.0
 Pygments==2.20.0
 requests==2.33.0
-setuptools==78.1.1
+setuptools==83.0.0
 snowballstemmer==2.2.0
 Sphinx==7.3.7
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
Fixes [CVE-2026-59890](https://github.com/advisories/GHSA-h35f-9h28-mq5c)