### PR TITLE
Fix str_* polyfills documenting non-empty-string parameters

### DIFF
--- a/library/helpers.php
+++ b/library/helpers.php
@@ -137,9 +137,6 @@ if (! \function_exists('str_contains')) {
      *
      * @copyright Fabien Potencier
      * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
-     *
-     * @param non-empty-string $haystack
-     * @param non-empty-string $needle
      */
     function str_contains(string $haystack, string $needle): bool
     {
@@ -153,9 +150,6 @@ if (! \function_exists('str_ends_with')) {
      *
      * @copyright Fabien Potencier
      * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
-     *
-     * @param non-empty-string $haystack
-     * @param non-empty-string $needle
      */
     function str_ends_with(string $haystack, string $needle): bool
     {
@@ -182,9 +176,6 @@ if (! \function_exists('str_starts_with')) {
      *
      * @copyright Fabien Potencier
      * @license https://github.com/symfony/polyfill/blob/1.x/src/Php80/LICENSE
-     *
-     * @param non-empty-string $haystack
-     * @param non-empty-string $needle
      */
     function str_starts_with(string $haystack, string $needle): bool
     {


### PR DESCRIPTION
The polyfills for str_contains(), str_ends_with() and str_starts_with() documented both parameters as non-empty-string. That contradicts the native functions as well as the polyfill bodies, which all handle an empty string.

Since library/helpers.php is autoloaded through composer, static analysers read these declarations as the definition of the global functions, so any project requiring Mockery started to report:

    Parameter #1 $haystack of function str_starts_with expects
    non-empty-string, string given.