### PR TITLE
Allow mocking `__clone` magic method

### DIFF
--- a/library/Mockery/Generator/MockConfigurationBuilder.php
+++ b/library/Mockery/Generator/MockConfigurationBuilder.php
@@ -20,7 +20,6 @@ class MockConfigurationBuilder
     protected $blackListedMethods = [
         '__call',
         '__callStatic',
-        '__clone',
         '__wakeup',
         '__set',
         '__get',

--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -977,10 +977,6 @@ class Mock implements MockInterface
      */
     protected function _mockery_constructorCalled(array $args)
     {
-        if (!isset($this->_mockery_expectations['__construct']) /* _mockery_handleMethodCall runs the other checks */) {
-            return;
-        }
-
         $this->_mockery_handleMethodCall('__construct', $args);
     }
 
@@ -1010,15 +1006,24 @@ class Mock implements MockInterface
      */
     protected function _mockery_handleMethodCall($method, array $args)
     {
-        /**
-         * Allow __clone and __construct to be mocked only if an expectations exists otherwise return void
-         */
-        // if (
-        //     array_key_exists($method, ['__clone' => 1, '__construct' => 1]) &&
-        //    !isset($this->_mockery_expectations[$method]) 
-        // ) {
-        //     return;
-        // }
+        static $mockableMagicMethods = [
+            '__construct' => true,
+            '__clone' => true,
+        ];
+
+        if (array_key_exists($method, $mockableMagicMethods) && ! array_key_exists($method, $this->_mockery_expectations)) {
+            /**
+             * Handle calls to magic methods that are not explicitly defined on the mock class.
+             *
+             * This is necessary because magic methods like __construct and __clone can be called on the mock object,
+             * but they may not have corresponding expectations set up.
+             *
+             * If an expectation exists for these methods, it will be handled accordingly;
+             *
+             * otherwise, the call will be ignored to prevent errors.
+             */
+            return;
+        }
 
         $this->_mockery_getReceivedMethodCalls()->push(new MethodCall($method, $args));
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1560,6 +1560,7 @@
     <MixedArgument>
       <code><![CDATA[$args]]></code>
       <code><![CDATA[$method]]></code>
+      <code><![CDATA[$mockableMagicMethods]]></code>
       <code><![CDATA[$this->_mockery_getReceivedMethodCalls()]]></code>
       <code><![CDATA[$this->_mockery_getReceivedMethodCalls()]]></code>
     </MixedArgument>
@@ -2905,6 +2906,20 @@
   <file src="tests/Unit/Mockery/Loader/RequireLoaderTest.php">
     <UnusedClass>
       <code><![CDATA[RequireLoaderTest]]></code>
+    </UnusedClass>
+  </file>
+  <file src="tests/Unit/Mockery/MagicMethodsTest.php">
+    <MixedMethodCall>
+      <code><![CDATA[andReturnUsing]]></code>
+      <code><![CDATA[twice]]></code>
+      <code><![CDATA[twice]]></code>
+    </MixedMethodCall>
+    <UndefinedMethod>
+      <code><![CDATA[expects]]></code>
+      <code><![CDATA[expects]]></code>
+    </UndefinedMethod>
+    <UnusedClass>
+      <code><![CDATA[MagicMethodsTest]]></code>
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/Matcher/HasKeyTest.php">

--- a/tests/Fixture/PHP74/MagicMethod/ClassWithCloneMethod.php
+++ b/tests/Fixture/PHP74/MagicMethod/ClassWithCloneMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PHP74\MagicMethod;
+
+class ClassWithCloneMethod implements InterfaceWithCloneMethod
+{
+    public function __clone(): void
+    {
+    }
+}

--- a/tests/Fixture/PHP74/MagicMethod/ClassWithCloneMethod.php
+++ b/tests/Fixture/PHP74/MagicMethod/ClassWithCloneMethod.php
@@ -2,9 +2,12 @@
 
 namespace PHP74\MagicMethod;
 
+use ReturnTypeWillChange;
+
 class ClassWithCloneMethod implements InterfaceWithCloneMethod
 {
-    public function __clone(): void
+    #[ReturnTypeWillChange]
+    public function __clone()
     {
     }
 }

--- a/tests/Fixture/PHP74/MagicMethod/InterfaceWithCloneMethod.php
+++ b/tests/Fixture/PHP74/MagicMethod/InterfaceWithCloneMethod.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHP74\MagicMethod;
+
+interface InterfaceWithCloneMethod
+{
+    public function __clone(): void;
+}

--- a/tests/Fixture/PHP74/MagicMethod/InterfaceWithCloneMethod.php
+++ b/tests/Fixture/PHP74/MagicMethod/InterfaceWithCloneMethod.php
@@ -2,7 +2,10 @@
 
 namespace PHP74\MagicMethod;
 
+use ReturnTypeWillChange;
+
 interface InterfaceWithCloneMethod
 {
-    public function __clone(): void;
+    #[ReturnTypeWillChange]
+    public function __clone();
 }

--- a/tests/Unit/AbstractTestCase.php
+++ b/tests/Unit/AbstractTestCase.php
@@ -15,6 +15,7 @@ namespace Tests\Unit;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 use function mock;
+use function sprintf;
 
 abstract class AbstractTestCase extends MockeryTestCase
 {
@@ -29,5 +30,23 @@ abstract class AbstractTestCase extends MockeryTestCase
     public function assertValidMock(string $class): void
     {
         self::assertInstanceOf($class, mock($class));
+    }
+
+    protected function assertInvalidCountExceptionMessage(
+        string $method,
+        string $class,
+        int $expected,
+        int $actual
+    ): void {
+        $this->expectExceptionMessage(
+            sprintf(
+                'Method %s from %s should be called%s exactly %d times but called %d times.',
+                $method,
+                $class,
+                PHP_EOL,
+                $expected,
+                $actual
+            )
+        );
     }
 }

--- a/tests/Unit/Mockery/MagicMethodsTest.php
+++ b/tests/Unit/Mockery/MagicMethodsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mockery (https://docs.mockery.io/en/stable/)
+ *
+ * @copyright https://github.com/mockery/mockery/blob/HEAD/COPYRIGHT.md
+ * @license   https://github.com/mockery/mockery/blob/HEAD/LICENSE BSD 3-Clause License
+ * @see       https://github.com/mockery/mockery for the canonical source repository
+ */
+
+namespace Tests\Unit\Mockery;
+
+use Mockery;
+use Mockery\Exception\InvalidCountException;
+use PHP74\MagicMethod\ClassWithCloneMethod;
+use PHP74\MagicMethod\InterfaceWithCloneMethod;
+use Tests\Unit\AbstractTestCase;
+use Throwable;
+
+use function get_class;
+use function mock;
+
+/**
+ * @coversDefaultClass \Mockery
+ */
+final class MagicMethodsTest extends AbstractTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function testCloneMethodFailsWhenExpectationIsNotMet(): void
+    {
+        $mock = mock(ClassWithCloneMethod::class);
+        $mock->expects('__clone')->twice();
+
+        self::assertInstanceOf(InterfaceWithCloneMethod::class, clone $mock);
+
+        $this->expectException(InvalidCountException::class);
+        $this->assertInvalidCountExceptionMessage('__clone(<Any Arguments>)', get_class($mock), 2, 1);
+
+        Mockery::close();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCloneMethodWorksWithExpectation(): void
+    {
+        $callCount = 0;
+        $mock = mock(ClassWithCloneMethod::class);
+        $mock->expects('__clone')
+            ->twice()
+            ->andReturnUsing(static function () use (&$callCount): void {
+                ++$callCount;
+            });
+
+        self::assertInstanceOf(ClassWithCloneMethod::class, clone $mock);
+        self::assertInstanceOf(InterfaceWithCloneMethod::class, clone $mock);
+        self::assertSame(2, $callCount);
+    }
+
+    /**
+     * Make sure existing projects that already call `clone` on a mock object without defining
+     * a `__clone` expectation continue to work as expected.
+     *
+     * @throws Throwable
+     */
+    public function testCloneMethodWorksWithoutExpectationForBackwardsCompatibility(): void
+    {
+        $mock = mock(InterfaceWithCloneMethod::class);
+        self::assertInstanceOf(InterfaceWithCloneMethod::class, clone $mock);
+    }
+}


### PR DESCRIPTION
This pull request allows mocking the `__clone` magic method.

- Updated `Mockery/Mock.php` to allow `__clone` and `__construct` to be mocked only if explicit expectations are set; otherwise, calls to these methods are ignored to prevent errors.

- Removed `__clone` from the `blackListedMethods` property  in `MockConfigurationBuilder.php`, making it possible to mock `__clone` when needed.

- Added comprehensive tests to verify the new behavior and ensure backward compatibility.

- Updated `psalm-baseline.xml`

Resolves #669

Closes #675