### PR TITLE
Add PHPUnit extension for Mockery

### DIFF
--- a/docs/reference/phpunit_integration.rst
+++ b/docs/reference/phpunit_integration.rst
@@ -101,8 +101,17 @@ Now, Mockery provides a PHPUnit listener that makes tests fail if
 ``Mockery::close()`` has not been called. It can help identify tests where
 we've forgotten to include the trait or extend the ``MockeryTestCase``.
 
-If we are using PHPUnit's XML configuration approach, we can include the
-following to load the ``TestListener``:
+If we are using PHPUnit's XML configuration approach, 
+
+for PHPUnit 10 or later, we can include the following to load the Mockery ``Extension``:
+
+.. code-block:: xml
+
+    <extensions>
+        <bootstrap class="Mockery\Adapter\Phpunit\Extension" />
+    </extensions>
+
+for PHPUnit 9 or earlier, we can include the following to load the Mockery ``TestListener``:
 
 .. code-block:: xml
 

--- a/ecs.php
+++ b/ecs.php
@@ -2,41 +2,64 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
-use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
+/**
+ * Mockery (https://docs.mockery.io/en/stable/)
+ *
+ * @copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md
+ * @license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License
+ * @see       https://github.com/mockery/mockery for the canonical source repository
+ */
+
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
+use PhpCsFixer\Fixer\Basic\SingleLineEmptyBodyFixer;
 use PhpCsFixer\Fixer\Casing\ConstantCaseFixer;
 use PhpCsFixer\Fixer\ClassNotation\FinalClassFixer;
 use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
+use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
+use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use PhpCsFixer\Fixer\Import\GroupImportFixer;
+use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
+use PhpCsFixer\Fixer\Import\NoUnneededImportAliasFixer;
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Fixer\Import\SingleImportPerStatementFixer;
+use PhpCsFixer\Fixer\Import\SingleLineAfterImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\GetClassToClassKeywordFixer;
+use PhpCsFixer\Fixer\NamespaceNotation\BlankLineAfterNamespaceFixer;
+use PhpCsFixer\Fixer\NamespaceNotation\CleanNamespaceFixer;
+use PhpCsFixer\Fixer\Operator\{ConcatSpaceFixer, NewWithParenthesesFixer};
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitAssertNewNamesFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
+use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitAttributesFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderNameFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderReturnTypeFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderStaticFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertInternalTypeFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitFqcnAnnotationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitInternalClassFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitNamespacedFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
+use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
+use Symplify\CodingStandard\Fixer\Annotation\RemoveMethodNameDuplicateDescriptionFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
-use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
+use Symplify\CodingStandard\Fixer\Commenting\AddMissingParamNameFixer;
+use Symplify\CodingStandard\Fixer\Commenting\AddMissingVarNameFixer;
+use Symplify\CodingStandard\Fixer\Commenting\DoubleAsteriskInlineVarFixer;
+use Symplify\CodingStandard\Fixer\Commenting\FixParamNameTypoFixer;
+use Symplify\CodingStandard\Fixer\Commenting\SingleLineInlineVarDocBlockFixer;
+use Symplify\CodingStandard\Fixer\Commenting\SwitchedTypeAndNameFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\CodingStandard\Fixer\Spacing\MethodChainingNewlineFixer;
 use Symplify\CodingStandard\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
@@ -45,189 +68,149 @@ use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 
-$cacheDirectory = __DIR__ . '/.cache/ecs';
-$cacheNamespace = \str_replace(search: \DIRECTORY_SEPARATOR, replace: '_', subject: $cacheDirectory);
+$cacheDirectory = \implode(DIRECTORY_SEPARATOR, [__DIR__, '.cache', 'ecs']);
 
 return ECSConfig::configure()
