### PR TITLE
Fix `Mock::shouldNotReceive()` ignoring additional arguments

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -313,10 +313,14 @@ class Mock implements MockInterface
             return new HigherOrderMessage($this, 'shouldNotReceive');
         }
 
-        $expectation = call_user_func_array(function (string $methodNames) {
-            return $this->shouldReceive($methodNames);
-        }, $methodNames);
-        $expectation->never();
+        /** @var ?Expectation $expectation */
+        $expectation = null;
+
+        foreach ($methodNames as $methodName) {
+            $expectation = $this->shouldReceive($methodName);
+            $expectation->never();
+        }
+
         return $expectation;
     }
 

--- a/tests/Unit/Mockery/ExpectationTest.php
+++ b/tests/Unit/Mockery/ExpectationTest.php
@@ -3373,6 +3373,58 @@ final class ExpectationTest extends MockeryTestCase
     /**
      * @throws Throwable
      */
+    public function testShouldNotReceiveWithMultipleMethodsAllGetNeverConstraint(): void
+    {
+        $this->mock->shouldNotReceive('foo', 'bar', 'baz');
+
+        $expectations = $this->mock->mockery_getExpectations();
+        self::assertArrayHasKey('foo', $expectations);
+        self::assertArrayHasKey('bar', $expectations);
+        self::assertArrayHasKey('baz', $expectations);
+
+        $director = $expectations['bar'];
+        foreach ($director->getExpectations() as $expectation) {
+            self::assertTrue($expectation->isCallCountConstrained());
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testShouldNotReceiveWithMultipleMethodsThrowsOnAnyCall(): void
+    {
+        $mock = mock(stdClass::class);
+        $mock->shouldReceive('foo', 'bar')->byDefault();
+        $mock->shouldNotReceive('foo', 'bar');
+
+        $this->expectException(InvalidCountException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Method foo(<Any Arguments>) from %s should be called%s exactly 0 times but called 1 times.',
+            get_class($mock),
+            "\n"
+        ));
+
+        $mock->foo();
+        $mock->bar();
+
+        Mockery::close();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testShouldNotReceiveWithSingleMethodStillWorks(): void
+    {
+        $this->mock->shouldNotReceive('foo');
+
+        $expectations = $this->mock->mockery_getExpectations();
+        self::assertArrayHasKey('foo', $expectations);
+        self::assertCount(1, $expectations);
+    }
+
+    /**
+     * @throws Throwable
+     */
     public function testShouldNotReceiveWithArgumentThrowsExceptionIfMethodCalled(): void
     {
         $this->mock->shouldNotReceive('foo')


### PR DESCRIPTION
This pull request improves how the `shouldNotReceive` method.

* Refactored `shouldNotReceive` in `Mock.php` to handle multiple method names correctly by applying the `shouldReceive` and `never()` constraint to each method individually, ensuring all specified methods are expected to not be called.

Closes #1489