### PR TITLE
Fix mocking a class with an overridden return type

### DIFF
--- a/library/Mockery/Generator/MockConfiguration.php
+++ b/library/Mockery/Generator/MockConfiguration.php
@@ -13,6 +13,7 @@ namespace Mockery\Generator;
 use Iterator;
 use IteratorAggregate;
 use Mockery\Exception;
+use ReflectionClass;
 use Serializable;
 
 use function array_filter;
@@ -707,7 +708,9 @@ class MockConfiguration
             $classes[] = $this->getTargetClass();
         }
 
+        /** @var Method[] $methods */
         $methods = [];
+
         foreach ($classes as $class) {
             $methods = array_merge($methods, $class->getMethods());
         }
@@ -720,18 +723,31 @@ class MockConfiguration
             }
         }
 
-        $names = [];
-        $methods = array_filter($methods, static function ($method) use (&$names) {
-            if (in_array($method->getName(), $names, true)) {
-                return false;
+        $unique = [];
+
+        foreach ($methods as $method) {
+            $name = $method->getName();
+
+            if (! isset($unique[$name])) {
+                $unique[$name] = $method;
+
+                continue;
             }
 
-            $names[] = $method->getName();
+            $existing = $unique[$name];
 
-            return true;
-        });
+            /** @var ReflectionClass $existingDeclaringClass */
+            $existingDeclaringClass = $existing->getDeclaringClass();
 
-        return $this->allMethods = $methods;
+            /** @var ReflectionClass $newDeclaringClass */
+            $newDeclaringClass = $method->getDeclaringClass();
+
+            if ($newDeclaringClass->isSubclassOf($existingDeclaringClass->getName())) {
+                $unique[$name] = $method;
+            }
+        }
+
+        return $this->allMethods = array_values($unique);
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -743,7 +743,6 @@
       <code><![CDATA[array_unique($this->targetTraits)]]></code>
     </InvalidPropertyAssignmentValue>
     <LessSpecificReturnStatement>
-      <code><![CDATA[$this->allMethods = $methods]]></code>
       <code><![CDATA[$this->name]]></code>
       <code><![CDATA[$this->targetInterfaces = array_unique($this->targetInterfaces)]]></code>
       <code><![CDATA[$this->targetTraits]]></code>
@@ -788,7 +787,6 @@
     <MoreSpecificReturnType>
       <code><![CDATA[class-string|null]]></code>
       <code><![CDATA[list<Method>]]></code>
-      <code><![CDATA[list<Method>]]></code>
       <code><![CDATA[list<TargetClassInterface>]]></code>
       <code><![CDATA[list<TargetClassInterface>]]></code>
     </MoreSpecificReturnType>
@@ -800,9 +798,11 @@
       <code><![CDATA[$params[1]]]></code>
     </PossiblyUndefinedIntArrayOffset>
     <PropertyTypeCoercion>
-      <code><![CDATA[$methods]]></code>
       <code><![CDATA[array_unique($this->targetInterfaces)]]></code>
     </PropertyTypeCoercion>
+    <RedundantCondition>
+      <code><![CDATA[$newDeclaringClass->isSubclassOf($existingDeclaringClass->getName())]]></code>
+    </RedundantCondition>
   </file>
   <file src="library/Mockery/Generator/MockConfigurationBuilder.php">
     <ClassMustBeFinal>
@@ -4191,6 +4191,11 @@
     </UndefinedMagicMethod>
     <UnusedClass>
       <code><![CDATA[SpyTest]]></code>
+    </UnusedClass>
+  </file>
+  <file src="tests/Unit/Mockery/TestCase1459Test.php">
+    <UnusedClass>
+      <code><![CDATA[TestCase1459Test]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/TraitsTest.php">

--- a/tests/Fixture/PHP74/RestrictReturnType.php
+++ b/tests/Fixture/PHP74/RestrictReturnType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHP74;
+
+/** @implements \Iterator<string, bool> */
+interface RestrictReturnType extends \Iterator
+{
+    public function current(): ?bool; // Parent returns "mixed"
+    public function key(): ?string;  // Parent returns "mixed"
+}

--- a/tests/Unit/Mockery/TestCase1459Test.php
+++ b/tests/Unit/Mockery/TestCase1459Test.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @see       https://github.com/mockery/mockery for the canonical source repository
  */
 
-namespace Tests\Unit\PHP82;
+namespace Tests\Unit\Mockery;
 
 use Iterator;
 use Mockery\Adapter\Phpunit\MockeryTestCase;

--- a/tests/Unit/Mockery/TestCase1459Test.php
+++ b/tests/Unit/Mockery/TestCase1459Test.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mockery (https://docs.mockery.io/en/stable/)
+ *
+ * @copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md
+ * @license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License
+ * @see       https://github.com/mockery/mockery for the canonical source repository
+ */
+
+namespace Tests\Unit\PHP82;
+
+use Iterator;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHP74\RestrictReturnType;
+use Throwable;
+
+use function mock;
+
+/**
+ * @coversDefaultClass \Mockery\Expectation
+ *
+ * @see https://github.com/mockery/mockery/issues/1459
+ */
+final class TestCase1459Test extends MockeryTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function testCanMockAClassWithOverriddenReturnType(): void
+    {
+        $mock = mock(RestrictReturnType::class);
+
+        self::assertInstanceOf(RestrictReturnType::class, $mock);
+        self::assertInstanceOf(Iterator::class, $mock);
+    }
+}


### PR DESCRIPTION
This pull request improves the method filtering accuracy in MockConfiguration when mocking classes with inherited methods with return type overrides.

- Updated `getAllMethods()` to retain the method from the most-derived (subclass)  declaring class when multiple methods share the same name.

Closes #1459