-                ->withCache(directory: $cacheDirectory, namespace: $cacheNamespace)
-                ->withPhpCsFixerSets(
-                    doctrineAnnotation: true,
-                    per: true,
-                    perCS: true,
-                    perCS10: true,
-                    perCS10Risky: true,
-                    perCS20: true,
-                    perCS20Risky: true,
-                    perCSRisky: true,
-                    perRisky: true,
-                    php54Migration: true,
-                    php56MigrationRisky: true,
-                    php70Migration: true,
-                    php70MigrationRisky: true,
-                    php71Migration: true,
-                    php71MigrationRisky: true,
-                    php73Migration: true,
-                    php74Migration: false,
-                    php74MigrationRisky: false,
-                    php80Migration: false,
-                    php80MigrationRisky: false,
-                    php81Migration: false,
-                    php82Migration: false,
-                    php83Migration: false,
-                    phpunit30MigrationRisky: true,
-                    phpunit32MigrationRisky: true,
-                    phpunit35MigrationRisky: true,
-                    phpunit43MigrationRisky: true,
-                    phpunit48MigrationRisky: true,
-                    phpunit50MigrationRisky: true,
-                    phpunit52MigrationRisky: true,
-                    phpunit54MigrationRisky: true,
-                    phpunit55MigrationRisky: true,
-                    phpunit56MigrationRisky: true,
-                    phpunit57MigrationRisky: true,
-                    phpunit60MigrationRisky: true,
-                    phpunit75MigrationRisky: true,
-                    phpunit84MigrationRisky: true,
-                    phpunit100MigrationRisky: true,
-                    psr1: true,
-                    psr2: true,
-                    psr12: true,
-                    psr12Risky: true,
-                    phpCsFixer: false,
-                    phpCsFixerRisky: false,
-                    symfony: false,
-                    symfonyRisky: false,
-                )
-                ->withPreparedSets(
-                    psr12: true,
-                    common: false,
-                    symplify: true,
-                    arrays: true,
-                    comments: true,
-                    docblocks: true,
-                    spaces: true,
-                    namespaces: true,
-                    controlStructures: true,
-                    phpunit: true,
-                    strict: true,
-                    cleanCode: true,
-                )
-                ->withConfiguredRule(NativeFunctionInvocationFixer::class, [
-                    'include' => ['@all'],
-                    'scope' => 'all',
-                ])
-                ->withConfiguredRule(
-                    checkerClass: GlobalNamespaceImportFixer::class,
-                    configuration: [
-                        'import_classes' => true,
-                        'import_constants' => true,
-                        'import_functions' => false,
-                    ]
-                )
-                ->withConfiguredRule(checkerClass: OrderedImportsFixer::class, configuration: [
-                    'imports_order' => ['class', 'const', 'function'],
-                ])
-
-                ->withConfiguredRule(checkerClass: PhpdocAlignFixer::class, configuration: [
-                    'tags' => ['method', 'param', 'property', 'return', 'throws', 'type', 'var'],
-                ])
-
-                ->withConfiguredRule(checkerClass: PhpUnitTestCaseStaticMethodCallsFixer::class, configuration: [
-                    'call_type' => 'self',
-                ])
-
-                ->withConfiguredRule(checkerClass: ArraySyntaxFixer::class, configuration: [
-                    'syntax' => 'short',
-                ])
-
-                ->withConfiguredRule(checkerClass: ConstantCaseFixer::class, configuration: [
-                    'case' => 'lower',
-                ])
-
-                ->withConfiguredRule(checkerClass: OrderedClassElementsFixer::class, configuration: [
-                    'case_sensitive' => true,
-                    'sort_algorithm' => 'alpha',
-                    'order' => [
-                        'use_trait',
-                        'case',
-                        'constant_public',
-                        'constant_protected',
-                        'constant_private',
-                        'property_public',
-                        'property_protected',
-                        'property_private',
-                        'construct',
-                        'destruct',
-                        'magic',
-                        'method:mockeryTestSetUp',
-                        'method:mockeryTestTearDown',
-                        'phpunit',
-                        'method_public',
-                        'method_protected',
-                        'method_private',
-                    ],
-                ])
-                ->withParallel()
-                ->withRootFiles()
-                ->withRules([
-                    PhpUnitAssertNewNamesFixer::class,
-                    PhpUnitConstructFixer::class,
-                    PhpUnitDataProviderNameFixer::class,
-                    PhpUnitDataProviderReturnTypeFixer::class,
-                    PhpUnitDataProviderStaticFixer::class,
-                    PhpUnitDedicateAssertFixer::class,
-                    PhpUnitDedicateAssertInternalTypeFixer::class,
-                    PhpUnitExpectationFixer::class,
-                    PhpUnitFqcnAnnotationFixer::class,
-                    //        PhpUnitInternalClassFixer::class,
-                    PhpUnitMethodCasingFixer::class,
-                    PhpUnitMockFixer::class,
-                    PhpUnitMockShortWillReturnFixer::class,
-                    PhpUnitNamespacedFixer::class,
-                    PhpUnitNoExpectationAnnotationFixer::class,
-                    PhpUnitSetUpTearDownVisibilityFixer::class,
-                    PhpUnitStrictFixer::class,
-                    FinalClassFixer::class,
-                    PhpUnitTestAnnotationFixer::class,
-
-                    //        PhpUnitTestClassRequiresCoversFixer::class,
-                    ParamReturnAndVarTagMalformsFixer::class,
-                    // arrays
-                    ArrayListItemNewlineFixer::class,
-                    ArrayOpenerAndCloserNewlineFixer::class,
-                    StandaloneLinePromotedPropertyFixer::class,
-                    // newlines
-                    SpaceAfterCommaHereNowDocFixer::class,
-                    BlankLineAfterStrictTypesFixer::class,
-                    LineLengthFixer::class,
-                ])
-                ->withConfiguredRule(
-                    GeneralPhpdocAnnotationRemoveFixer::class,
-                    [
-                        'annotations' => ['small', 'internal', 'coversDefaultClass1', 'coversNothing'],
-                    ]
-                )
-                ->withSkip(skip: [
-                    __DIR__ . '/library/Mockery/Mock.php',
-                    __DIR__ . '/tests/Fixture/*',
-                    PhpUnitTestClassRequiresCoversFixer::class,
-                    PhpUnitInternalClassFixer::class,
-                    MethodChainingNewlineFixer::class,
-                    GetClassToClassKeywordFixer::class,
-                    //        \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer::class,
-                    StrictComparisonFixer::class => [
-                        __DIR__ . '/library/Mockery/Matcher/IsEqual.php',
-                        __DIR__ . '/library/Mockery/Matcher/MustBe.php',
-                        __DIR__ . '/library/Mockery/Matcher/Subset.php',
-                        __DIR__ . '/library/Mockery/Generator/StringManipulation',
-                    ],
-                    // Enable later
-                    FinalClassFixer::class,
-                    PhpUnitAttributesFixer::class,
-                ])
-                ->withSpacing(indentation: Option::INDENTATION_SPACES, lineEnding: PHP_EOL)
-                ->withPaths(paths: [
-                    __DIR__ . '/tests',
-                    // __DIR__ . '/library',
-                ])
-    ;
+    ->withCache($cacheDirectory, \md5($cacheDirectory))
+    ->withConfiguredRule(ArraySyntaxFixer::class, [
+        'syntax' => 'short'
+    ])
+    ->withConfiguredRule(ConstantCaseFixer::class, [
+        'case' => 'lower'
+    ])
+    ->withConfiguredRule(OrderedClassElementsFixer::class, [
+        'case_sensitive' => true,
+        'sort_algorithm' => 'alpha',
+        'order' => [
+            'use_trait',
+            'case',
+            'constant_public',
+            'constant_protected',
+            'constant_private',
+            'property_public',
+            'property_protected',
+            'property_private',
+            'construct',
+            'destruct',
+            'magic',
+            'method:getInstance',
+            'phpunit',
+            'method:mockeryTestSetUp',
+            'method:mockeryTestTearDown',
+            'method_public',
+            'method_protected',
+            'method_private'
+        ]
+    ])
+    ->withConfiguredRule(GeneralPhpdocAnnotationRemoveFixer::class, [
+        'annotations' => ['small', 'internal', 'coversDefaultClass1', 'coversNothing']
+    ])
+    ->withConfiguredRule(GlobalNamespaceImportFixer::class, [
+        'import_classes' => true,
+        'import_constants' => true,
+        'import_functions' => true
+    ])
+    ->withConfiguredRule(HeaderCommentFixer::class, [
+        'header' => \implode("\n", [
+            'Mockery (https://docs.mockery.io/en/stable/)',
+            '',
+            '@copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md',
+            '@license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License',
+            '@see       https://github.com/mockery/mockery for the canonical source repository'
+        ]),
+        'comment_type' => 'PHPDoc',
+        'location' => 'after_declare_strict'
+    ])
+    ->withConfiguredRule(NativeFunctionInvocationFixer::class, [
+        'include' => ['@all'],
+        'scope' => 'all'
+    ])
+    ->withConfiguredRule(NoTrailingCommaInSinglelineFixer::class, [
+        'elements' => ['arguments', 'array_destructuring', 'array', 'group_import']
+    ])
+    ->withConfiguredRule(OrderedImportsFixer::class, [
+        'imports_order' => ['class', 'const', 'function']
+    ])
+    ->withConfiguredRule(PhpdocAlignFixer::class, [
+        'tags' => ['method', 'param', 'property', 'return', 'throws', 'type', 'var']
+    ])
+    ->withConfiguredRule(PhpdocOrderFixer::class, [
+        'order' => ['param', 'return', 'throws']
+    ])
+    ->withConfiguredRule(PhpdocSeparationFixer::class, [
+        'groups' => [
+            ['deprecated', 'link', 'see', 'since'],
+            ['author', 'copyright', 'license'],
+            ['category', 'package', 'subpackage'],
+            ['property', 'property-read', 'property-write'],
+            ['param', 'return']
+        ]
+    ])
+    ->withConfiguredRule(PhpUnitTestCaseStaticMethodCallsFixer::class, [
+        'call_type' => 'self'
+    ])
+    ->withConfiguredRule(YodaStyleFixer::class, [
+        'always_move_variable' => true
+    ])
+    ->withEditorConfig()
+    ->withParallel()
+    ->withPaths([__FILE__, __DIR__ . '/library', __DIR__ . '/tests'])
+    ->withPreparedSets(psr12: true, common: true, cleanCode: true, standaloneLine: true)
+    ->withRules([
+        AddMissingParamNameFixer::class,
+        AddMissingVarNameFixer::class,
+        ArrayListItemNewlineFixer::class,
+        ArrayOpenerAndCloserNewlineFixer::class,
+        BlankLineAfterNamespaceFixer::class,
+        BlankLineAfterOpeningTagFixer::class,
+        BlankLineAfterStrictTypesFixer::class,
+        BlankLineBeforeStatementFixer::class,
+        BlankLineBetweenImportGroupsFixer::class,
+        CleanNamespaceFixer::class,
+        DoubleAsteriskInlineVarFixer::class,
+        FinalClassFixer::class,
+        FixParamNameTypoFixer::class,
+        FullyQualifiedStrictTypesFixer::class,
+        LambdaNotUsedImportFixer::class,
+        LineLengthFixer::class,
+        NoExtraBlankLinesFixer::class,
+        NoLeadingImportSlashFixer::class,
+        NoUnneededImportAliasFixer::class,
+        NoUnusedImportsFixer::class,
+        SingleImportPerStatementFixer::class,
+        SingleLineAfterImportsFixer::class,
+        SingleLineEmptyBodyFixer::class,
+        SingleLineInlineVarDocBlockFixer::class,
+        SpaceAfterCommaHereNowDocFixer::class,
+        StandaloneLinePromotedPropertyFixer::class,
+        SwitchedTypeAndNameFixer::class,
+    ])
+    ->withSkip([
+        StrictComparisonFixer::class => [
+            __DIR__ . '/library/Mockery/Matcher/IsEqual.php',
+            __DIR__ . '/library/Mockery/Matcher/MustBe.php',
+            __DIR__ . '/library/Mockery/Matcher/Subset.php',
+            __DIR__ . '/library/Mockery/Generator/StringManipulation'
+        ],
+        FullyQualifiedStrictTypesFixer::class => [__DIR__ . '/library/helpers.php'],
+        HeaderCommentFixer::class => [__DIR__ . '/tests/Fixture/*'],
+        ConcatSpaceFixer::class,
+        GetClassToClassKeywordFixer::class,
+        GroupImportFixer::class,
+        MethodChainingNewlineFixer::class,
+        NewWithParenthesesFixer::class,
+        PhpdocNoAliasTagFixer::class,
+        PhpdocNoEmptyReturnFixer::class,
+        PhpUnitInternalClassFixer::class,
+        PhpUnitTestClassRequiresCoversFixer::class,
+        RemoveMethodNameDuplicateDescriptionFixer::class,
+        TrailingCommaInMultilineFixer::class,
+        VoidReturnFixer::class,
+        // Enable later
+        DeclareStrictTypesFixer::class,
+        FinalClassFixer::class,
+        PhpUnitAttributesFixer::class,
+        __DIR__ . '/library/Mockery/Mock.php',
+        __DIR__ . '/tests/Fixture/*',
+    ])
+    ->withSpacing(Option::INDENTATION_SPACES, "\n");

