### PR TITLE
Fix partial mocks skipping real `__construct` and `__clone`

### DIFF
--- a/library/Mockery/Mock.php
+++ b/library/Mockery/Mock.php
@@ -1020,9 +1020,15 @@ class Mock implements MockInterface
              *
              * If an expectation exists for these methods, it will be handled accordingly;
              *
-             * otherwise, the call will be ignored to prevent errors.
+             * otherwise, the call is forwarded to the real method of a partial mock, or ignored to prevent errors.
              */
-            return;
+            $subject = is_null($this->_mockery_partial) && $this->_mockery_deferMissing
+                ? $this->_mockery_parentClass
+                : $this->_mockery_partial;
+
+            if (! $subject || ! method_exists($subject, $method)) {
+                return;
+            }
         }
 
         $this->_mockery_getReceivedMethodCalls()->push(new MethodCall($method, $args));

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1515,6 +1515,9 @@
     <ClassMustBeFinal>
       <code><![CDATA[Mock]]></code>
     </ClassMustBeFinal>
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_null($this->_mockery_partial)]]></code>
+    </DocblockTypeContradiction>
     <InvalidReturnStatement>
       <code><![CDATA[$this->shouldNotHaveReceived('__invoke', $args)]]></code>
     </InvalidReturnStatement>
@@ -2909,14 +2912,33 @@
     </UnusedClass>
   </file>
   <file src="tests/Unit/Mockery/MagicMethodsTest.php">
+    <DirectConstructorCall>
+      <code><![CDATA[$mock->__construct('value')]]></code>
+      <code><![CDATA[$mock->__construct('value')]]></code>
+    </DirectConstructorCall>
+    <MixedAssignment>
+      <code><![CDATA[$mock]]></code>
+      <code><![CDATA[$mock]]></code>
+    </MixedAssignment>
+    <MixedClone>
+      <code><![CDATA[clone $mock]]></code>
+    </MixedClone>
     <MixedMethodCall>
+      <code><![CDATA[__construct]]></code>
+      <code><![CDATA[__construct]]></code>
       <code><![CDATA[andReturnUsing]]></code>
       <code><![CDATA[twice]]></code>
       <code><![CDATA[twice]]></code>
     </MixedMethodCall>
+    <MixedPropertyFetch>
+      <code><![CDATA[$mock->value]]></code>
+      <code><![CDATA[(clone $mock)->value]]></code>
+    </MixedPropertyFetch>
     <UndefinedMethod>
       <code><![CDATA[expects]]></code>
       <code><![CDATA[expects]]></code>
+      <code><![CDATA[makePartial]]></code>
+      <code><![CDATA[makePartial]]></code>
     </UndefinedMethod>
     <UnusedClass>
       <code><![CDATA[MagicMethodsTest]]></code>

--- a/tests/Fixture/PHP74/MagicMethod/ClassWithConstructorAndCloneMethod.php
+++ b/tests/Fixture/PHP74/MagicMethod/ClassWithConstructorAndCloneMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PHP74\MagicMethod;
+
+class ClassWithConstructorAndCloneMethod
+{
+    /**
+     * @var string
+     */
+    public $value = '';
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __clone()
+    {
+        $this->value .= ' cloned';
+    }
+}

--- a/tests/Unit/Mockery/MagicMethodsTest.php
+++ b/tests/Unit/Mockery/MagicMethodsTest.php
@@ -15,6 +15,7 @@ namespace Tests\Unit\Mockery;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
 use PHP74\MagicMethod\ClassWithCloneMethod;
+use PHP74\MagicMethod\ClassWithConstructorAndCloneMethod;
 use PHP74\MagicMethod\InterfaceWithCloneMethod;
 use Tests\Unit\AbstractTestCase;
 use Throwable;
@@ -71,5 +72,27 @@ final class MagicMethodsTest extends AbstractTestCase
     {
         $mock = mock(InterfaceWithCloneMethod::class);
         self::assertInstanceOf(InterfaceWithCloneMethod::class, clone $mock);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testPartialMockCallsRealCloneMethodWithoutExpectation(): void
+    {
+        $mock = mock(ClassWithConstructorAndCloneMethod::class)->makePartial();
+        $mock->__construct('value');
+
+        self::assertSame('value cloned', (clone $mock)->value);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testPartialMockCallsRealConstructorWithoutExpectation(): void
+    {
+        $mock = mock(ClassWithConstructorAndCloneMethod::class)->makePartial();
+        $mock->__construct('value');
+
+        self::assertSame('value', $mock->value);
     }
 }


### PR DESCRIPTION
Since 1.6.14, `_mockery_handleMethodCall()` returns early for `__construct` and `__clone` whenever no expectation is set, which happens before the partial and defer-missing fallthrough. Partial mocks therefore never reach the real methods: an explicit `$mock->__construct(...)` no longer initialises the object, and a real `__clone` is shadowed by the generated one.

The early return now only applies when there is no real implementation to defer to, so a partial mock keeps calling the subject's own `__construct`/`__clone` while explicit expectations still take precedence.

Fixes #1514.
