### PR TITLE
Changelog v1.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.13] - 2026-08-14
+
+### Added
+
+- [1505: Add PHPUnit extension for Mockery](https://github.com/mockery/mockery/pull/1505)
+- [1451: Add `withAndOthers` expectation shorthand](https://github.com/mockery/mockery/pull/1451)
+
+### Changed
+
+- [1495: Do not return from constructors/destructors](https://github.com/mockery/mockery/pull/1495)
+
 ### Fixed
 
-- [1453: Misleading, possibly invalid, mock @param phpdoc signature for the variadic param $args](https://github.com/mockery/mockery/issues/1453)
+- [1506: Fix `Mock::shouldNotReceive()` ignoring additional arguments](https://github.com/mockery/mockery/pull/1506)
+- [1503: Fix mocking a class with an overridden return type](https://github.com/mockery/mockery/pull/1503)
+- [1502: Fixed Generics DocComments &amp; readonly class mock handling](https://github.com/mockery/mockery/pull/1502)
+- [1474: Mock demeter chains and fluent interface methods with `static` return type](https://github.com/mockery/mockery/pull/1474)
+- [1454: Fixed invalid variadic $args parameters](https://github.com/mockery/mockery/pull/1454)
+- [1450: Phpunit integration test listener false positive](https://github.com/mockery/mockery/pull/1450)
+- [1449: Handle `ReflectionException` when resolving named arguments](https://github.com/mockery/mockery/pull/1449)
+- [1448: &#91;PHP/8.0&#93; Resolve issue with named parameters](https://github.com/mockery/mockery/pull/1448)
+- [1441: Fix Undefined Array Key in Mockery `withArgs` for PHP 8.2](https://github.com/mockery/mockery/pull/1441)
+- [1423: Properly Handle Initialization Errors and Ensure Accurate 'Failed Expectation' Messages](https://github.com/mockery/mockery/pull/1423)
 
 ## [1.6.12] - 2024-05-15
 
 ### Changed
 
-- [1420: Update `psalm-baseline.xml` ](https://github.com/mockery/mockery/pull/1420)
+- [1420: Update `psalm-baseline.xml`](https://github.com/mockery/mockery/pull/1420)
 - [1419: Update e2e-test.sh](https://github.com/mockery/mockery/pull/1419)
 - [1413: Upgrade `phar` tools and `phive.xml` configuration](https://github.com/mockery/mockery/pull/1413)
 


### PR DESCRIPTION
- [1507: Fix psalm issues and bump RTD to Ubuntu 24.04](https://github.com/mockery/mockery/pull/1507)
- [1506: Fix `Mock::shouldNotReceive()` ignoring additional arguments](https://github.com/mockery/mockery/pull/1506)
- [1505: Add PHPUnit extension for Mockery](https://github.com/mockery/mockery/pull/1505)
- [1504: Add PHPUnit EndToEnd Tests](https://github.com/mockery/mockery/pull/1504)
- [1503: Fix mocking a class with an overridden return type](https://github.com/mockery/mockery/pull/1503)
- [1502: Fixed Generics DocComments &amp; readonly class mock handling](https://github.com/mockery/mockery/pull/1502)
- [1501: Updates Composer constraints and autoload setup](https://github.com/mockery/mockery/pull/1501)
- [1500: Bump PHIVE tool versions](https://github.com/mockery/mockery/pull/1500)
- [1499: Bump `setuptools` from `78.1.1` to `83.0.0`](https://github.com/mockery/mockery/pull/1499)
- [1498: Update GitHub Actions workflows](https://github.com/mockery/mockery/pull/1498)
- [1497: Add PHP 8.4, 8.5, and 8.6 to bug report template](https://github.com/mockery/mockery/pull/1497)
- [1495: Do not return from constructors/destructors](https://github.com/mockery/mockery/pull/1495)
- [1487: Bump `idna` from `3.7` to `3.15`](https://github.com/mockery/mockery/pull/1487)
- [1484: Bump `urllib3` from `2.6.3` to `2.7.0`](https://github.com/mockery/mockery/pull/1484)
- [1483: Add export-ignore rules to .gitattributes](https://github.com/mockery/mockery/pull/1483)
- [1482: Bump `requests` from `2.32.4` to `2.33.0`](https://github.com/mockery/mockery/pull/1482)
- [1481: Bump `Pygments` from `2.17.2` to `2.20.0`](https://github.com/mockery/mockery/pull/1481)
- [1479: Update Psalm scripts and baseline](https://github.com/mockery/mockery/pull/1479)
- [1478: Bump PHPUnit from 9.6.22 to 9.6.34](https://github.com/mockery/mockery/pull/1478)
- [1477: Update wheel version requirement for docs](https://github.com/mockery/mockery/pull/1477)
- [1476: Update urllib3 version requirement in docs](https://github.com/mockery/mockery/pull/1476)
- [1475: Update .gitattributes: add `docs/`](https://github.com/mockery/mockery/pull/1475)
- [1474: Mock demeter chains and fluent interface methods with `static` return type](https://github.com/mockery/mockery/pull/1474)
- [1468: Bump `urllib3` from `2.2.2` to `2.5.0`](https://github.com/mockery/mockery/pull/1468)
- [1467: Bump `setuptools` from `70.0.0` to `78.1.1`](https://github.com/mockery/mockery/pull/1467)
- [1466: Bump `requests` from `2.32.0` to `2.32.4`](https://github.com/mockery/mockery/pull/1466)
- [1463: Docs: add alternative approaches for mocking final classes](https://github.com/mockery/mockery/pull/1463)
- [1460: Fixes CVE-2025-27516](https://github.com/mockery/mockery/pull/1460)
- [1458: Update psalm baseline](https://github.com/mockery/mockery/pull/1458)
- [1457: Update phive dependencies](https://github.com/mockery/mockery/pull/1457)
- [1456: Update composer dependencies](https://github.com/mockery/mockery/pull/1456)
- [1455: Bump jinja2 from 3.1.4 to 3.1.5](https://github.com/mockery/mockery/pull/1455)
- [1454: Fixed invalid variadic $args parameters](https://github.com/mockery/mockery/pull/1454)
- [1451: Add `withAndOthers` expectation shorthand](https://github.com/mockery/mockery/pull/1451)
- [1450: Phpunit integration test listener false positive](https://github.com/mockery/mockery/pull/1450)
- [1449: Handle `ReflectionException` when resolving named arguments](https://github.com/mockery/mockery/pull/1449)
- [1448: &#91;PHP/8.0&#93; Resolve issue with named parameters](https://github.com/mockery/mockery/pull/1448)
- [1446: Bump symplify/easy-coding-standard from 12.1.14 to 12.3.5](https://github.com/mockery/mockery/pull/1446)
- [1445: Bump `phpunit` from 11.2.9 to 11.3.6](https://github.com/mockery/mockery/pull/1445)
- [1444: Bump `phive` phar from 0.15.2 to 0.15.3](https://github.com/mockery/mockery/pull/1444)
- [1443: Bump `psalm` phar from 5.25.0 to 5.26.1](https://github.com/mockery/mockery/pull/1443)
- [1441: Fix Undefined Array Key in Mockery `withArgs` for PHP 8.2](https://github.com/mockery/mockery/pull/1441)
- [1437: Upload test results to Codecov](https://github.com/mockery/mockery/pull/1437)
- [1436: Refactor `\Mockery\Container::mock`](https://github.com/mockery/mockery/pull/1436)
- [1435: Bump setuptools from 69.2.0 to 70.0.0](https://github.com/mockery/mockery/pull/1435)
- [1434: Bump psalm from 5.24.0 to 5.25.0](https://github.com/mockery/mockery/pull/1434)
- [1433: Bump phpunit from 11.1.3 to 11.2.9](https://github.com/mockery/mockery/pull/1433)
- [1432: Bump phpdocumentor from 3.4.3 to 3.5.3](https://github.com/mockery/mockery/pull/1432)
- [1431: Bump infection from 0.28.1 to 0.29.6](https://github.com/mockery/mockery/pull/1431)
- [1430: Bump `urllib3` from 2.2.1 to 2.2.2](https://github.com/mockery/mockery/pull/1430)
- [1429: Bump `certifi` from 2024.2.2 to 2024.07.04](https://github.com/mockery/mockery/pull/1429)
- [1428: Bump `requests` from 2.31.0 to 2.32.0](https://github.com/mockery/mockery/pull/1428)
- [1427: Fix Generics DocComments](https://github.com/mockery/mockery/pull/1427)
- [1424: Add test and fixture for PR #1423](https://github.com/mockery/mockery/pull/1424)
- [1423: Properly Handle Initialization Errors and Ensure Accurate 'Failed Expectation' Messages](https://github.com/mockery/mockery/pull/1423)
- [1422: Separate tests and fixtures by PHP versions](https://github.com/mockery/mockery/pull/1422)

https://github.com/mockery/mockery/compare/1.6.12...1.6.x