--- a/library/Mockery/Adapter/Phpunit/Extension.php
+++ b/library/Mockery/Adapter/Phpunit/Extension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mockery (https://docs.mockery.io/en/stable/)
+ *
+ * @copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md
+ * @license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License
+ * @see       https://github.com/mockery/mockery for the canonical source repository
+ */
+
+namespace Mockery\Adapter\Phpunit;
+
+use Mockery\Adapter\Phpunit\Extension\Subscriber\ApplicationStartedSubscriber;
+use Mockery\Adapter\Phpunit\Extension\Subscriber\TestFinishedSubscriber;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class Extension implements \PHPUnit\Runner\Extension\Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $facade->registerSubscribers(new ApplicationStartedSubscriber(), new TestFinishedSubscriber());
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/Extension.php
+++ b/library/Mockery/Adapter/Phpunit/Extension.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Mockery\Adapter\Phpunit;
 
-use Mockery\Adapter\Phpunit\Extension\Subscriber\ApplicationStartedSubscriber;
 use Mockery\Adapter\Phpunit\Extension\Subscriber\TestFinishedSubscriber;
+use Mockery\Adapter\Phpunit\Extension\Subscriber\TestSuiteStartedSubscriber;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
@@ -22,6 +22,6 @@ final class Extension implements \PHPUnit\Runner\Extension\Extension
 {
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
-        $facade->registerSubscribers(new ApplicationStartedSubscriber(), new TestFinishedSubscriber());
+        $facade->registerSubscribers(new TestFinishedSubscriber(), new TestSuiteStartedSubscriber());
     }
 }

