### PR TITLE
Add framework compatibility test

### DIFF
--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -101,7 +101,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer require mockery/mockery:"${{ github.base_ref }}-dev" --dev --no-interaction --no-progress --with-dependencies
+          composer require mockery/mockery:"@dev" --dev --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -78,6 +78,19 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.framework-version }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.framework-version }}-
 
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: |
+          composerCommand="update"
+          composerOptions=("--no-interaction" "--no-progress" "--ansi")
+          # Use `update` if there is no composer.lock file
+          if [ ! -f "composer.lock" ]; then
+            composerCommand="update"
+          fi
+          fullCommand="composer ${composerCommand} ${composerOptions[*]}"
+          echo "Running: ${fullCommand}"
+          ${fullCommand}
+
       - name: Set framework version ${{ matrix.framework-version }}
         continue-on-error: ${{ matrix.php == matrix.dev }}
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -1,0 +1,102 @@
+name: Framework
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+.x"
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+jobs:
+  phpunit:
+    name: PHP ${{ matrix.php }} / Branch ${{ matrix.framework-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      memcached:
+        image: memcached:1.6-alpine
+        ports:
+          - 11211:11211
+      mysql:
+        image: mysql:9.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: forge
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        image: redis:7.0
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+      dynamodb:
+        image: amazon/dynamodb-local:2.0.0
+        ports:
+          - 8888:8000
+
+    strategy:
+      fail-fast: false
+      matrix:
+        framework-version: ['12.x', '13.x']
+        php: ['8.3', '8.4', '8.5', '8.6']
+        dev: ['8.6']
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          coverage: xdebug
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, igbinary, msgpack, memcached, gmp, :php-psr
+          ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+        env:
+          REDIS_CONFIGURE_OPTS: --enable-redis --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --with-liblzf --enable-redis-zstd --with-libzstd --enable-redis-lz4 --with-liblz4
+          REDIS_LIBS: liblz4-dev, liblzf-dev, libzstd-dev
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup Problem Matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.framework-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.framework-version }}-
+
+      - name: Set framework version ${{ matrix.framework-version }}
+        working-directory: ${{ github.workspace }}/framework
+        shell: bash
+        run: |
+          git clone https://github.com/laravel/framework.git . --branch="${{ matrix.framework-version }}" --depth=1
+          git rev-parse HEAD
+          composer config version "${{ matrix.framework-version }}-dev"
+          composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
+          composer update mockery/mockery --with-all-dependencies --ignore-platform-reqs --no-interaction
+
+      - name: Execute tests
+        continue-on-error: ${{ matrix.php == matrix.dev }}
+        env:
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          DB_USERNAME: root
+          DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
+          DYNAMODB_ENDPOINT: "http://localhost:8888"
+          AWS_ACCESS_KEY_ID: randomKey
+          AWS_SECRET_ACCESS_KEY: randomSecret
+        run: php vendor/bin/phpunit --no-coverage
+        shell: bash
+        working-directory: ${{ github.workspace }}/framework

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   phpunit:
-    name: PHP ${{ matrix.php }} / Branch ${{ matrix.framework-version }}
+    name: Branch ${{ matrix.framework-version }} / PHPUnit ${{ matrix.phpunit }} / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:
@@ -39,9 +39,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # See https://github.com/laravel/framework/blob/HEAD/.github/workflows/tests.yml
+        phpunit: ['11.5.50', '12.5.8', '13.0.3']
         framework-version: ['12.x', '13.x']
         php: ['8.3', '8.4', '8.5', '8.6']
         dev: ['8.6']
+        exclude:
+          - php: '8.3'
+            phpunit: '13.0.3'
 
     steps:
       - name: Checkout Code
@@ -102,6 +107,7 @@ jobs:
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
           composer require mockery/mockery:"@dev" --dev --no-interaction --no-progress --with-dependencies
+          composer require phpunit/phpunit:"~${{ matrix.phpunit }}" --dev --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -87,7 +87,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer update --no-interaction --no-progress
+          composer require mockery/mockery:"dev-${{ github.ref_name }}#${{ github.sha }}" --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -87,7 +87,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer require mockery/mockery:"dev-${{ github.base_ref }}#${{ github.sha }}" --no-interaction --no-progress --with-dependencies
+          composer require mockery/mockery:"dev-${{ github.base_ref }}#${{ github.sha }}" --dev --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -79,6 +79,7 @@ jobs:
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.framework-version }}-
 
       - name: Set framework version ${{ matrix.framework-version }}
+        continue-on-error: ${{ matrix.php == matrix.dev }}
         working-directory: ${{ github.workspace }}
         shell: bash
         run: |
@@ -87,7 +88,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer require mockery/mockery:"${{ github.base_ref }}-dev#${{ github.sha }}" --dev --no-interaction --no-progress --with-dependencies
+          composer require mockery/mockery:"${{ github.base_ref }}-dev" --dev --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -87,7 +87,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer update mockery/mockery --with-all-dependencies --ignore-platform-reqs --no-interaction
+          composer update --no-interaction --no-progress
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -79,10 +79,11 @@ jobs:
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.framework-version }}-
 
       - name: Set framework version ${{ matrix.framework-version }}
-        working-directory: ${{ github.workspace }}/framework
+        working-directory: ${{ github.workspace }}
         shell: bash
         run: |
-          git clone https://github.com/laravel/framework.git . --branch="${{ matrix.framework-version }}" --depth=1
+          git clone https://github.com/laravel/framework.git framework --branch="${{ matrix.framework-version }}" --depth=1
+          cd framework
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -87,7 +87,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer require mockery/mockery:"dev-${{ github.ref_name }}#${{ github.sha }}" --no-interaction --no-progress --with-dependencies
+          composer require mockery/mockery:"dev-${{ github.base_ref }}#${{ github.sha }}" --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -87,7 +87,7 @@ jobs:
           git rev-parse HEAD
           composer config version "${{ matrix.framework-version }}-dev"
           composer config repositories.local '{"type": "path", "url": "${{ github.workspace }}"}'
-          composer require mockery/mockery:"dev-${{ github.base_ref }}#${{ github.sha }}" --dev --no-interaction --no-progress --with-dependencies
+          composer require mockery/mockery:"${{ github.base_ref }}-dev#${{ github.sha }}" --dev --no-interaction --no-progress --with-dependencies
 
       - name: Execute tests
         continue-on-error: ${{ matrix.php == matrix.dev }}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to run the test suite in the framework branches 12.x and 13.x across PHP 8.3 through 8.6 using PHPUnit 11 through 13, with MySQL, Redis, Memcached, and DynamoDB services.

For each pull request/push, the workflow:

- Clones the framework repository.

- Configures the framework's composer.json to use the package code from the current pull request or branch under test.

- Runs the framework's test suite against the modified package.