### PR TITLE
Add PHPUnit EndToEnd Tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,11 @@
 /ecs.php export-ignore
 /Makefile export-ignore
 /phive.xml export-ignore
+/phpunit-10.5.xml.dist export-ignore
+/phpunit-11.5.xml.dist export-ignore
+/phpunit-12.5.xml.dist export-ignore
+/phpunit-13.3.xml.dist export-ignore
+/phpunit-9.6.xml.dist export-ignore
 /phpunit.xml.dist export-ignore
 /psalm-baseline.xml export-ignore
 /psalm.xml.dist export-ignore

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,106 @@
+name: PHPUnit EndToEnd Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+.x"
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  phpunit:
+    name: PHPUnit ${{ matrix.phpunit }} on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # phpunit 9.6 >= 7.3
+        # phpunit 10.5 >= 8.1
+        # phpunit 11.5 >=8.2
+        # phpunit 12.5 >=8.3
+        # phpunit 13.3 >=8.4.1
+        dev: ['8.6']
+        php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
+        phpunit: ['9.6']
+        include:
+          - php: '8.1'
+            phpunit: '10.5'
+          - php: '8.2'
+            phpunit: '10.5'
+          - php: '8.2'
+            phpunit: '11.5'
+          - php: '8.3'
+            phpunit: '10.5'
+          - php: '8.3'
+            phpunit: '11.5'
+          - php: '8.3'
+            phpunit: '12.5'
+          - php: '8.4'
+            phpunit: '10.5'
+          - php: '8.4'
+            phpunit: '11.5'
+          - php: '8.4'
+            phpunit: '12.5'
+          - php: '8.4'
+            phpunit: '13.3'
+          - php: '8.5'
+            phpunit: '10.5'
+          - php: '8.5'
+            phpunit: '11.5'
+          - php: '8.5'
+            phpunit: '12.5'
+          - php: '8.5'
+            phpunit: '13.3'
+          - php: '8.6'
+            phpunit: '10.5'
+          - php: '8.6'
+            phpunit: '11.5'
+          - php: '8.6'
+            phpunit: '12.5'
+          - php: '8.6'
+            phpunit: '13.3'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          coverage: xdebug
+          extensions: mongodb, redis
+          ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup Problem Matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.phpunit }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.phpunit }}-
+
+      - name: Install PHPUnit ${{ matrix.phpunit }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          composer config platform.php ${{ matrix.php }}.999;
+          composer require --dev phpunit/phpunit:^${{ matrix.phpunit }};
+          composer update --no-interaction --no-progress --ansi;
+
+      - name: Execute PHPUnit
+        run: vendor/bin/phpunit --configuration phpunit-${{ matrix.phpunit }}.xml.dist --colors=always --do-not-cache-result
+        continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   phpunit:
-    name: PHPUnit ${{ matrix.phpunit }} on PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -98,8 +98,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           composer config platform.php ${{ matrix.php }}.999;
-          composer require --dev phpunit/phpunit:^${{ matrix.phpunit }};
-          composer update --no-interaction --no-progress --ansi;
+          composer require --dev phpunit/phpunit:^${{ matrix.phpunit }} --ansi --no-interaction --prefer-dist --with-all-dependencies;
+          composer update --ansi --no-interaction;
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit --configuration phpunit-${{ matrix.phpunit }}.xml.dist --colors=always --do-not-cache-result

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@ SHELL := /bin/sh
 PROJECT := /opt/mockery
 PHP_IMAGE := ghcr.io/ghostwriter/php
 PHP_VERSIONS := 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5 8.6
+PHPUNIT_VERSION := 9.6 10.5 11.5 12.5 13.3
 
 .PHONY: tests
 tests: test-7.3 test-8.5
 
 .PHONY: test-all
 test-all: $(PHP_VERSIONS:%=test-%)
+
+.PHONY: $(PHPUNIT_VERSION:%=phpunit-%)
+$(PHPUNIT_VERSION:%=phpunit-%):
+	php vendor/bin/phpunit --config "phpunit-$(@:phpunit-%=%).xml.dist"
 
 .PHONY: test
 test: deps

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -65,8 +65,6 @@ trait MockeryPHPUnitIntegration
         $this->addMockeryExpectationsToAssertionCount();
         $this->checkMockeryExceptions();
         $this->closeMockery();
-
-        parent::assertPostConditions();
     }
 
     /**

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php
@@ -22,5 +22,7 @@ trait MockeryPHPUnitIntegrationAssertPostConditions
     protected function assertPostConditions(): void
     {
         $this->mockeryAssertPostConditions();
+
+        parent::assertPostConditions();
     }
 }

--- a/library/Mockery/Container.php
+++ b/library/Mockery/Container.php
@@ -12,6 +12,7 @@ namespace Mockery;
 
 use Closure;
 use Exception as PHPException;
+use LogicException;
 use Mockery;
 use Mockery\Exception\BadMethodCallException;
 use Mockery\Exception\InvalidOrderException;
@@ -459,10 +460,18 @@ class Container
      * to change it thus why the method name is "self" since it will be used during the programming of the same mock.
      *
      * @return MockInterface
+     *
+     * @throws LogicException
      */
     public function self()
     {
         $mocks = array_values($this->_mocks);
+
+        if ([] === $mocks) {
+            // No mocks have been created yet
+            throw new LogicException('You have not declared any mocks yet');
+        }
+
         $index = count($mocks) - 1;
 
         return $mocks[$index];

--- a/phpunit-10.5.xml.dist
+++ b/phpunit-10.5.xml.dist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".cache/phpunit"
+    cacheResult="false"
+    colors="true"
+    executionOrder="default"
+    requireCoverageMetadata="false"
+>
+    <coverage>
+        <report>
+            <html outputDirectory=".cache/phpunit/coverage-html" />
+            <clover outputFile=".cache/phpunit/clover.xml" />
+            <text outputFile=".cache/phpunit/coverage.txt" />
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile=".cache/phpunit/junit.xml" />
+    </logging>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/Unit</directory>
+            <exclude>tests/Unit/PHP*</exclude>
+        </testsuite>
+        <testsuite name="php">
+            <directory phpVersion="7.3.0-dev">tests/Unit/PHP73</directory>
+            <directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>
+            <directory phpVersion="8.5.0-dev">tests/Unit/PHP85</directory>
+            <directory phpVersion="8.6.0-dev">tests/Unit/PHP86</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">library</directory>
+        </include>
+        <exclude>
+            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
+            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+        </exclude>
+    </source>
+    <extensions>
+        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+    </extensions>
+</phpunit>

--- a/phpunit-11.5.xml.dist
+++ b/phpunit-11.5.xml.dist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".cache/phpunit"
+    cacheResult="false"
+    colors="true"
+    executionOrder="default"
+    requireCoverageMetadata="false"
+>
+    <coverage>
+        <report>
+            <html outputDirectory=".cache/phpunit/coverage-html" />
+            <clover outputFile=".cache/phpunit/clover.xml" />
+            <text outputFile=".cache/phpunit/coverage.txt" />
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile=".cache/phpunit/junit.xml" />
+    </logging>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/Unit</directory>
+            <exclude>tests/Unit/PHP*</exclude>
+        </testsuite>
+        <testsuite name="php">
+            <directory phpVersion="7.3.0-dev">tests/Unit/PHP73</directory>
+            <directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>
+            <directory phpVersion="8.5.0-dev">tests/Unit/PHP85</directory>
+            <directory phpVersion="8.6.0-dev">tests/Unit/PHP86</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">library</directory>
+        </include>
+        <exclude>
+            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
+            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+        </exclude>
+    </source>
+    <extensions>
+        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+    </extensions>
+</phpunit>

--- a/phpunit-12.5.xml.dist
+++ b/phpunit-12.5.xml.dist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".cache/phpunit"
+    cacheResult="false"
+    colors="true"
+    executionOrder="default"
+    requireCoverageMetadata="false"
+>
+    <coverage>
+        <report>
+            <html outputDirectory=".cache/phpunit/coverage-html" />
+            <clover outputFile=".cache/phpunit/clover.xml" />
+            <text outputFile=".cache/phpunit/coverage.txt" />
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile=".cache/phpunit/junit.xml" />
+    </logging>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/Unit</directory>
+            <exclude>tests/Unit/PHP*</exclude>
+        </testsuite>
+        <testsuite name="php">
+            <directory phpVersion="7.3.0-dev">tests/Unit/PHP73</directory>
+            <directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>
+            <directory phpVersion="8.5.0-dev">tests/Unit/PHP85</directory>
+            <directory phpVersion="8.6.0-dev">tests/Unit/PHP86</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">library</directory>
+        </include>
+        <exclude>
+            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
+            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+        </exclude>
+    </source>
+    <extensions>
+        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+    </extensions>
+</phpunit>

--- a/phpunit-13.3.xml.dist
+++ b/phpunit-13.3.xml.dist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory=".cache/phpunit"
+    colors="true"
+    executionOrder="default"
+    recordTestRunHistory="false"
+    requireCoverageMetadata="false"
+>
+    <coverage>
+        <report>
+            <html outputDirectory=".cache/phpunit/coverage-html" />
+            <clover outputFile=".cache/phpunit/clover.xml" />
+            <text outputFile=".cache/phpunit/coverage.txt" />
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile=".cache/phpunit/junit.xml" />
+    </logging>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/Unit</directory>
+            <exclude>tests/Unit/PHP*</exclude>
+        </testsuite>
+        <testsuite name="php">
+            <directory phpVersion="7.3.0-dev">tests/Unit/PHP73</directory>
+            <directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>
+            <directory phpVersion="8.5.0-dev">tests/Unit/PHP85</directory>
+            <directory phpVersion="8.6.0-dev">tests/Unit/PHP86</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">library</directory>
+        </include>
+        <exclude>
+            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
+            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+        </exclude>
+    </source>
+    <extensions>
+        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+    </extensions>
+</phpunit>

--- a/phpunit-9.6.xml.dist
+++ b/phpunit-9.6.xml.dist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/autoload.php"
+    cacheResult="false"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    executionOrder="default"
+    forceCoversAnnotation="false"
+    verbose="true"
+>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">library</directory>
+        </include>
+        <exclude>
+            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
+            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
+            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+        </exclude>
+        <report>
+            <html outputDirectory=".cache/phpunit/coverage-html"/>
+            <clover outputFile=".cache/phpunit/clover.xml"/>
+            <text outputFile=".cache/phpunit/coverage.txt"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile=".cache/phpunit/junit.xml"/>
+    </logging>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/Unit</directory>
+            <exclude>tests/Unit/PHP*</exclude>
+        </testsuite>
+        <testsuite name="php">
+            <directory phpVersion="7.3.0-dev">tests/Unit/PHP73</directory>
+            <directory phpVersion="7.4.0-dev">tests/Unit/PHP74</directory>
+            <directory phpVersion="8.0.0-dev">tests/Unit/PHP80</directory>
+            <directory phpVersion="8.1.0-dev">tests/Unit/PHP81</directory>
+            <directory phpVersion="8.2.0-dev">tests/Unit/PHP82</directory>
+            <directory phpVersion="8.3.0-dev">tests/Unit/PHP83</directory>
+            <directory phpVersion="8.4.0-dev">tests/Unit/PHP84</directory>
+            <directory phpVersion="8.5.0-dev">tests/Unit/PHP85</directory>
+            <directory phpVersion="8.6.0-dev">tests/Unit/PHP86</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -272,9 +272,6 @@
     <InvalidArgument>
       <code><![CDATA[$argument]]></code>
     </InvalidArgument>
-    <InvalidArrayOffset>
-      <code><![CDATA[$mocks[$index]]]></code>
-    </InvalidArrayOffset>
     <InvalidCast>
       <code><![CDATA[$argument]]></code>
     </InvalidCast>
@@ -320,9 +317,6 @@
       <code><![CDATA[shouldReceive]]></code>
       <code><![CDATA[shouldReceive]]></code>
     </MixedMethodCall>
-    <MixedReturnStatement>
-      <code><![CDATA[$mocks[$index]]]></code>
-    </MixedReturnStatement>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$exceptions]]></code>
       <code><![CDATA[array<BadMethodCallException>]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1986,6 +1986,9 @@
       <code><![CDATA[wasSuccessful]]></code>
       <code><![CDATA[wasSuccessful]]></code>
     </MixedMethodCall>
+    <UndefinedAttributeClass>
+      <code><![CDATA[RequiresPhpunit]]></code>
+    </UndefinedAttributeClass>
     <UndefinedInterfaceMethod>
       <code><![CDATA[bar]]></code>
       <code><![CDATA[bar]]></code>
@@ -3623,6 +3626,9 @@
     <PossiblyFalseArgument>
       <code><![CDATA[file_get_contents(__FILE__)]]></code>
     </PossiblyFalseArgument>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UndefinedMethod>
       <code><![CDATA[expects]]></code>
       <code><![CDATA[expects]]></code>
@@ -3771,6 +3777,9 @@
       <code><![CDATA[$actual]]></code>
       <code><![CDATA[$expected]]></code>
     </MissingParamType>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UnusedClass>
       <code><![CDATA[IsEqualTest]]></code>
     </UnusedClass>
@@ -3780,6 +3789,9 @@
       <code><![CDATA[$actual]]></code>
       <code><![CDATA[$expected]]></code>
     </MissingParamType>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UnusedClass>
       <code><![CDATA[IsSameTest]]></code>
     </UnusedClass>
@@ -3985,12 +3997,6 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MockingNullableMethodsTest.php">
-    <InternalMethod>
-      <code><![CDATA[new MethodWithNullableReturnType()]]></code>
-      <code><![CDATA[new MethodWithNullableReturnType()]]></code>
-      <code><![CDATA[new MethodWithNullableReturnType()]]></code>
-      <code><![CDATA[new MethodWithNullableReturnType()]]></code>
-    </InternalMethod>
     <MixedMethodCall>
       <code><![CDATA[andReturn]]></code>
       <code><![CDATA[andReturn]]></code>
@@ -4150,6 +4156,10 @@
       <code><![CDATA[$refClass->getMethods()[0]]]></code>
       <code><![CDATA[$refMethod->getParameters()[0]]]></code>
     </PossiblyUndefinedIntArrayOffset>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UnusedClass>
       <code><![CDATA[ReflectorTest]]></code>
     </UnusedClass>
@@ -4272,6 +4282,12 @@
       <code><![CDATA[andReturn]]></code>
       <code><![CDATA[with]]></code>
     </MixedMethodCall>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UndefinedMethod>
       <code><![CDATA[allows]]></code>
       <code><![CDATA[expects]]></code>
@@ -4323,6 +4339,10 @@
       <code><![CDATA[$object->stringProperty]]></code>
       <code><![CDATA[$object->stringProperty]]></code>
     </MixedPropertyFetch>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UnusedClass>
       <code><![CDATA[WithCustomFormatterExpectationTest]]></code>
     </UnusedClass>
@@ -4344,6 +4364,9 @@
     <MixedMethodCall>
       <code><![CDATA[with]]></code>
     </MixedMethodCall>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+    </UndefinedAttributeClass>
     <UndefinedMethod>
       <code><![CDATA[shouldReceive]]></code>
     </UndefinedMethod>
@@ -4512,6 +4535,11 @@
       <code><![CDATA[assertFalse]]></code>
       <code><![CDATA[assertTrue]]></code>
     </RedundantCondition>
+    <UndefinedAttributeClass>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[DataProvider]]></code>
+      <code><![CDATA[RequiresPhp]]></code>
+    </UndefinedAttributeClass>
     <UndefinedClass>
       <code><![CDATA[$class->foo]]></code>
       <code><![CDATA[$class->foo]]></code>