--- a/library/Mockery/Adapter/Phpunit/Extension/Subscriber/ApplicationStartedSubscriber.php
+++ b/library/Mockery/Adapter/Phpunit/Extension/Subscriber/ApplicationStartedSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mockery (https://docs.mockery.io/en/stable/)
+ *
+ * @copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md
+ * @license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License
+ * @see       https://github.com/mockery/mockery for the canonical source repository
+ */
+
+namespace Mockery\Adapter\Phpunit\Extension\Subscriber;
+
+use Mockery;
+use PHPUnit\Event\Application\Started;
+use PHPUnit\Event\Application\StartedSubscriber;
+use PHPUnit\Util\ExcludeList;
+use ReflectionClass;
+
+use function dirname;
+
+final class ApplicationStartedSubscriber implements StartedSubscriber
+{
+    public function notify(Started $event): void
+    {
+        $excludeList = new ExcludeList();
+
+        $filename = (new ReflectionClass(Mockery::class))->getFileName();
+
+        if (! $excludeList->isExcluded($filename)) {
+            ExcludeList::addDirectory(dirname($filename));
+        }
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestFinishedSubscriber.php
+++ b/library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestFinishedSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mockery (https://docs.mockery.io/en/stable/)
+ *
+ * @copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md
+ * @license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License
+ * @see       https://github.com/mockery/mockery for the canonical source repository
+ */
+
+namespace Mockery\Adapter\Phpunit\Extension\Subscriber;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Event\Facade;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+use Throwable;
+
+use function implode;
+use function sprintf;
+
+final class TestFinishedSubscriber implements FinishedSubscriber
+{
+    public function notify(Finished $event): void
+    {
+        try {
+            // The self() call is used as a sentinel. Anything that throws if
+            // the container is closed already will do.
+            Mockery::self();
+        } catch (Throwable $_) {
+            return;
+        }
+
+        Facade::emitter()->testConsideredRisky($event->test(), sprintf(
+            implode("\n", [
+                'Mockery\'s expectations have not been verified for this test.',
+                'Make sure that \Mockery::close() is called at the end of the test.',
+                '* Consider extending "%s" class or using "%s" trait to automatically verify expectations at the end of each test.',
+            ]),
+            MockeryTestCase::class,
+            MockeryPHPUnitIntegration::class
+        ));
+    }
+}

--- a/library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestSuiteStartedSubscriber.php
+++ b/library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestSuiteStartedSubscriber.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 namespace Mockery\Adapter\Phpunit\Extension\Subscriber;
 
 use Mockery;
-use PHPUnit\Event\Application\Started;
-use PHPUnit\Event\Application\StartedSubscriber;
+use PHPUnit\Event\TestSuite\Started;
+use PHPUnit\Event\TestSuite\StartedSubscriber;
 use PHPUnit\Util\ExcludeList;
 use ReflectionClass;
 
 use function dirname;
 
-final class ApplicationStartedSubscriber implements StartedSubscriber
+final class TestSuiteStartedSubscriber implements StartedSubscriber
 {
     public function notify(Started $event): void
     {

--- a/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
+++ b/library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php
@@ -11,10 +11,12 @@
 namespace Mockery\Adapter\Phpunit;
 
 use Mockery;
+use PHPUnit\Event\Facade;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use Throwable;
 
+use function get_class;
 use function method_exists;
 
 /**
@@ -34,13 +36,28 @@ trait MockeryPHPUnitIntegration
 
     protected function checkMockeryExceptions()
     {
-        if (! method_exists($this, 'markAsRisky')) {
+        if (method_exists($this, 'valueObjectForEvents')) {
+            foreach (Mockery::getContainer()->mockery_thrownExceptions() as $exception) {
+                if (! $exception->dismissed()) {
+                    Facade::emitter()->testConsideredRisky(
+                        $this->valueObjectForEvents(),
+                        get_class($exception) . ': '. $exception->getMessage()
+                    );
+
+                    return;
+                }
+            }
+
             return;
         }
 
-        foreach (Mockery::getContainer()->mockery_thrownExceptions() as $exception) {
-            if (! $exception->dismissed()) {
-                $this->markAsRisky();
+        if (method_exists($this, 'markAsRisky')) {
+            foreach (Mockery::getContainer()->mockery_thrownExceptions() as $exception) {
+                if (! $exception->dismissed()) {
+                    $this->markAsRisky();
+
+                    return;
+                }
             }
         }
     }

--- a/phpunit-10.5.xml.dist
+++ b/phpunit-10.5.xml.dist
@@ -40,13 +40,10 @@
             <directory suffix=".php">library</directory>
         </include>
         <exclude>
-            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit</directory>
         </exclude>
     </source>
     <extensions>
-        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+        <bootstrap class="Mockery\Adapter\Phpunit\Extension" />
     </extensions>
 </phpunit>

--- a/phpunit-11.5.xml.dist
+++ b/phpunit-11.5.xml.dist
@@ -40,13 +40,10 @@
             <directory suffix=".php">library</directory>
         </include>
         <exclude>
-            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit</directory>
         </exclude>
     </source>
     <extensions>
-        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+        <bootstrap class="Mockery\Adapter\Phpunit\Extension" />
     </extensions>
 </phpunit>

--- a/phpunit-12.5.xml.dist
+++ b/phpunit-12.5.xml.dist
@@ -40,13 +40,10 @@
             <directory suffix=".php">library</directory>
         </include>
         <exclude>
-            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit</directory>
         </exclude>
     </source>
     <extensions>
-        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+        <bootstrap class="Mockery\Adapter\Phpunit\Extension" />
     </extensions>
 </phpunit>

--- a/phpunit-13.3.xml.dist
+++ b/phpunit-13.3.xml.dist
@@ -40,13 +40,10 @@
             <directory suffix=".php">library</directory>
         </include>
         <exclude>
-            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit</directory>
         </exclude>
     </source>
     <extensions>
-        <!-- <bootstrap class="Mockery\Adapter\Phpunit\Extension" /> -->
+        <bootstrap class="Mockery\Adapter\Phpunit\Extension" />
     </extensions>
 </phpunit>

--- a/phpunit-9.6.xml.dist
+++ b/phpunit-9.6.xml.dist
@@ -15,10 +15,7 @@
             <directory suffix=".php">library</directory>
         </include>
         <exclude>
-            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit</directory>
         </exclude>
         <report>
             <html outputDirectory=".cache/phpunit/coverage-html"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,10 +16,7 @@
             <directory suffix=".php">library</directory>
         </include>
         <exclude>
-            <directory>library/Mockery/Adapter/Phpunit/Legacy</directory>
-            <file>library/Mockery/Adapter/Phpunit/TestListener.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationAssertPostConditions.php</file>
-            <file>library/Mockery/Adapter/Phpunit/MockeryTestCaseSetUp.php</file>
+            <directory>library/Mockery/Adapter/Phpunit</directory>
         </exclude>
         <report>
             <html outputDirectory=".cache/phpunit/coverage-html"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -99,6 +99,41 @@
       <code><![CDATA[require $fileName]]></code>
     </UnresolvableInclude>
   </file>
+  <file src="library/Mockery/Adapter/Phpunit/Extension.php">
+    <UndefinedClass>
+      <code><![CDATA[\PHPUnit\Runner\Extension\Extension]]></code>
+    </UndefinedClass>
+    <UnusedClass>
+      <code><![CDATA[Extension]]></code>
+    </UnusedClass>
+    <UnusedParam>
+      <code><![CDATA[$configuration]]></code>
+      <code><![CDATA[$facade]]></code>
+      <code><![CDATA[$parameters]]></code>
+    </UnusedParam>
+  </file>
+  <file src="library/Mockery/Adapter/Phpunit/Extension/Subscriber/ApplicationStartedSubscriber.php">
+    <UndefinedClass>
+      <code><![CDATA[StartedSubscriber]]></code>
+    </UndefinedClass>
+    <UnusedClass>
+      <code><![CDATA[ApplicationStartedSubscriber]]></code>
+    </UnusedClass>
+    <UnusedParam>
+      <code><![CDATA[$event]]></code>
+    </UnusedParam>
+  </file>
+  <file src="library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestFinishedSubscriber.php">
+    <UndefinedClass>
+      <code><![CDATA[FinishedSubscriber]]></code>
+    </UndefinedClass>
+    <UnusedClass>
+      <code><![CDATA[TestFinishedSubscriber]]></code>
+    </UnusedClass>
+    <UnusedParam>
+      <code><![CDATA[$event]]></code>
+    </UnusedParam>
+  </file>
   <file src="library/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegration.php">
     <InternalMethod>
       <code><![CDATA[addToAssertionCount]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -112,23 +112,23 @@
       <code><![CDATA[$parameters]]></code>
     </UnusedParam>
   </file>
-  <file src="library/Mockery/Adapter/Phpunit/Extension/Subscriber/ApplicationStartedSubscriber.php">
-    <UndefinedClass>
-      <code><![CDATA[StartedSubscriber]]></code>
-    </UndefinedClass>
-    <UnusedClass>
-      <code><![CDATA[ApplicationStartedSubscriber]]></code>
-    </UnusedClass>
-    <UnusedParam>
-      <code><![CDATA[$event]]></code>
-    </UnusedParam>
-  </file>
   <file src="library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestFinishedSubscriber.php">
     <UndefinedClass>
       <code><![CDATA[FinishedSubscriber]]></code>
     </UndefinedClass>
     <UnusedClass>
       <code><![CDATA[TestFinishedSubscriber]]></code>
+    </UnusedClass>
+    <UnusedParam>
+      <code><![CDATA[$event]]></code>
+    </UnusedParam>
+  </file>
+  <file src="library/Mockery/Adapter/Phpunit/Extension/Subscriber/TestSuiteStartedSubscriber.php">
+    <UndefinedClass>
+      <code><![CDATA[StartedSubscriber]]></code>
+    </UndefinedClass>
+    <UnusedClass>
+      <code><![CDATA[TestSuiteStartedSubscriber]]></code>
     </UnusedClass>
     <UnusedParam>
       <code><![CDATA[$event]]></code>
@@ -149,6 +149,9 @@
       <code><![CDATA[purgeMockeryContainer]]></code>
       <code><![CDATA[startMockery]]></code>
     </MissingReturnType>
+    <MixedMethodCall>
+      <code><![CDATA[testConsideredRisky]]></code>
+    </MixedMethodCall>
     <PossiblyUnusedMethod>
       <code><![CDATA[purgeMockeryContainer]]></code>
       <code><![CDATA[startMockery]]></code>
@@ -157,6 +160,9 @@
       <code><![CDATA[After]]></code>
       <code><![CDATA[Before]]></code>
     </UndefinedAttributeClass>
+    <UndefinedClass>
+      <code><![CDATA[Facade]]></code>
+    </UndefinedClass>
   </file>
   <file src="library/Mockery/Adapter/Phpunit/TestListener.php">
     <ClassMustBeFinal>
@@ -3908,6 +3914,9 @@
     <InaccessibleMethod>
       <code><![CDATA[foo]]></code>
     </InaccessibleMethod>
+    <MixedArgument>
+      <code><![CDATA[$mock]]></code>
+    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$mock]]></code>
       <code><![CDATA[$mock]]></code>

--- a/tests/Unit/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php
+++ b/tests/Unit/Mockery/Adapter/Phpunit/MockeryPHPUnitIntegrationTest.php
@@ -30,19 +30,24 @@ final class MockeryPHPUnitIntegrationTest extends MockeryTestCase
      */
     public function testItMarksAPassingTestAsRiskyIfWeThrewExceptions(): void
     {
+        $e = null;
         $mock = mock();
 
         try {
             $mock->foobar();
-        } catch (Throwable $e) {
+        } catch (BadMethodCallException $e) {
             // exception swallowed...
         }
 
         $test = spy(BaseClassStub::class)->makePartial();
         $test->finish();
 
-        $test->shouldHaveReceived()
-            ->markAsRisky();
+        $test->shouldHaveReceived()->markAsRisky();
+
+        // We can dismiss the exception to avoid the risky test
+        if ($e instanceof BadMethodCallException) {
+            $e->dismiss();
+        }
     }
 
     /**

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -631,9 +631,17 @@ final class ContainerTest extends MockeryTestCase
     public function testCantCallMethodWhenUsingBlacklistAndNoExpectation(): void
     {
         $m = mock(MockeryTest_PartialNormalClass2::class . '[!foo]');
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/::bar\(\), but no expectations were specified/');
-        $m->bar();
+
+        try {
+            $m->bar();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Received ' . get_class($m)
+                . '::bar(), but no expectations were specified',
+                $e->getMessage()
+            );
+            $e->dismiss();
+        }
     }
 
     /**
@@ -1278,6 +1286,10 @@ final class ContainerTest extends MockeryTestCase
         try {
             StaticNoMethod::staticFoo();
         } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'StaticNoMethod::staticFoo() does not exist on this mock object',
+                $e->getMessage()
+            );
             // Mockery + PHPUnit has a fail safe for tests swallowing our
             // exceptions
             $e->dismiss();
@@ -1563,6 +1575,7 @@ final class ContainerTest extends MockeryTestCase
             self::assertTrue((bool) preg_match('/stdClass/', $e->getMessage()));
             self::assertTrue((bool) preg_match('/ArrayAccess/', $e->getMessage()));
             self::assertTrue((bool) preg_match('/Countable/', $e->getMessage()));
+            $e->dismiss();
         }
     }
 
@@ -1582,6 +1595,7 @@ final class ContainerTest extends MockeryTestCase
             $m->f();
         } catch (BadMethodCallException $e) {
             self::assertStringContainsString(__FUNCTION__, $e->getMessage());
+            $e->dismiss();
         }
     }
 
@@ -1607,6 +1621,7 @@ final class ContainerTest extends MockeryTestCase
             $m->f();
         } catch (BadMethodCallException $e) {
             self::assertStringContainsString(__FUNCTION__, $e->getMessage());
+            $e->dismiss();
         }
     }
 
@@ -1675,8 +1690,16 @@ final class ContainerTest extends MockeryTestCase
     {
         $m = mock(MockeryTest_ClassConstructor2::class, [$param1 = new stdClass()]);
         $m->makePartial();
-        $this->expectException(\BadMethodCallException::class);
-        $m->foorbar123();
+
+        try {
+            $m->foorbar123();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Method ' . get_class($m) . '::foorbar123() does not exist on this mock object',
+                $e->getMessage()
+            );
+            $e->dismiss();
+        }
         $m->mockery_verify();
     }
 

--- a/tests/Unit/Mockery/ContainerTest.php
+++ b/tests/Unit/Mockery/ContainerTest.php
@@ -151,6 +151,17 @@ final class ContainerTest extends MockeryTestCase
     }
 
     /**
+     * @throws Throwable
+     */
+    public function testCallingSelfOnContainerWithoutMocksThrowsException(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('You have not declared any mocks yet');
+
+        Mockery::getContainer()->self();
+    }
+
+    /**
      * @issue issue/35
      *
      * @throws Throwable
@@ -1935,16 +1946,5 @@ final class ContainerTest extends MockeryTestCase
     public function testWakeupMagicIsNotMockedToAllowSerialisationInstanceHack(): void
     {
         self::assertInstanceOf(DateTime::class, mock(DateTime::class));
-    }
-
-    /**
-     * @throws Throwable
-     */
-    public function testCallingSelfOnContainerWithoutMocksThrowsException(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('You have not declared any mocks yet');
-
-        Mockery::getContainer()->self();
     }
 }

--- a/tests/Unit/Mockery/ExpectationTest.php
+++ b/tests/Unit/Mockery/ExpectationTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Mockery;
 
-use BadMethodCallException;
 use Error;
 use Exception;
 use InvalidArgumentException;
@@ -20,6 +19,7 @@ use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Container;
 use Mockery\CountValidator\Exception as CountValidatorException;
+use Mockery\Exception\BadMethodCallException;
 use Mockery\Exception\InvalidCountException;
 use Mockery\Exception\NoMatchingExpectationException;
 use Mockery\MockInterface;
@@ -1851,14 +1851,16 @@ final class ExpectationTest extends MockeryTestCase
     {
         $mock = mock(Mockery_Duck::class);
 
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(
-            'Received ' . get_class($mock)
-            . '::quack(), but no expectations were specified'
-        );
-
-        $mock->quack();
-        Mockery::close();
+        try {
+            $mock->quack();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Received ' . get_class($mock)
+                . '::quack(), but no expectations were specified',
+                $e->getMessage()
+            );
+            $e->dismiss();
+        }
     }
 
     /**
@@ -1868,14 +1870,15 @@ final class ExpectationTest extends MockeryTestCase
     {
         $mock = mock(Mockery_Duck::class);
 
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(
-            'Method ' . get_class($mock)
-            . '::nonExistent() does not exist on this mock object'
-        );
-
-        $mock->nonExistent();
-        Mockery::close();
+        try {
+            $mock->nonExistent();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Method ' . get_class($mock) . '::nonExistent() does not exist on this mock object',
+                $e->getMessage()
+            );
+            $e->dismiss();
+        }
     }
 
     /**
@@ -3506,7 +3509,9 @@ final class ExpectationTest extends MockeryTestCase
             ->times(2);
         $this->mock->foo();
         $this->mock->foo();
+
         $this->expectException(CountValidatorException::class);
+
         $this->mock->foo();
         Mockery::close();
     }

--- a/tests/Unit/Mockery/GlobalHelpersTest.php
+++ b/tests/Unit/Mockery/GlobalHelpersTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Mockery;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\Exception\BadMethodCallException;
 use Mockery\Matcher\AndAnyOtherArgs;
 use Mockery\Matcher\AnyArgs;
 use Mockery\MockInterface;
@@ -21,6 +22,7 @@ use Throwable;
 use function andAnyOtherArgs;
 use function andAnyOthers;
 use function anyArgs;
+use function get_class;
 use function mock;
 use function namedMock;
 use function spy;
@@ -60,13 +62,20 @@ final class GlobalHelpersTest extends MockeryTestCase
      */
     public function testMockCreatesAMock(): void
     {
-        $double = mock();
+        $mock = mock();
 
-        self::assertInstanceOf(MockInterface::class, $double);
+        self::assertInstanceOf(MockInterface::class, $mock);
 
-        $this->expectException(Throwable::class);
+        try {
+            $mock->foo();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Method ' . get_class($mock) . '::foo() does not exist on this mock object',
+                $e->getMessage()
+            );
 
-        $double->foo();
+            $e->dismiss();
+        }
     }
 
     /**

--- a/tests/Unit/Mockery/MockClassWithMethodOverloadingTest.php
+++ b/tests/Unit/Mockery/MockClassWithMethodOverloadingTest.php
@@ -18,6 +18,7 @@ use PHP73\TestWithMethodOverloading;
 use PHP73\TestWithMethodOverloadingWithoutCall;
 use Throwable;
 
+use function get_class;
 use function mock;
 
 /**
@@ -58,8 +59,14 @@ final class MockClassWithMethodOverloadingTest extends MockeryTestCase
 
         self::assertInstanceOf(TestWithMethodOverloadingWithoutCall::class, $mock);
 
-        $this->expectException(BadMethodCallException::class);
-
-        $mock->randomMethod();
+        try {
+            $mock->randomMethod();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Method ' . get_class($mock) . '::randomMethod() does not exist on this mock object',
+                $e->getMessage()
+            );
+            $e->dismiss();
+        }
     }
 }

--- a/tests/Unit/Mockery/MockTest.php
+++ b/tests/Unit/Mockery/MockTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Mockery;
 
-use BadMethodCallException;
 use ErrorException;
 use Exception;
 use InvalidArgumentException;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\Exception as MockeryException;
+use Mockery\Exception\BadMethodCallException;
 use Mockery\Mock;
 use Mockery\MockInterface;
 use PHP73\ClassWithMethods;
@@ -28,6 +28,7 @@ use PHP73\ClassWithToString;
 use PHP73\ExampleClassForTestingNonExistentMethod;
 use Throwable;
 
+use function get_class;
 use function method_exists;
 use function mock;
 
@@ -262,9 +263,19 @@ final class MockTest extends MockeryTestCase
     public function testShouldIgnoreMissingCallingNonExistentMethodsUsingGlobalConfiguration(): void
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
+
         $mock = mock(ClassWithMethods::class)->shouldIgnoreMissing();
-        $this->expectException(BadMethodCallException::class);
-        $mock->nonExistentMethod();
+
+        try {
+            $mock->nonExistentMethod();
+        } catch (BadMethodCallException $e) {
+            self::assertStringContainsString(
+                'Method ' . get_class($mock) . '::nonExistentMethod() does not exist on this mock object',
+                $e->getMessage()
+            );
+
+            $e->dismiss();
+        }
     }
 
     /**
@@ -274,7 +285,12 @@ final class MockTest extends MockeryTestCase
     {
         Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
         $mock = mock(ClassWithMethods::class)->shouldIgnoreMissing();
+
         $this->expectException(MockeryException::class);
+        $this->expectExceptionMessage(
+            "Mockery's configuration currently forbids mocking the method nonExistentMethod as it does not exist on the class or object being mocked"
+        );
+
         $mock->shouldReceive('nonExistentMethod');
     }
 
@@ -284,6 +300,8 @@ final class MockTest extends MockeryTestCase
     public function testShouldThrowExceptionWithInvalidClassName(): void
     {
         $this->expectException(MockeryException::class);
+        $this->expectExceptionMessage("Mockery can't find 'ClassName.CannotContainDot' so can't mock it");
+
         mock('ClassName.CannotContainDot');
     }
 }


### PR DESCRIPTION
This pull request introduces a new PHPUnit 10+ extension for Mockery.

- Added a new `Mockery\Adapter\Phpunit\Extension` class and two event subscribers (`TestSuiteStartedSubscriber`, `TestFinishedSubscriber`) 

> `Mockery\Adapter\Phpunit\Extension\Subscriber\TestSuiteStartedSubscriber`: Excludes Mockery internals in PHPUnit’s exclude list setup.

> `Mockery\Adapter\Phpunit\Extension\Subscriber\TestFinishedSubscriber`: Reports tests as risky when Mockery expectations are left unverified because `\Mockery::close()` was not called.

- Updated all `phpunit-*.xml.dist` files to enable the new Mockery PHPUnit extension
- Refactored `ecs.php` file

PHPUnit config:

``` text
    <extensions>
        <bootstrap class="Mockery\Adapter\Phpunit\Extension" />
    </extensions>
```

Closes #1024
Closes #1219
Closes #1480
Closes #1442