--- a/tests/Fixture/PHP73/ClassWithConstants.php
+++ b/tests/Fixture/PHP73/ClassWithConstants.php
@@ -1,23 +1,4 @@
 <?php
-/**
- * Mockery
- *
- * LICENSE
- *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://github.com/padraic/mockery/master/LICENSE
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to padraic@php.net so we can send you a copy immediately.
- *
- * @category   Mockery
- * @package    Mockery
- * @subpackage UnitTests
- * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
- * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
- */
 
 namespace PHP73;
 

--- a/tests/Fixture/PHP73/MethodWithNullableReturnType.php
+++ b/tests/Fixture/PHP73/MethodWithNullableReturnType.php
@@ -1,29 +1,8 @@
 <?php
-/**
- * Mockery
- *
- * LICENSE
- *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://github.com/padraic/mockery/master/LICENSE
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to padraic@php.net so we can send you a copy immediately.
- *
- * @category   Mockery
- * @package    Mockery
- * @subpackage UnitTests
- * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
- * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
- */
 
 namespace PHP73;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-
-class MethodWithNullableReturnType extends MockeryTestCase
+class MethodWithNullableReturnType
 {
     public function nonNullablePrimitive(): string
     {

--- a/tests/Fixture/PHP73/MethodWithVoidReturnType.php
+++ b/tests/Fixture/PHP73/MethodWithVoidReturnType.php
@@ -1,23 +1,4 @@
 <?php
-/**
- * Mockery
- *
- * LICENSE
- *
- * This source file is subject to the new BSD license that is bundled
- * with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://github.com/padraic/mockery/master/LICENSE
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to padraic@php.net so we can send you a copy immediately.
- *
- * @category   Mockery
- * @package    Mockery
- * @subpackage UnitTests
- * @copyright  Copyright (c) 2010 Pádraic Brady (http://blog.astrumfutura.com)
- * @license    http://github.com/padraic/mockery/blob/master/LICENSE New BSD License
- */
 
 namespace PHP73;
 

--- a/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -17,6 +17,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Adapter\Phpunit\TestListener;
 use Override;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Util\Blacklist;
@@ -27,7 +28,10 @@ use function method_exists;
 
 /**
  * @coversDefaultClass \Mockery
+ *
+ * @requires PHPUnit < 10.0
  */
+#[RequiresPhpunit('<10.0')]
 final class TestListenerTest extends MockeryTestCase
 {
     protected $container;

--- a/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/TestListenerTest.php
@@ -31,7 +31,7 @@ use function method_exists;
  *
  * @requires PHPUnit < 10.0
  */
-#[RequiresPhpunit('<10.0')]
+#[RequiresPhpunit('<10.0.0')]
 final class TestListenerTest extends MockeryTestCase
 {
     protected $container;

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -94,6 +94,8 @@ use PHP73\MockeryTestIsset_Bar;
 use PHP73\MockeryTestIsset_Foo;
 use PHP73\MockeryTestRef1;
 use PHP81\MockeryTest_ClassThatImplementsSerializable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use Redis;
 use ReflectionClass;
 use Serializable;
@@ -1161,6 +1163,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideIsValidClassNameCases')]
     public function testIsValidClassName($expected, $className): void
     {
         self::assertSame($expected, (new Container())->isValidClassName($className));
@@ -1476,6 +1479,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[RequiresPhp('<8.0')]
     public function testMockingIteratorAggregateDoesNotImplementIterator(): void
     {
         $mock = mock(MockeryTest_ImplementsIteratorAggregate::class);
@@ -1500,6 +1504,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[RequiresPhp('<8.0')]
     public function testMockingIteratorDoesNotImplementIterator(): void
     {
         $mock = mock(MockeryTest_ImplementsIterator::class);

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -315,6 +315,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[RequiresPhp('<8.1')]
     public function testCanMockClassesThatImplementSerializable(): void
     {
         $mock = mock(MockeryTest_ClassThatImplementsSerializable::class);

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -315,7 +315,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
-    #[RequiresPhp('<8.1')]
+    #[RequiresPhp('<8.1.0')]
     public function testCanMockClassesThatImplementSerializable(): void
     {
         $mock = mock(MockeryTest_ClassThatImplementsSerializable::class);
@@ -1480,7 +1480,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
-    #[RequiresPhp('<8.0')]
+    #[RequiresPhp('<8.0.0')]
     public function testMockingIteratorAggregateDoesNotImplementIterator(): void
     {
         $mock = mock(MockeryTest_ImplementsIteratorAggregate::class);
@@ -1505,7 +1505,7 @@ final class ContainerTest extends MockeryTestCase
      *
      * @throws Throwable
      */
-    #[RequiresPhp('<8.0')]
+    #[RequiresPhp('<8.0.0')]
     public function testMockingIteratorDoesNotImplementIterator(): void
     {
         $mock = mock(MockeryTest_ImplementsIterator::class);

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -1936,4 +1936,15 @@ final class ContainerTest extends MockeryTestCase
     {
         self::assertInstanceOf(DateTime::class, mock(DateTime::class));
     }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCallingSelfOnContainerWithoutMocksThrowsException(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('You have not declared any mocks yet');
+
+        Mockery::getContainer()->self();
+    }
 }

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/CallTypeHintPassTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 namespace Tests\Unit\Mockery\Generator\StringManipulation\Pass;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\CallTypeHintPass;
-use PHPUnit\Framework\TestCase;
 use Throwable;
 
 use function mb_strpos;
@@ -23,7 +23,7 @@ use function mb_strpos;
 /**
  * @coversDefaultClass \Mockery
  */
-final class CallTypeHintPassTest extends TestCase
+final class CallTypeHintPassTest extends MockeryTestCase
 {
     public const CODE = ' public function __call($method, array $args) {}
                    public static function __callStatic($method, array $args) {}

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/ClassAttributesPassTest.php
@@ -16,6 +16,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\ClassAttributesPass;
 use Mockery\Generator\UndefinedTargetClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 use function file_get_contents;
@@ -54,6 +55,7 @@ class ClassAttributesPassTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideCanApplyClassAttributesCases')]
     public function testCanApplyClassAttributes(array $attributes, string $expected): void
     {
         $undefinedTargetClass = mock(UndefinedTargetClass::class);

--- a/tests/Unit/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
+++ b/tests/Unit/Mockery/Generator/StringManipulation/Pass/InterfacePassTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 namespace Tests\Unit\Mockery\Generator\StringManipulation\Pass;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Generator\MockConfiguration;
 use Mockery\Generator\StringManipulation\Pass\InterfacePass;
-use PHPUnit\Framework\TestCase;
 use Throwable;
 
 use function mb_strpos;
@@ -23,7 +23,7 @@ use function mb_strpos;
 /**
  * @coversDefaultClass \Mockery
  */
-final class InterfacePassTest extends TestCase
+final class InterfacePassTest extends MockeryTestCase
 {
     public const CODE = 'class Mock implements MockInterface';
 

--- a/tests/Unit/Mockery/Matcher/IsEqualTest.php
+++ b/tests/Unit/Mockery/Matcher/IsEqualTest.php
@@ -14,6 +14,7 @@ namespace Tests\Unit\Mockery\Matcher;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 /**
@@ -28,6 +29,7 @@ final class IsEqualTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('isEqualDataProvider')]
     public function testItWorks($expected, $actual): void
     {
         self::assertTrue(Mockery::isEqual($expected)->match($actual));

--- a/tests/Unit/Mockery/Matcher/IsSameTest.php
+++ b/tests/Unit/Mockery/Matcher/IsSameTest.php
@@ -14,6 +14,7 @@ namespace Tests\Unit\Mockery\Matcher;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 /**
@@ -28,6 +29,7 @@ final class IsSameTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('isSameDataProvider')]
     public function testItWorks($expected, $actual): void
     {
         self::assertTrue(Mockery::isSame($expected)->match($actual));

--- a/tests/Unit/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php
+++ b/tests/Unit/Mockery/MockeryCanMockClassesWithSemiReservedWordsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Mockery;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PHP73\SemiReservedWordsAsMethods;
-use PHPUnit\Framework\TestCase;
 use Throwable;
 
 use function method_exists;
@@ -22,7 +22,7 @@ use function method_exists;
 /**
  * @coversDefaultClass \Mockery
  */
-final class MockeryCanMockClassesWithSemiReservedWordsTest extends TestCase
+final class MockeryCanMockClassesWithSemiReservedWordsTest extends MockeryTestCase
 {
     /**
      * @throws Throwable

--- a/tests/Unit/Mockery/ReflectorTest.php
+++ b/tests/Unit/Mockery/ReflectorTest.php
@@ -17,6 +17,7 @@ use Mockery\Reflector;
 use PHP73\ChildClass;
 use PHP73\NullableObject;
 use PHP73\ParentClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use Throwable;
 
@@ -63,6 +64,7 @@ final class ReflectorTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideGetTypeHintCases')]
     public function testGetTypeHint(string $class, string $expectedTypeHint): void
     {
         $refClass = new ReflectionClass($class);
@@ -77,6 +79,7 @@ final class ReflectorTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideIsReservedWordCases')]
     public function testIsReservedWord(string $type): void
     {
         self::assertTrue(Reflector::isReservedWord($type));

--- a/tests/Unit/PHP73/TestCase1328Test.php
+++ b/tests/Unit/PHP73/TestCase1328Test.php
@@ -15,9 +15,9 @@ namespace Tests\Unit\PHP73;
 use DateTime;
 use InvalidArgumentException;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception\InvalidCountException;
 use Mockery\Expectation;
-use PHPUnit\Framework\TestCase;
 use Throwable;
 
 use function restore_error_handler;
@@ -30,7 +30,7 @@ use function set_error_handler;
  *
  * @see https://github.com/mockery/mockery/issues/1328
  */
-final class TestCase1328Test extends TestCase
+final class TestCase1328Test extends MockeryTestCase
 {
     /**
      * @throws Throwable

--- a/tests/Unit/PHP73/TestCase1404Test.php
+++ b/tests/Unit/PHP73/TestCase1404Test.php
@@ -14,9 +14,10 @@ namespace Tests\Unit\PHP73;
 
 use Generator;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PDO;
 use PDOStatement;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 /**
@@ -26,7 +27,7 @@ use Throwable;
  *
  * @see https://github.com/mockery/mockery/issues/1404
  */
-final class TestCase1404Test extends TestCase
+final class TestCase1404Test extends MockeryTestCase
 {
     /**
      * @return Generator<string,list<string>>
@@ -44,6 +45,7 @@ final class TestCase1404Test extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideResult')]
     public function testDemeterChainsAlternativeSyntax(array $result): void
     {
         $dbConnection = Mockery::mock(PDO::class);
@@ -59,6 +61,7 @@ final class TestCase1404Test extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideResult')]
     public function testDemeterChainsExpects(array $result): void
     {
         $dbConnection = Mockery::mock(PDO::class);
@@ -74,6 +77,7 @@ final class TestCase1404Test extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideResult')]
     public function testDetestDemeterChainsAllowsmeterChainsAllows(array $result): void
     {
         $dbConnection = Mockery::mock(PDO::class);
@@ -89,6 +93,7 @@ final class TestCase1404Test extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideResult')]
     public function testNonDemeterChainsSyntax(array $result): void
     {
         $dbStatement = Mockery::mock(PDOStatement::class);

--- a/tests/Unit/PHP73/WithCustomFormatterExpectationTest.php
+++ b/tests/Unit/PHP73/WithCustomFormatterExpectationTest.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 namespace Tests\Unit\PHP73;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Override;
 use PHP73\ClassChildOfWithCustomFormatter;
 use PHP73\ClassImplementsWithCustomFormatter;
 use PHP73\ClassWithCustomFormatter;
 use PHP73\ClassWithoutCustomFormatter;
 use PHP73\InterfaceWithCustomFormatter;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Throwable;
 
@@ -28,10 +29,10 @@ use function get_class;
 /**
  * @coversDefaultClass \Mockery
  */
-final class WithCustomFormatterExpectationTest extends TestCase
+final class WithCustomFormatterExpectationTest extends MockeryTestCase
 {
     #[Override]
-    protected function setUp(): void
+    protected function mockeryTestSetUp()
     {
         Mockery::getConfiguration()->setObjectFormatter(
             ClassWithCustomFormatter::class,
@@ -100,6 +101,7 @@ final class WithCustomFormatterExpectationTest extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideFormatObjectsCases')]
     public function testFormatObjects($obj, $shouldContains, $shouldNotContains): void
     {
         $string = Mockery::formatObjects([$obj]);
@@ -116,6 +118,7 @@ final class WithCustomFormatterExpectationTest extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideGetObjectFormatterCases')]
     public function testGetObjectFormatter($object, $expected): void
     {
         $defaultFormatter = function ($class, $nesting) {

--- a/tests/Unit/PHP73/WithFormatterExpectationTest.php
+++ b/tests/Unit/PHP73/WithFormatterExpectationTest.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 namespace Tests\Unit\PHP73;
 
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHP73\ClassWithGetter;
 use PHP73\ClassWithGetterWithParam;
 use PHP73\ClassWithPublicStaticGetter;
 use PHP73\ClassWithPublicStaticProperty;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Throwable;
 
@@ -27,7 +28,7 @@ use function mb_strpos;
 /**
  * @coversDefaultClass \Mockery
  */
-final class WithFormatterExpectationTest extends TestCase
+final class WithFormatterExpectationTest extends MockeryTestCase
 {
     public static function provideFormatObjectsCases(): iterable
     {
@@ -39,6 +40,7 @@ final class WithFormatterExpectationTest extends TestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideFormatObjectsCases')]
     public function testFormatObjects($args, $expected): void
     {
         self::assertSame($expected, Mockery::formatObjects($args));

--- a/tests/Unit/PHP80/TestCase1414Test.php
+++ b/tests/Unit/PHP80/TestCase1414Test.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PHP80;
 
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use stdClass;
 use Throwable;
 
@@ -24,7 +24,7 @@ use Throwable;
  *
  * @see https://github.com/mockery/mockery/issues/1414
  */
-final class TestCase1414Test extends TestCase
+final class TestCase1414Test extends MockeryTestCase
 {
     /**
      * @throws Throwable

--- a/tests/Unit/PHP82/Php82LanguageFeaturesTest.php
+++ b/tests/Unit/PHP82/Php82LanguageFeaturesTest.php
@@ -28,6 +28,8 @@ use PHP82\TestReturnCoVarianceThree;
 use PHP82\TestReturnCoVarianceTwo;
 use PHP82\TestThree;
 use PHP82\TestTwo;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use ReflectionClass;
 use ReflectionType;
 use Throwable;
@@ -39,6 +41,7 @@ use function mock;
  *
  * @coversDefaultClass \Mockery
  */
+#[RequiresPhp('>=8.2.0-dev')]
 final class Php82LanguageFeaturesTest extends MockeryTestCase
 {
     /**
@@ -126,6 +129,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideMockParameterDisjunctiveNormalFormTypesCases')]
     public function testMockParameterDisjunctiveNormalFormTypes(string $fullyQualifiedClassName): void
     {
         $expectedReflectionClass = new ReflectionClass($fullyQualifiedClassName);
@@ -151,6 +155,7 @@ final class Php82LanguageFeaturesTest extends MockeryTestCase
      *
      * @throws Throwable
      */
+    #[DataProvider('provideMockReturnDisjunctiveNormalFormTypesCases')]
     public function testMockReturnDisjunctiveNormalFormTypes(string $fullyQualifiedClassName): void
     {
         $expectedReflectionClass = new ReflectionClass($fullyQualifiedClassName);


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow (`.github/workflows/phpunit.yml`) that runs PHPUnit tests across a matrix of PHP and PHPUnit versions.

- Added PHPUnit configuration files for versions `9.6`, `10.5`, `11.5`, `12.5`, and `13.3` to support testing across a wider range of PHPUnit and PHP versions. 

- Updated the `Makefile` to add a `PHPUNIT_VERSION` variable and new targets, making it easier to run tests with specific PHPUnit versions.

- Updated tests to add PHPUnit attribute classes (e.g., `DataProvider`, `RequiresPhpunit`, `RequiresPhp`)

- Removed legacy license header comments test fixtures.

- Updated `psalm-baseline.xml` file

- Updated `.gitattributes` to export-ignore PHPUnit configurations files